### PR TITLE
Fix issues when compiling with docbook2X

### DIFF
--- a/docs/man/Makefile.am
+++ b/docs/man/Makefile.am
@@ -12,10 +12,10 @@ man_MANS =						\
 
 fwupdmgr.1: fwupdmgr.sgml
 	$(AM_V_GEN)					\
-	docbook2man $? > /dev/null
+	$(DOCBOOK2MAN) $? > /dev/null
 dfu-tool.1: dfu-tool.sgml
 	$(AM_V_GEN)					\
-	docbook2man $? > /dev/null
+	$(DOCBOOK2MAN) $? > /dev/null
 
 MAINTAINERCLEANFILES =					\
 	manpage.links					\

--- a/docs/man/dfu-tool.sgml
+++ b/docs/man/dfu-tool.sgml
@@ -1,4 +1,4 @@
-<!doctype refentry PUBLIC "-//OASIS//DTD DocBook V4.1//EN" [
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook V4.1.2//EN" "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
   <!-- Please adjust the date whenever revising the manpage. -->
   <!ENTITY date        "<date>26 February,2015</date>">
   <!ENTITY package     "dfu-tool">

--- a/docs/man/fwupdmgr.sgml
+++ b/docs/man/fwupdmgr.sgml
@@ -1,4 +1,4 @@
-<!doctype refentry PUBLIC "-//OASIS//DTD DocBook V4.1//EN" [
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook V4.1.2//EN" "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
   <!-- Please adjust the date whenever revising the manpage. -->
   <!ENTITY date        "<date>26 February,2015</date>">
   <!ENTITY package     "fwupdmgr">


### PR DESCRIPTION
The following changes had to be made to successfully compile with docbook2X which is shipped with Gentoo. Additionally, a patch to configure.ac is needed to turn docbook2man into docbook2man.pl but that is not part of this patch. It's only part of my build script.

It was not tested against classic docbook2man but I guess it should work.