### PR TITLE
trivial: link against fwup

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -206,6 +206,7 @@ AM_CPPFLAGS +=						\
 	$(LIBSMBIOS_CFLAGS)				\
 	$(EFIVAR_CFLAGS)
 fwupd_LDADD +=						\
+	$(UEFI_LIBS)					\
 	$(LIBSMBIOS_LIBS)				\
 	$(EFIVAR_LIBS)
 fu_self_test_LDADD +=					\


### PR DESCRIPTION
If UEFI is disabled, but Dell non-ESRT capsule support enabled, fwupd fails to
link against libfwup as needed.