### PR TITLE
Make documentation and man pages optional

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -94,6 +94,8 @@ Files for development with libdfu.
 %build
 
 %meson \
+    -Denable-doc=true \
+    -Denable-man=true \
     -Denable-tests=false \
     -Denable-thunderbolt=false \
 %if 0%{?have_uefi}

--- a/docs/man/meson.build
+++ b/docs/man/meson.build
@@ -1,23 +1,21 @@
-docbook2man = find_program('docbook2man', required : false)
-if docbook2man.found()
-  custom_target('fwupdmgr-man',
-    input : 'fwupdmgr.sgml',
-    output : 'fwupdmgr.1',
-    command : [
-      docbook2man, '@INPUT@',
-      '--output', meson.current_build_dir(),
-    ],
-    install : true,
-    install_dir : join_paths(get_option('mandir'), 'man1'),
-  )
-  custom_target('dfu-tool-man',
-    input : 'dfu-tool.sgml',
-    output : 'dfu-tool.1',
-    command : [
-      docbook2man, '@INPUT@',
-      '--output', meson.current_build_dir(),
-    ],
-    install : true,
-    install_dir : join_paths(get_option('mandir'), 'man1'),
-  )
-endif
+docbook2man = find_program('docbook2man')
+custom_target('fwupdmgr-man',
+  input : 'fwupdmgr.sgml',
+  output : 'fwupdmgr.1',
+  command : [
+    docbook2man, '@INPUT@',
+    '--output', meson.current_build_dir(),
+  ],
+  install : true,
+  install_dir : join_paths(get_option('mandir'), 'man1'),
+)
+custom_target('dfu-tool-man',
+  input : 'dfu-tool.sgml',
+  output : 'dfu-tool.1',
+  command : [
+    docbook2man, '@INPUT@',
+    '--output', meson.current_build_dir(),
+  ],
+  install : true,
+  install_dir : join_paths(get_option('mandir'), 'man1'),
+)

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -1,3 +1,7 @@
-subdir('libdfu')
-subdir('libfwupd')
-subdir('man')
+if get_option('enable-doc')
+  subdir('libdfu')
+  subdir('libfwupd')
+endif
+if get_option('enable-man')
+  subdir('man')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,5 @@
+option('enable-doc', type : 'boolean', value : true, description : 'enable developer documentation')
+option('enable-man', type : 'boolean', value : true, description : 'enable man pages')
 option('enable-tests', type : 'boolean', value : true, description : 'enable tests')
 option('enable-colorhug', type : 'boolean', value : true, description : 'enable ColorHug support')
 option('enable-libelf', type : 'boolean', value : true, description : 'enable libelf support')


### PR DESCRIPTION
Reduce the minimum build-time dependencies.

---

Please consider adding options for building the documentation (which looks like developers only) and man pages: this would reduce the dependencies for building on a minimal system.

docbook2man is currently an automagic dependency for the man pages, but this in itself causes problems for e.g. Gentoo where it ends up being safer to make it a mandatory dependency. This patch requires it if you have enabled the man pages option.

I've made changes to the spec file to enable them both to keep the current behaviour, but can't test it.
