### PR TITLE
Only use the test runner plugin when CI is set in the env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_script:
   - docker build -t fwupd-debian-experimental -f contrib/ci/Dockerfile-debian-experimental .
 
 script:
-  - docker run -t -v `pwd`:/build fwupd-fedora-25 ./contrib/ci/build_and_install_rpms.sh
-  - docker run -t -v `pwd`:/build fwupd-debian-experimental ./contrib/ci/build_and_install_debs.sh
+  - docker run -e CI=true -t -v `pwd`:/build fwupd-fedora-25 ./contrib/ci/build_and_install_rpms.sh
+  - docker run -e CI=true -t -v `pwd`:/build fwupd-debian-experimental ./contrib/ci/build_and_install_debs.sh

--- a/contrib/ci/build_and_install_debs.sh
+++ b/contrib/ci/build_and_install_debs.sh
@@ -14,5 +14,10 @@ dpkg-buildpackage
 dpkg -i ../*.deb
 
 # run the installed tests
-/etc/init.d/dbus start
-gnome-desktop-testing-runner fwupd
+if [ "$CI" = "true" ]; then
+	sed -i "s,Exec=,Exec=/bin/sh -c 'FWUPD_TESTS=$CI ,;
+		s,Exec=.*$,&',;" \
+		/usr/share/dbus-1/system-services/org.freedesktop.fwupd.service
+	/etc/init.d/dbus start
+	gnome-desktop-testing-runner fwupd
+fi

--- a/contrib/ci/build_and_install_debs.sh
+++ b/contrib/ci/build_and_install_debs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 #build deb packages
-VERSION=`git describe --abbrev=0 --tags`
+VERSION=`head meson.build | sed "/version :/!d; /meson/d; s/,//; s/'//g;" | awk -F ':' '{print $2}'`
 rm -rf build/
 mkdir -p build && pushd build
 ln -s ../* .

--- a/contrib/ci/build_and_install_rpms.sh
+++ b/contrib/ci/build_and_install_rpms.sh
@@ -38,8 +38,13 @@ dnf install -C -y $HOME/rpmbuild/RPMS/*/*.rpm
 cp $HOME/rpmbuild/RPMS/*/*.rpm .
 
 # run the installed tests
-mkdir -p /run/dbus
-mkdir -p /var
-ln -s /var/run /run
-dbus-daemon --system --fork
-gnome-desktop-testing-runner fwupd
+if [ "$CI" = "true" ]; then
+        sed -i "s,Exec=,Exec=/bin/sh -c 'FWUPD_TESTS=$CI ,;
+		s,Exec=.*$,&',;" \
+		/usr/share/dbus-1/system-services/org.freedesktop.fwupd.service
+	mkdir -p /run/dbus
+	mkdir -p /var
+	ln -s /var/run /run
+	dbus-daemon --system --fork
+	gnome-desktop-testing-runner fwupd
+fi

--- a/plugins/test/fu-plugin-test.c
+++ b/plugins/test/fu-plugin-test.c
@@ -45,6 +45,13 @@ fu_plugin_destroy (FuPlugin *plugin)
 gboolean
 fu_plugin_startup (FuPlugin *plugin, GError **error)
 {
+	if (g_getenv ("FWUPD_TESTS") == NULL) {
+                g_set_error (error,
+                             FWUPD_ERROR,
+                             FWUPD_ERROR_NOT_FOUND,
+                             "Test plugin is only used for continuous integration.");
+		return FALSE;
+	}
 	g_debug ("startup");
 	return TRUE;
 }

--- a/plugins/test/fu-plugin-test.c
+++ b/plugins/test/fu-plugin-test.c
@@ -46,10 +46,10 @@ gboolean
 fu_plugin_startup (FuPlugin *plugin, GError **error)
 {
 	if (g_getenv ("FWUPD_TESTS") == NULL) {
-                g_set_error (error,
-                             FWUPD_ERROR,
-                             FWUPD_ERROR_NOT_FOUND,
-                             "Test plugin is only used for continuous integration.");
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_NOT_FOUND,
+			     "Test plugin is only used for continuous integration");
 		return FALSE;
 	}
 	g_debug ("startup");

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -178,6 +178,9 @@ fu_plugin_module_func (void)
 	g_autoptr(GBytes) blob_cab = NULL;
 	g_autoptr(GMappedFile) mapped_file = NULL;
 
+	/* the test plugin is only usable if this is set */
+	g_setenv ("FWUPD_TESTS", "true", TRUE);
+
 	/* create a fake device */
 	plugin = fu_plugin_new ();
 	ret = fu_plugin_open (plugin, PLUGINBUILDDIR "/libfu_plugin_test.so", &error);


### PR DESCRIPTION
This lets the tests be installed onto a system without FakeDevices showing up.