### PR TITLE
thunderbolt: Add special handling for safe mode on Dell systems

### DIFF
--- a/plugins/thunderbolt/Makefile.am
+++ b/plugins/thunderbolt/Makefile.am
@@ -17,6 +17,13 @@ libfu_plugin_thunderbolt_la_LDFLAGS = -module -avoid-version
 libfu_plugin_thunderbolt_la_CFLAGS = $(WARN_CFLAGS)	\
 	-DG_LOG_DOMAIN=\"FuPluginThunderbolt\"
 
+if HAVE_DELL
+AM_CPPFLAGS +=						\
+	$(LIBSMBIOS_CFLAGS)
+libfu_plugin_thunderbolt_la_LIBADD =			\
+	$(LIBSMBIOS_LIBS)
+endif
+
 EXTRA_DIST = README.md
 
 -include $(top_srcdir)/git.mk

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -182,10 +182,10 @@ fu_plugin_thunderbolt_rescan (FuPlugin *plugin, GError **error)
 			   when in safe mode, they can be flashed */
 #ifdef HAVE_DELL
 			de_table = smbios_get_next_struct_by_type (0, 0xDE);
-			smbios_struct_get_data (de_table, &(dell_supported), 0x00, sizeof(guint8));
+			smbios_struct_get_data (de_table, &dell_supported, 0x00, sizeof(guint8));
 			if (dell_supported == 0xDE) {
 				info->vendor_id = 0x00d4;
-				info->model_id = sysinfo_get_dell_system_id();
+				info->model_id = sysinfo_get_dell_system_id ();
 				safe_mode = 0;
 			}
 #endif /* HAVE_DELL */


### PR DESCRIPTION
Per discussion with @ybernat  and @hughsie:

Dell systems are known to have the Model ID the same as the SystemID
that can be recovered from libsmbios.  If the thunderbolt controller
is in safe mode, identify with this ID to allow the controller to be
flashed with a good FW.
