### PR TITLE
Fix compiler warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,7 +82,6 @@ WARN_CFLAGS_EXTRA="
 	-Wmissing-parameter-type
 	-Wmissing-prototypes
 	-Wnested-externs
-	-Wno-discarded-qualifiers
 	-Wno-missing-field-initializers
 	-Wno-strict-aliasing
 	-Wno-suggest-attribute=format

--- a/libdfu/dfu-format-elf.c
+++ b/libdfu/dfu-format-elf.c
@@ -278,7 +278,7 @@ dfu_format_elf_pack_element (Elf *e, DfuElement *element, GError **error)
 	data = elf_newdata (scn);
 	data->d_align = 1;
 	data->d_off = 0;
-	data->d_buf = g_bytes_get_data (bytes, NULL);
+	data->d_buf = (gpointer) g_bytes_get_data (bytes, NULL);
 	data->d_type = ELF_T_BYTE;
 	data->d_size = g_bytes_get_size (bytes);
 	data->d_version = EV_CURRENT;
@@ -338,7 +338,7 @@ dfu_firmware_to_elf (DfuFirmware *firmware, GError **error)
 	goffset fsize;
 	g_autoptr(Elf) e = NULL;
 	g_autoptr(GInputStream) stream = NULL;
-	const gchar string_table2[] =
+	gchar string_table2[] =
 		"\0"
 		".text\0" // FIXME: use the name in the DfuImage?
 		".shstrtab";

--- a/libdfu/dfu-tool.c
+++ b/libdfu/dfu-tool.c
@@ -481,9 +481,9 @@ dfu_tool_bytes_replace (GBytes *data, GBytes *search, GBytes *replace)
 	guint8 *search_buf;
 	guint cnt = 0;
 
-	data_buf = g_bytes_get_data (data, &data_sz);
-	search_buf = g_bytes_get_data (search, &search_sz);
-	replace_buf = g_bytes_get_data (replace, &replace_sz);
+	data_buf = (gpointer) g_bytes_get_data (data, &data_sz);
+	search_buf = (gpointer) g_bytes_get_data (search, &search_sz);
+	replace_buf = (gpointer) g_bytes_get_data (replace, &replace_sz);
 
 	g_return_val_if_fail (search_sz == replace_sz, FALSE);
 

--- a/plugins/altos/fu-device-altos.c
+++ b/plugins/altos/fu-device-altos.c
@@ -534,7 +534,7 @@ fu_device_altos_write_firmware (FuDeviceAltos *device,
 		return FALSE;
 
 	/* check firmware will fit */
-	data = g_bytes_get_data (fw_blob, &data_len);
+	data = g_bytes_get_data (fw_blob, (gsize *) &data_len);
 	if (data_len > flash_len) {
 		g_set_error (error,
 			     FWUPD_ERROR,

--- a/plugins/udev/fu-rom-tool.c
+++ b/plugins/udev/fu-rom-tool.c
@@ -103,7 +103,7 @@ fu_fuzzer_rom_create (GError **error)
 	buffer[0x18] = 0x20;			/* cpi_ptr lo */
 	buffer[0x19] = 0x00;			/* cpi_ptr hi */
 	memcpy (&blob_header[0x6], "hdr-no-data       ", 18);
-	g_hash_table_insert (hash, "header-no-data.rom",
+	g_hash_table_insert (hash, (gpointer) "header-no-data.rom",
 			     g_string_new_len ((gchar *) blob_header, 512));
 
 	/* data for header */
@@ -133,7 +133,7 @@ fu_fuzzer_rom_create (GError **error)
 	/* blob */
 	memcpy (&buffer[0x1c], "Version 1.0", 12);
 	memcpy (&blob_header[0x6], "hdr-data-payload  ", 18);
-	g_hash_table_insert (hash, "header-data-payload.rom",
+	g_hash_table_insert (hash, (gpointer) "header-data-payload.rom",
 			     g_string_new_len ((gchar *) blob_header, 512));
 
 	/* optional IFR header on some NVIDIA blobs */
@@ -142,12 +142,12 @@ fu_fuzzer_rom_create (GError **error)
 	memcpy (buffer, "NVGI", 4);
 	sz = GUINT16_TO_BE (0x80);
 	memcpy (&buffer[0x15], &sz, 2);
-	g_hash_table_insert (hash, "naked-ifr.rom",
+	g_hash_table_insert (hash, (gpointer) "naked-ifr.rom",
 			     g_string_new_len (blob_ifr, 0x80));
 	str = g_string_new_len ((gchar *) blob_ifr, 0x80);
 	memcpy (&blob_header[0x6], "ifr-hdr-data-payld", 18);
 	g_string_append_len (str, (gchar *) blob_header, 0x200);
-	g_hash_table_insert (hash, "ifr-header-data-payload.rom", str);
+	g_hash_table_insert (hash, (gpointer) "ifr-header-data-payload.rom", str);
 
 	/* dump to files */
 	return fu_fuzzer_write_files (hash, error);


### PR DESCRIPTION
My compiler doesn't understand -Wno-discard-qualifiers so drop it and
fix the warnings instead. I think it is better to explicitly fix them
anyways instead of just to ignore the discarded const qualifier in
general.

I think the option should be avoided in hand-written code. The warning
is there for a reason: To protect you from possibly overwriting data you
expect to not be modified when passing pointers around.

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=41215