### PR TITLE
Set HAVE_POLKIT_0_114 when polkit is newer than 0.114

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -113,6 +113,9 @@ gio = dependency('gio-2.0', version : '>= 2.45.8')
 gmodule = dependency('gmodule-2.0')
 giounix = dependency('gio-unix-2.0', version : '>= 2.45.8')
 polkit = dependency('polkit-gobject-1', version : '>= 0.103')
+if polkit.version() >= '0.114'
+  conf.set('HAVE_POLKIT_0_114', '1')
+endif
 gcab = dependency('libgcab-1.0')
 gudev = dependency('gudev-1.0')
 appstream_glib = dependency('appstream-glib', version : '>= 0.5.10')


### PR DESCRIPTION
It looks like this was missed during the migration to meson