### PR TITLE
Build fixes: C99 and feature test macros

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -117,6 +117,9 @@ add_global_link_arguments(
   language: 'c'
 )
 
+# Needed for realpath(), syscall(), cfmakeraw(), etc.
+add_project_arguments('-D_DEFAULT_SOURCE', language : 'c')
+
 gio = dependency('gio-2.0', version : '>= 2.45.8')
 gmodule = dependency('gmodule-2.0')
 giounix = dependency('gio-unix-2.0', version : '>= 2.45.8')

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('fwupd', 'c',
   version : '0.9.7',
   license : 'LGPL-2.1+',
   meson_version : '>=0.37.0',
-  default_options : 'warning_level=2',
+  default_options : ['warning_level=2', 'c_std=c99'],
 )
 
 fwupd_version = meson.project_version()


### PR DESCRIPTION
The same fixes as I seem to be making everywhere. Probably as a result of using old GCC on Debian Jessie. Still, let’s fix it.