### PR TITLE
Add support for ConsoleKit2

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -38,20 +38,24 @@ configure_file(
                           'system-services'),
 )
 
-# replace @bindir@
-configure_file(
-  input : 'fwupd-offline-update.service.in',
-  output : 'fwupd-offline-update.service',
-  configuration : con2,
-  install: true,
-  install_dir: systemd.get_pkgconfig_variable('systemdsystemunitdir'),
-)
+if get_option('enable-systemd')
+  # replace @bindir@
+  configure_file(
+    input : 'fwupd-offline-update.service.in',
+    output : 'fwupd-offline-update.service',
+    configuration : con2,
+    install: true,
+    install_dir: systemd.get_pkgconfig_variable('systemdsystemunitdir'),
+  )
+endif
 
-# replace @localstatedir@ and @bootdir@
-configure_file(
-  input : 'fwupd.service.in',
-  output : 'fwupd.service',
-  configuration : con2,
-  install: true,
-  install_dir: systemd.get_pkgconfig_variable('systemdsystemunitdir'),
-)
+if get_option('enable-systemd')
+  # replace @localstatedir@ and @bootdir@
+  configure_file(
+    input : 'fwupd.service.in',
+    output : 'fwupd.service',
+    configuration : con2,
+    install: true,
+    install_dir: systemd.get_pkgconfig_variable('systemdsystemunitdir'),
+  )
+endif

--- a/meson.build
+++ b/meson.build
@@ -127,7 +127,6 @@ soup = dependency('libsoup-2.4', version : '>= 2.51.92')
 gpgme = cc.find_library('gpgme')
 gpgerror = cc.find_library('gpg-error')
 libm = cc.find_library('m', required: false)
-systemd = dependency('systemd', version : '>= 231')
 udev = dependency('udev')
 
 if valgrind.found()
@@ -160,6 +159,15 @@ endif
 
 if get_option('enable-thunderbolt')
   thunderbolt = dependency('libtbtfwu', version : '>= 1', required: false)
+endif
+
+if get_option('enable-systemd')
+  systemd = dependency('systemd', version : '>= 231')
+  conf.set('HAVE_SYSTEMD' , '1')
+endif
+
+if get_option('enable-consolekit')
+  conf.set('HAVE_CONSOLEKIT' , '1')
 endif
 
 gnome = import('gnome')
@@ -223,4 +231,6 @@ else
   message('git not found, you will not be able to run `ninja dist`')
 endif
 
-meson.add_install_script('meson_post_install.sh', systemd.get_pkgconfig_variable('systemdsystemunitdir'), localstatedir)
+if get_option('enable-systemd')
+  meson.add_install_script('meson_post_install.sh', systemd.get_pkgconfig_variable('systemdsystemunitdir'), localstatedir)
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,4 +6,6 @@ option('enable-libelf', type : 'boolean', value : true, description : 'enable li
 option('enable-uefi', type : 'boolean', value : true, description : 'enable UEFI support')
 option('enable-dell', type : 'boolean', value : true, description : 'enable Dell-specific support')
 option('enable-thunderbolt', type : 'boolean', value : true, description : 'enable Thunderbolt support')
+option('enable-systemd', type : 'boolean', value : true, description : 'enable systemd support')
+option('enable-consolekit', type : 'boolean', value : true, description : 'enable ConsoleKit support')
 option('with-bootdir', type : 'string', value : '/boot/efi', description : 'Directory for EFI system partition')


### PR DESCRIPTION
Make systemd and ConsoleKit support an optional compile time flag
with both enabled by default. If both are used, the ifdef/elif will
ensure only the systemd calls are used so there's no conflict.