### PR TITLE
close USB devices before error returns

### DIFF
--- a/libdfu/dfu-device.c
+++ b/libdfu/dfu-device.c
@@ -1402,20 +1402,26 @@ dfu_device_open (DfuDevice *device, DfuDeviceOpenFlags flags,
 
 	/* automatically abort any uploads or downloads */
 	if ((flags & DFU_DEVICE_OPEN_FLAG_NO_AUTO_REFRESH) == 0) {
-		if (!dfu_device_refresh (device, cancellable, error))
+		if (!dfu_device_refresh (device, cancellable, error)) {
+			g_usb_device_close (device, NULL);
 			return FALSE;
+		}
 		switch (priv->state) {
 		case DFU_STATE_DFU_UPLOAD_IDLE:
 		case DFU_STATE_DFU_DNLOAD_IDLE:
 		case DFU_STATE_DFU_DNLOAD_SYNC:
 			g_debug ("aborting transfer %s", dfu_status_to_string (priv->status));
-			if (!dfu_device_abort (device, cancellable, error))
+			if (!dfu_device_abort (device, cancellable, error)) {
+				g_usb_device_close (device, NULL);
 				return FALSE;
+			}
 			break;
 		case DFU_STATE_DFU_ERROR:
 			g_debug ("clearing error %s", dfu_status_to_string (priv->status));
-			if (!dfu_device_clear_status (device, cancellable, error))
+			if (!dfu_device_clear_status (device, cancellable, error)) {
+				g_usb_device_close (device, NULL);
 				return FALSE;
+			}
 			break;
 		default:
 			break;

--- a/src/fu-provider-usb.c
+++ b/src/fu-provider-usb.c
@@ -95,6 +95,7 @@ fu_provider_usb_device_added (FuProviderUsb *provider_usb, GUsbDevice *device)
 	}
 	if (product == NULL) {
 		g_debug ("no product string descriptor");
+		g_usb_device_close (device, NULL);
 		return;
 	}
 	fu_device_set_name (dev, product);

--- a/src/plugins/fu-plugin-steelseries.c
+++ b/src/plugins/fu-plugin-steelseries.c
@@ -62,6 +62,7 @@ fu_plugin_device_probe (FuPlugin *plugin, FuDevice *device, GError **error)
 	flags = G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER;
 	if (!g_usb_device_claim_interface (usb_device, iface_idx, flags, error)) {
 		g_prefix_error (error, "failed to claim interface: ");
+		g_usb_device_close (usb_device, NULL);
 		return FALSE;
 	}
 
@@ -83,6 +84,7 @@ fu_plugin_device_probe (FuPlugin *plugin, FuDevice *device, GError **error)
 					     error);
 	if (!ret) {
 		g_prefix_error (error, "failed to do control transfer: ");
+		g_usb_device_close (usb_device, NULL);
 		return FALSE;
 	}
 	if (actual_len != 32) {
@@ -102,6 +104,7 @@ fu_plugin_device_probe (FuPlugin *plugin, FuDevice *device, GError **error)
 					       error);
 	if (!ret) {
 		g_prefix_error (error, "failed to do IN transfer: ");
+		g_usb_device_close (usb_device, NULL);
 		return FALSE;
 	}
 	if (actual_len != 32) {
@@ -121,6 +124,7 @@ fu_plugin_device_probe (FuPlugin *plugin, FuDevice *device, GError **error)
 	/* release device */
 	if (!g_usb_device_release_interface (usb_device, iface_idx, flags, error)) {
 		g_prefix_error (error, "failed to release interface: ");
+		g_usb_device_close (usb_device, NULL);
 		return FALSE;
 	}
 	if (!g_usb_device_close (usb_device, error))


### PR DESCRIPTION
In fwupd, a few of usb devices are not closed when there are some failures of operations. This issue will cause fwupd has some orphan USB nodes inside during fwupd is running. A orphan USB node might introduce memory leak and block some runtime power features as well.

The objective of this commit  it to close this kind of USB device.