### PR TITLE
gir creation optional

### DIFF
--- a/libdfu/meson.build
+++ b/libdfu/meson.build
@@ -89,41 +89,43 @@ executable(
   install_dir : get_option('bindir')
 )
 
-gnome.generate_gir(dfu,
-  sources : [
-    'dfu-common.c',
-    'dfu-common.h',
-    'dfu-context.c',
-    'dfu-context.h',
-    'dfu-device.c',
-    'dfu-device.h',
-    'dfu-element.c',
-    'dfu-element.h',
-    'dfu-error.c',
-    'dfu-error.h',
-    'dfu-firmware.c',
-    'dfu-firmware.h',
-    'dfu-image.c',
-    'dfu-image.h',
-    'dfu-sector.c',
-    'dfu-sector.h',
-    'dfu-target.c',
-    'dfu-target.h',
-  ],
-  nsversion : '1.0',
-  namespace : 'Dfu',
-  symbol_prefix : 'dfu',
-  identifier_prefix : 'Dfu',
-  export_packages : 'dfu',
-  dependencies : deps,
-  includes : [
-    'AppStreamGlib-1.0',
-    'Gio-2.0',
-    'GObject-2.0',
-    'GUsb-1.0',
-  ],
-  install : true
-)
+if get_option('enable-introspection')
+  gnome.generate_gir(dfu,
+    sources : [
+      'dfu-common.c',
+      'dfu-common.h',
+      'dfu-context.c',
+      'dfu-context.h',
+      'dfu-device.c',
+      'dfu-device.h',
+      'dfu-element.c',
+      'dfu-element.h',
+      'dfu-error.c',
+      'dfu-error.h',
+      'dfu-firmware.c',
+      'dfu-firmware.h',
+      'dfu-image.c',
+      'dfu-image.h',
+      'dfu-sector.c',
+      'dfu-sector.h',
+      'dfu-target.c',
+      'dfu-target.h',
+    ],
+    nsversion : '1.0',
+    namespace : 'Dfu',
+    symbol_prefix : 'dfu',
+    identifier_prefix : 'Dfu',
+    export_packages : 'dfu',
+    dependencies : deps,
+    includes : [
+      'AppStreamGlib-1.0',
+      'Gio-2.0',
+      'GObject-2.0',
+      'GUsb-1.0',
+    ],
+    install : true
+  )
+endif
 
 if get_option('enable-tests')
   testdatadir = join_paths(meson.current_source_dir(), 'tests')

--- a/libfwupd/meson.build
+++ b/libfwupd/meson.build
@@ -68,39 +68,41 @@ pkgg.generate(
   description : 'fwupd is a system daemon for installing device firmware',
 )
 
-gnome.generate_gir(fwupd,
-  sources : [
-    'fwupd-client.c',
-    'fwupd-client.h',
-    'fwupd-device.c',
-    'fwupd-device.h',
-    'fwupd-enums.c',
-    'fwupd-enums.h',
-    'fwupd-error.c',
-    'fwupd-error.h',
-    'fwupd-release.c',
-    'fwupd-release.h',
-    'fwupd-remote.c',
-    'fwupd-remote.h',
-    'fwupd-result.c',
-    'fwupd-result.h',
-  ],
-  nsversion : '1.0',
-  namespace : 'Fwupd',
-  symbol_prefix : 'fwupd',
-  identifier_prefix : 'Fwupd',
-  export_packages : 'fwupd',
-  dependencies : [
-    giounix,
-    soup,
-  ],
-  includes : [
-    'Gio-2.0',
-    'GObject-2.0',
-    'Soup-2.4',
-  ],
-  install : true
-)
+if get_option('enable-introspection')
+  gnome.generate_gir(fwupd,
+    sources : [
+      'fwupd-client.c',
+      'fwupd-client.h',
+      'fwupd-device.c',
+      'fwupd-device.h',
+      'fwupd-enums.c',
+      'fwupd-enums.h',
+      'fwupd-error.c',
+      'fwupd-error.h',
+      'fwupd-release.c',
+      'fwupd-release.h',
+      'fwupd-remote.c',
+      'fwupd-remote.h',
+      'fwupd-result.c',
+      'fwupd-result.h',
+    ],
+    nsversion : '1.0',
+    namespace : 'Fwupd',
+    symbol_prefix : 'fwupd',
+    identifier_prefix : 'Fwupd',
+    export_packages : 'fwupd',
+    dependencies : [
+      giounix,
+      soup,
+    ],
+    includes : [
+      'Gio-2.0',
+      'GObject-2.0',
+      'Soup-2.4',
+    ],
+    install : true
+  )
+endif
 
 if get_option('enable-tests')
   testdatadir = join_paths(meson.source_root(), 'data')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
 option('enable-doc', type : 'boolean', value : true, description : 'enable developer documentation')
+option('enable-introspection', type : 'boolean', value : true, description : 'generate GObject Introspection data')
 option('enable-man', type : 'boolean', value : true, description : 'enable man pages')
 option('enable-tests', type : 'boolean', value : true, description : 'enable tests')
 option('enable-colorhug', type : 'boolean', value : true, description : 'enable ColorHug support')


### PR DESCRIPTION
I'm working on packaging fwupd for OpenEmbedded, or more specifically,
https://github.com/intel/intel-iot-refkit.

OE currently has technical problems with gobject-introspection when
using meson. This is going to be addressed eventually, but some
intermediate solution is needed. As gir data is not needed for fwupd,
it would be great if it could be made optional. That might also be
useful in other builds that try to build only what's really needed.

Depends on a similar change in appstream-glib, see
https://github.com/hughsie/appstream-glib/pull/182.