### PR TITLE
build: Fix gtk-doc build when srcdir != builddir

### DIFF
--- a/docs/libfwupd/Makefile.am
+++ b/docs/libfwupd/Makefile.am
@@ -16,7 +16,7 @@ DOC_MAIN_SGML_FILE=$(DOC_MODULE)-docs.xml
 # gtk-doc will search all .c and .h files beneath these paths
 # for inline comments documenting functions and macros.
 # e.g. DOC_SOURCE_DIR=$(top_srcdir)/gtk $(top_srcdir)/gdk
-DOC_SOURCE_DIR=$(top_srcdir)/libfwupd
+DOC_SOURCE_DIR=$(top_srcdir)/libfwupd $(top_builddir)/libfwupd
 
 # Extra options to pass to gtkdoc-scangobj. Normally not needed.
 SCANGOBJ_OPTIONS=


### PR DESCRIPTION
This fixes the following error:
```
warning: failed to load external entity "../xml/fwupd-version.xml"
../libfwupd-docs.xml:40: element include: XInclude error : could not load ../xml/fwupd-version.xml, and no fallback was found
```