### PR TITLE
Updates for thunderolt plugin, including matching v1.0.0 of libtbtfwu

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -189,7 +189,7 @@ AC_ARG_ENABLE(thunderbolt,
 			     [Enable Thunderbolt support [default=auto]]),,
 	      enable_thunderbolt=maybe)
 if test x$enable_thunderbolt != xno; then
-	PKG_CHECK_MODULES(THUNDERBOLT, [libtbtfwu >= 0.9],
+	PKG_CHECK_MODULES(THUNDERBOLT, [libtbtfwu >= 1],
 			  has_thunderbolt=yes,
 			  has_thunderbolt=no)
 fi

--- a/plugins/thunderbolt/README.md
+++ b/plugins/thunderbolt/README.md
@@ -30,12 +30,11 @@ opinion, the suboptimal design features are as follows:
  * The daemon does not keep track of the physical devices, so we have to check
    a list of cached added sysfs paths to be able to do a rescan only when a
    Thunderbolt controller is removed.
- * The `thunderboltd` daemon does not know whether devices are internal or not.
 
 Build Requirements
 ------------------
 
-For UEFI capsule support, you need to install libtbtfwu.
+For Thunderbolt online update support, you need to install libtbtfwu.
 * source:		https://github.com/01org/thunderbolt-software-user-space/tree/fwupdate
 
 If you don't want or need this functionality you can use the

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -281,6 +281,13 @@ fu_plugin_thunderbolt_device_matches (GUdevDevice *device)
 	return TRUE;
 }
 
+static void
+fu_plugin_thunderbolt_percentage_changed_cb (guint percentage, gpointer user_data)
+{
+	FuPlugin *plugin = FU_PLUGIN (user_data);
+	fu_plugin_set_percentage (plugin, percentage);
+}
+
 gboolean
 fu_plugin_update_online (FuPlugin *plugin,
 			 FuDevice *dev,
@@ -317,7 +324,11 @@ fu_plugin_update_online (FuPlugin *plugin,
 	}
 
 	/* update the device */
-	rc = tbt_fwu_Controller_updateFW (info->controller, blob, blob_sz);
+	rc = tbt_fwu_Controller_updateFW (info->controller,
+					  blob,
+					  blob_sz,
+					  fu_plugin_thunderbolt_percentage_changed_cb,
+					  plugin);
 	if (rc != TBT_OK) {
 		g_set_error (error,
 			     FWUPD_ERROR,

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -193,7 +193,7 @@ fu_plugin_thunderbolt_rescan (FuPlugin *plugin, GError **error)
 		fu_device_add_guid (info->dev, guid_id);
 
 		/* format version */
-		version = g_strdup_printf ("%" G_GUINT32_FORMAT ".%02" G_GUINT32_FORMAT,
+		version = g_strdup_printf ("%" G_GINT32_MODIFIER "x.%02" G_GINT32_MODIFIER "x",
 					   info->version_major,
 					   info->version_minor);
 		fu_device_set_version (info->dev, version);

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
  *
- * Copyright (C) 2016 Intel Corporation <thunderbolt-software@lists.01.org>
+ * Copyright (C) 2016-2017 Intel Corporation <thunderbolt-software@lists.01.org>
  * Copyright (C) 2016 Richard Hughes <richard@hughsie.com>
  *
  * Licensed under the GNU General Public License Version 2
@@ -126,8 +126,7 @@ fu_plugin_thunderbolt_rescan (FuPlugin *plugin, GError **error)
 		FuThunderboltInfo *info;
 		gchar tdbid[FU_PLUGIN_THUNDERBOLT_MAX_ID_LEN];
 		gsize tdbid_sz = sizeof (tdbid);
-		g_autofree gchar *guid_id1 = NULL;
-		g_autofree gchar *guid_id2 = NULL;
+		g_autofree gchar *guid_id = NULL;
 		g_autofree gchar *version = NULL;
 
 		/* get the ID */
@@ -188,15 +187,10 @@ fu_plugin_thunderbolt_rescan (FuPlugin *plugin, GError **error)
 		fu_device_add_flag (info->dev, FWUPD_DEVICE_FLAG_ALLOW_ONLINE);
 		fu_device_set_id (info->dev, info->id);
 
-		/* add GUID that fwupd will know about */
-		guid_id1 = g_strdup_printf ("PCI\\VEN_%04X&DEV_%04X",
-					    info->vendor_id, info->model_id);
-		fu_device_add_guid (info->dev, guid_id1);
-
 		/* add GUID that the info firmware uses */
-		guid_id2 = g_strdup_printf ("TBT-%04x%04x",
-					    info->vendor_id, info->model_id);
-		fu_device_add_guid (info->dev, guid_id2);
+		guid_id = g_strdup_printf ("TBT-%04x%04x",
+					   info->vendor_id, info->model_id);
+		fu_device_add_guid (info->dev, guid_id);
 
 		/* format version */
 		version = g_strdup_printf ("%" G_GUINT32_FORMAT ".%02" G_GUINT32_FORMAT,

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -152,15 +152,14 @@ fu_plugin_thunderbolt_rescan (FuPlugin *plugin, GError **error)
 		info->id = g_strdup (tdbid);
 		g_ptr_array_add (data->infos, info);
 
-		rc = tbt_fwu_Controller_isInSafeMode(data->controllers[i], &safe_mode);
+		rc = tbt_fwu_Controller_isInSafeMode (data->controllers[i], &safe_mode);
 		if (rc != TBT_OK) {
 			g_warning ("failed to get controller status: %s",
 				   tbt_strerror (rc));
 			continue;
 		}
 
-		if (safe_mode)
-		{
+		if (safe_mode != 0) {
 			info->vendor_id = 0;
 			info->model_id = 0;
 			info->version_major = 0;
@@ -169,9 +168,7 @@ fu_plugin_thunderbolt_rescan (FuPlugin *plugin, GError **error)
 				   "Please visit https://github.com/01org/tbtfwupd/wiki "
 				   "for information on how to restore normal operation.",
 				   info->id);
-		}
-		else
-		{
+		} else {
 			/* get the vendor ID */
 			rc = tbt_fwu_Controller_getVendorID (data->controllers[i],
 							     &info->vendor_id);
@@ -206,10 +203,8 @@ fu_plugin_thunderbolt_rescan (FuPlugin *plugin, GError **error)
 		fu_device_set_vendor (info->dev, "Intel");
 		fu_device_set_name (info->dev, "Thunderbolt Controller");
 		fu_device_add_flag (info->dev, FWUPD_DEVICE_FLAG_INTERNAL);
-		if (!safe_mode)
-		{
+		if (safe_mode == 0)
 			fu_device_add_flag (info->dev, FWUPD_DEVICE_FLAG_ALLOW_ONLINE);
-		}
 		fu_device_set_id (info->dev, info->id);
 
 		/* add GUID that the info firmware uses */


### PR DESCRIPTION
The changes include what we have discussed here: [4ff3169](https://github.com/hughsie/fwupd/commit/4ff3169556b391ab9808df5bcea063a830c1bd07)

It also aligns with v1.0.0 of libtbtfwu released yesterday ([d83532a](https://github.com/01org/thunderbolt-software-user-space/commit/d83532a9945a0156bd13a0627d3c999fc5166bd5)) and uses the new option of FW update progress reporting.

Last but not least, we handle safe-mode in a way that shows the controller to the user but prevents auto-updating.