### PR TITLE
Allow building against older appstream-glib

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -125,7 +125,7 @@ if polkit.version() >= '0.114'
   conf.set('HAVE_POLKIT_0_114', '1')
 endif
 gudev = dependency('gudev-1.0')
-appstream_glib = dependency('appstream-glib', version : '>= 0.6.13')
+appstream_glib = dependency('appstream-glib', version : '>= 0.6.9')
 gusb = dependency('gusb', version : '>= 0.2.9')
 sqlite = dependency('sqlite3')
 libarchive = dependency('libarchive')

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -5,9 +5,14 @@ subdir('raspberrypi')
 subdir('steelseries')
 subdir('test')
 subdir('udev')
-subdir('unifying')
 subdir('upower')
 subdir('usb')
+
+if appstream_glib.version().version_compare('>=0.6.13')
+subdir('unifying')
+else
+message('appstream-glib 0.6.13+ not found, disabling unifying plugin')
+endif
 
 if get_option('enable-amt')
 subdir('amt')

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2195,6 +2195,7 @@ fu_engine_plugin_set_coldplug_delay_cb (FuPlugin *plugin, guint duration, FuEngi
 		 duration, self->coldplug_delay);
 }
 
+#if AS_CHECK_VERSION(0,6,13)
 static gboolean
 fu_engine_load_hwids (FuEngine *self, GError **error)
 {
@@ -2229,6 +2230,7 @@ fu_engine_load_hwids (FuEngine *self, GError **error)
 
 	return TRUE;
 }
+#endif
 
 static gboolean
 fu_engine_load_plugins (FuEngine *self, GError **error)
@@ -2388,11 +2390,13 @@ fu_engine_load (FuEngine *self, GError **error)
 		return FALSE;
 	}
 
+#if AS_CHECK_VERSION(0,6,13)
 	/* load the hwids */
 	if (!fu_engine_load_hwids (self, error)) {
 		g_prefix_error (error, "Failed to load hwids: ");
 		return FALSE;
 	}
+#endif
 
 	/* delete old data files */
 	if (!fu_engine_cleanup_state (error)) {

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -21,6 +21,7 @@
 
 #include "config.h"
 
+#include <appstream-glib.h>
 #include <fwupd.h>
 #include <glib-object.h>
 #include <glib/gstdio.h>
@@ -422,7 +423,9 @@ main (int argc, char **argv)
 	g_assert_cmpint (g_mkdir_with_parents ("/tmp/fwupd-self-test/var/lib/fwupd", 0755), ==, 0);
 
 	/* tests go here */
+#if AS_CHECK_VERSION(0,6,13)
 	g_test_add_func ("/fwupd/hwids", fu_hwids_func);
+#endif
 	g_test_add_func ("/fwupd/pending", fu_pending_func);
 	g_test_add_func ("/fwupd/plugin{delay}", fu_plugin_delay_func);
 	g_test_add_func ("/fwupd/plugin{module}", fu_plugin_module_func);

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -1635,12 +1635,14 @@ main (int argc, char *argv[])
 		     /* TRANSLATORS: command description */
 		     _("Get all devices that support firmware updates"),
 		     fu_util_get_devices);
+#if AS_CHECK_VERSION(0,6,13)
 	fu_util_add (priv->cmd_array,
 		     "hwids",
 		     NULL,
 		     /* TRANSLATORS: command description */
 		     _("Return all the hardware IDs for the machine"),
 		     fu_util_hwids);
+#endif
 	fu_util_add (priv->cmd_array,
 		     "install-prepared",
 		     NULL,


### PR DESCRIPTION
The main things that appstream-glib 0.6.13 adds are related to the unifying plugin and hwids.  These can be made optional and allow building on older appstream-glib.

I wasn't sure if you thought this would be a good idea though.
