### PR TITLE
Increase minimum required AppStream-Glib version to 0.6.13

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -118,7 +118,7 @@ if polkit.version() >= '0.114'
 endif
 gcab = dependency('libgcab-1.0')
 gudev = dependency('gudev-1.0')
-appstream_glib = dependency('appstream-glib', version : '>= 0.5.10')
+appstream_glib = dependency('appstream-glib', version : '>= 0.6.13')
 gusb = dependency('gusb', version : '>= 0.2.9')
 sqlite = dependency('sqlite3')
 libarchive = dependency('libarchive')


### PR DESCRIPTION
Adds regex command used for comparing firmware versions.

----

With  0.6.8 updating Unifying Receiver fails for me with:
```
version of bootloader incorrect: failed predicate [BOT01.0[0-3]_* regex BOT01.02_B0014]
```
