### PR TITLE
man/Makefile.am: Use --sgml option in docbook2man

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -10,7 +10,7 @@ man_MANS =						\
 
 fwupdmgr.1: fwupdmgr.sgml
 	$(AM_V_GEN)					\
-	docbook2man $? > /dev/null
+	docbook2man --sgml $? > /dev/null
 
 MAINTAINERCLEANFILES =					\
 	manpage.links					\


### PR DESCRIPTION
If not build fails with new versions of docbook2man with this error:

fwupdmgr.sgml:1: parser error : StartTag: invalid element name
<!doctype refentry PUBLIC "-//OASIS//DTD DocBook V4.1//EN" [
 ^
fwupdmgr.sgml:1: parser error : Extra content at the end of the document
<!doctype refentry PUBLIC "-//OASIS//DTD DocBook V4.1//EN" [
 ^
unable to parse fwupdmgr.sgml

no element found at line 1, column 0, byte 0 at /usr/lib/perl5/vendor_perl/XML/Parser.pm line 187.