### PR TITLE
Make flashing ebitdo devices actually work

### DIFF
--- a/plugins/ebitdo/fu-ebitdo-tool.c
+++ b/plugins/ebitdo/fu-ebitdo-tool.c
@@ -89,7 +89,7 @@ main (int argc, char **argv)
 		g_print ("\t%u = 0x%08x\n", i, fu_device_ebitdo_get_serial(dev)[i]);
 
 	/* not in bootloader mode, so print what to do */
-	if (!fu_device_has_flag (dev, FWUPD_DEVICE_FLAG_NEEDS_BOOTLOADER)) {
+	if (fu_device_has_flag (dev, FWUPD_DEVICE_FLAG_NEEDS_BOOTLOADER)) {
 		g_print ("1. Disconnect the controller\n");
 		switch (fu_device_ebitdo_get_kind (dev)) {
 		case FU_DEVICE_EBITDO_KIND_FC30:


### PR DESCRIPTION
When my SNES30 controller was in bootloader mode, it wouldn't update, and when it was in controller mode, it tried and failed. Now, it prints out the instructions on how to reset the device if it's in controller mode, and if it's in bootloader mode, it successfully installs the firmware update from the .DAT file.