### PR TITLE
Add Arch Linux to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ services:
   - docker
 
 before_script:
-  - docker build -t fwupd-fedora-25 -f contrib/ci/Dockerfile-fedora-25 .
-  - docker build -t fwupd-debian-experimental -f contrib/ci/Dockerfile-debian-experimental .
+  - docker build -t fwupd-arch -f contrib/ci/Dockerfile-arch .
 
 script:
-  - docker run -e CI=true -t -v `pwd`:/build fwupd-fedora-25 ./contrib/ci/build_and_install_rpms.sh
-  - docker run -e CI=true -t -v `pwd`:/build fwupd-debian-experimental ./contrib/ci/build_and_install_debs.sh
+  - docker run -e CI=true -t -v `pwd`:/build fwupd-arch ./contrib/ci/build_and_install_pkgs.sh

--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: Bruno Pagani (a.k.a. ArchangeGabriel) <archange@archlinux.org>
+# Contributor: Mirco Tischler <mt-ml at gmx dot de>
+
+pkgname=fwupd
+pkgver=0.9.4.r53.ge90542f
+pkgrel=1
+pkgdesc='A simple daemon to allow session software to update firmware'
+arch=('i686' 'x86_64')
+url='https://github.com/hughsie/fwupd'
+license=('GPL2')
+depends=('appstream-glib' 'fwupdate' 'colord')
+makedepends=('meson' 'valgrind' 'docbook-utils' 'docbook-sgml' 'perl-sgmls'
+             'gobject-introspection' 'gtk-doc' 'python-pillow' 'python-cairo'
+             'ttf-dejavu' 'adobe-source-han-sans-cn-fonts' 'python-gobject' 'git')
+
+pkgver() {
+    cd ${pkgname}
+    git describe | sed 's/-/.r/;s/-/./'
+}
+
+build() {
+    cd ${pkgname}
+    meson --prefix=/usr \
+        --sysconfdir=/etc \
+        --localstatedir=/var \
+        --libexecdir=/usr/lib \
+        --buildtype=plain \
+        ../build
+
+    ninja -v -C ../build
+}
+
+check() {
+    ninja -C build test
+}
+
+package() {
+    DESTDIR="${pkgdir}" ninja -C build install
+}

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,7 +1,7 @@
 Distribution packages
 =====================
-The relevant packaging necessary to generate *RPM* and *DEB* distribution packages is contained here.
-It is used regularly for continuous integration using [Travis CI](http://travis-ci.org). The generated packages can be used on a distribution such as Fedora, Debian or Ubuntu.
+The relevant packaging necessary to generate *RPM*, *DEB* and *PKG* distribution packages is contained here.
+It is used regularly for continuous integration using [Travis CI](http://travis-ci.org). The generated packages can be used on a distribution such as Fedora, Debian, Ubuntu or Arch Linux.
 
 The build can be performed using Linux containers with [Docker](www.docker.com).
 
@@ -34,6 +34,19 @@ DEBs will be made available in your working directory when complete.
 
 To use the packages, you may need to enable the experimental repository for dependency resolution.
 Additional information is available here: https://wiki.debian.org/DebianExperimental
+
+## PKG packages
+A Dockerfile is available for Arch Linux.
+
+To prepare the Docker container run this command:
+
+`docker build -t fwupd-arch -f contrib/ci/Dockerfile-arch .`
+
+To build the PKGs run this command (from the root of your git checkout):
+
+```docker run -t -v `pwd`:/build fwupd-arch ./contrib/ci/build_and_install_pkgs.sh```
+
+PKGs will be made available in your working directory when complete.
 
 ## Additional packages
 Submissions for generating additional packages for other distribution mechanisms are also welcome.  

--- a/contrib/ci/Dockerfile-arch
+++ b/contrib/ci/Dockerfile-arch
@@ -1,0 +1,38 @@
+FROM archlinux/base
+# set the locale
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+# keep the package DB
+RUN rm /usr/share/libalpm/hooks/package-cleanup.hook
+# update the image, install devel packages
+RUN pacman -Syu --noconfirm
+RUN pacman -S --noconfirm base-devel
+# runtime deps
+RUN pacman -S --noconfirm \
+              appstream-glib \
+              colord \
+              fwupdate
+# buildtime deps
+RUN pacman -S --noconfirm \
+              adobe-source-han-sans-cn-fonts \
+              docbook-utils \
+              docbook-sgml \
+              gobject-introspection \
+              gtk-doc \
+              meson \
+              perl-sgmls \
+              python-cairo \
+              python-gobject \
+              python-pillow \
+              ttf-dejavu \
+              valgrind
+# CI dep
+RUN pacman -S --noconfirm git
+# add an user to build the package with
+RUN useradd -s /bin/bash build
+RUN echo 'build ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+# prepare the build environment
+RUN mkdir /build
+RUN chown build /build
+USER build
+WORKDIR /build

--- a/contrib/ci/build_and_install_pkgs.sh
+++ b/contrib/ci/build_and_install_pkgs.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+# prepare the build tree
+rm -rf build
+mkdir build && pushd build
+cp ../contrib/PKGBUILD .
+mkdir -p src/fwupd && pushd src/fwupd
+ln -s ../../../* .
+ln -s ../../../.git .
+popd
+
+# build the package and install it
+makepkg -ei --noconfirm
+
+# move the package to working dir
+cp *.pkg.tar.xz ../
+
+# no testing here because gnome-desktop-testing isn’t available in Arch


### PR DESCRIPTION
This is a first attempt, likely not working and probably requiring some cleaning.

No tests in the build script because `gnome-desktop-testing` is not available in Arch.