### PR TITLE
build: Fix gtk-doc build when srcdir != builddir

### DIFF
--- a/docs/libdfu/Makefile.am
+++ b/docs/libdfu/Makefile.am
@@ -62,7 +62,7 @@ HTML_IMAGES=
 # Extra files that are included by $(DOC_MAIN_SGML_FILE).
 # e.g. content_files=running.xml building.xml changes-2.0.xml
 content_files=							\
-	$(top_srcdir)/docs/version.xml
+	$(top_builddir)/docs/version.xml
 
 # Files where gtk-doc abbrevations (#GtkWidget) are expanded
 # e.g. expand_content_files=running.xml

--- a/docs/libfwupd/Makefile.am
+++ b/docs/libfwupd/Makefile.am
@@ -58,7 +58,7 @@ HTML_IMAGES=
 # Extra files that are included by $(DOC_MAIN_SGML_FILE).
 # e.g. content_files=running.xml building.xml changes-2.0.xml
 content_files=						\
-	$(top_srcdir)/docs/version.xml
+	$(top_builddir)/docs/version.xml
 
 # Files where gtk-doc abbrevations (#GtkWidget) are expanded
 # e.g. expand_content_files=running.xml


### PR DESCRIPTION
This fixes the following error:
```
*** No rule to make target '../../../fwupd/docs/version.xml', needed by 'html-build.stamp'.  Stop.
```