### PR TITLE
Re-order output of get-devices to be easier to read

### DIFF
--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -30,6 +30,7 @@
 #define FWUPD_RESULT_KEY_DEVICE_CHECKSUM_KIND	"DeviceChecksumKind"	/* u */
 #define FWUPD_RESULT_KEY_DEVICE_MODIFIED	"Modified"	/* t */
 #define FWUPD_RESULT_KEY_DEVICE_NAME		"DisplayName"	/* s */
+#define FWUPD_RESULT_KEY_DEVICE_ID		"DeviceID"	/* s */
 #define FWUPD_RESULT_KEY_DEVICE_PROVIDER	"Provider"	/* s */
 #define FWUPD_RESULT_KEY_DEVICE_VERSION		"Version"	/* s */
 #define FWUPD_RESULT_KEY_DEVICE_VERSION_LOWEST	"VersionLowest"	/* s */

--- a/libfwupd/fwupd-result.c
+++ b/libfwupd/fwupd-result.c
@@ -1600,11 +1600,11 @@ fwupd_result_to_string (FwupdResult *result)
 
 	/* not set when using GetDetails */
 	if (priv->device_id != NULL)
-		g_string_append_printf (str, "%s\n", priv->device_id);
+		g_string_append_printf (str, "%s\n", priv->device_name);
 
 	/* device */
 	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_GUID, priv->guid);
-	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_DEVICE_NAME, priv->device_name);
+	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_DEVICE_ID, priv->device_id);
 	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_DEVICE_DESCRIPTION, priv->device_description);
 	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_DEVICE_PROVIDER, priv->device_provider);
 	fwupd_pad_kv_dfl (str, FWUPD_RESULT_KEY_DEVICE_FLAGS, priv->device_flags);

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -125,9 +125,9 @@ fwupd_result_func (void)
 	g_print ("\n%s", str);
 
 	ret = as_test_compare_lines (str,
-		"USB:foo\n"
+		"ColorHug2\n"
 		"  Guid:                 2082b5e0-7a64-478a-b1b2-e3404fab6dad\n"
-		"  DisplayName:          ColorHug2\n"
+		"  DeviceID:             USB:foo\n"
 		"  Flags:                allow-offline|require-ac\n"
 		"  FirmwareHash:         beefdead\n"
 		"  DeviceChecksumKind:   sha256\n"

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -848,7 +848,7 @@ fu_util_get_results (FuUtilPrivate *priv, gchar **values, GError **error)
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_INVALID_ARGS,
-				     "Invalid arguments: expected 'id'");
+				     "Invalid arguments: expected 'DeviceID'");
 		return FALSE;
 	}
 	res = fwupd_client_get_results (priv->client, values[0], NULL, error);
@@ -1283,4 +1283,3 @@ out:
 	}
 	return retval;
 }
-


### PR DESCRIPTION
Previously running get-devices would show the device_id as the top level indicator.  Something like this on a Precision 5510:
```
ro__sys_devices_pci0000_00_0000_00_01_0_0000_01_00_0
  Guid:                 2b07aa6b-6b41-5e92-8f2f-ff742f711a81
  DisplayName:          GM107GLM [Quadro M1000M]
  Provider:             Udev
  Flags:                internal|locked
  DeviceVendor:         NVIDIA Corporation
  Created:              2016-04-14
  Trusted:              none

ro__sys_devices_pci0000_00_0000_00_02_0
  Guid:                 8ec3e242-65bd-58ee-9c5e-b28f1e32e7ae
  DisplayName:          Skylake Integrated Graphics
  Provider:             Udev
  Flags:                internal|locked
  DeviceVendor:         Intel Corporation
  Created:              2016-04-14
  Trusted:              none

UEFI-124c207d-5db8-4d95-bd31-34fd971b34f9-dev0
  Guid:                 124c207d-5db8-4d95-bd31-34fd971b34f9
  DisplayName:          Precision 5510
  Provider:             UEFI
  Flags:                internal|allow-offline|require-ac
  Version:              0.1.1.19
  VersionLowest:        0.1.1.19
  Created:              2016-04-14
  Trusted:              none

usb:00:02
  Guid:                 da6082b0-a033-5b25-b280-bcba3720eddd
  DisplayName:          AX88179
  Provider:             USB
  Flags:                none
  Version:              1.0
  Created:              2016-04-14
  Trusted:              none

usb:00:0c
  Guid:                 4c03e6af-b94c-5c18-8689-e77ceadbe524
  DisplayName:          Integrated_Webcam_HD
  Provider:             USB
  Flags:                none
  Version:              86.5
  Created:              2016-04-14
  Trusted:              none
```

This patch changes it so that the DisplayName shows as the top level indicator and the Device ID is one of the children (making it more apparent what it is).
Output looks like this now:
```
GM107GLM [Quadro M1000M]
  Guid:                 2b07aa6b-6b41-5e92-8f2f-ff742f711a81
  DeviceID:             ro__sys_devices_pci0000_00_0000_00_01_0_0000_01_00_0
  Provider:             Udev
  Flags:                internal|locked
  DeviceVendor:         NVIDIA Corporation
  Created:              2016-04-14
  Trusted:              none

Skylake Integrated Graphics
  Guid:                 8ec3e242-65bd-58ee-9c5e-b28f1e32e7ae
  DeviceID:             ro__sys_devices_pci0000_00_0000_00_02_0
  Provider:             Udev
  Flags:                internal|locked
  DeviceVendor:         Intel Corporation
  Created:              2016-04-14
  Trusted:              none

Precision 5510
  Guid:                 124c207d-5db8-4d95-bd31-34fd971b34f9
  DeviceID:             UEFI-124c207d-5db8-4d95-bd31-34fd971b34f9-dev0
  Provider:             UEFI
  Flags:                internal|allow-offline|require-ac
  Version:              0.1.1.19
  VersionLowest:        0.1.1.19
  Created:              2016-04-14
  Trusted:              none

AX88179
  Guid:                 da6082b0-a033-5b25-b280-bcba3720eddd
  DeviceID:             usb:00:02
  Provider:             USB
  Flags:                none
  Version:              1.0
  Created:              2016-04-14
  Trusted:              none

Integrated_Webcam_HD
  Guid:                 4c03e6af-b94c-5c18-8689-e77ceadbe524
  DeviceID:             usb:00:0c
  Provider:             USB
  Flags:                none
  Version:              86.5
  Created:              2016-04-14
  Trusted:              none
```

All the providers provide a name as far as I can tell except ```fake```.  I'm unsure if that's a big deal.  I also wasn't sure if anything else is using libfwupd's ```fwupd_result_to_string``` that will freak out from this change.