### PR TITLE
Revert "man/Makefile.am: Add --sgml to docbook2man invocation"

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -10,7 +10,7 @@ man_MANS =						\
 
 fwupdmgr.1: fwupdmgr.sgml
 	$(AM_V_GEN)					\
-	docbook2man --sgml $? > /dev/null
+	docbook2man $? > /dev/null
 
 MAINTAINERCLEANFILES =					\
 	manpage.links					\


### PR DESCRIPTION
This reverts commit b4143665fe46ad71379de41441dd36cd6be39066.

docbook-utils' docbook2man doesn't have a --sgml flag
and is arguably a more modern utility compared to docbook2man
from docbook2X