### PR TITLE
Add firmware-packager Script

### DIFF
--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -100,7 +100,8 @@ Package: fwupd
 Architecture: linux-any
 Depends: ${misc:Depends},
          ${shlibs:Depends}
-Recommends: fwupdate
+Recommends: fwupdate,
+            python3
 Multi-Arch: foreign
 Description: Firmware update daemon
  fwupd is a daemon to allow session software to update device firmware.

--- a/contrib/firmware-packager/README.md
+++ b/contrib/firmware-packager/README.md
@@ -1,0 +1,104 @@
+# Firmware Packager
+
+This script is intended to make firmware updating easier until OEMs upload their firmware packages to the LVFS. It works by extracting the firmware binary contained in a Microsoft .exe file (intended for performing the firmware update from a Windows system) and repackaging it in a cab file usable by fwupd. The cab file can then be install using `fwupdmgr install`
+
+## Prerequisites 
+
+To run this script you will need
+
+1. Python3.5, a standard install should include all packages you need
+2. 7z (for extracting .exe files)
+3. gcab (for creating the cab file)
+
+## Usage
+
+To create a firmware package, you must supply, at a minimum:
+
+1. A string ID to name the firmware (`--firmware-id`). You are free to choose this, but [fwupd.org](http://fwupd.org/vendors.html) recommends using "a reverse-DNS prefix similar to java" and to "always use a .firmware suffix" (e.g. net.queuecumber.DellTBT.firmware)
+2. A short name for the firmware package, again you are free to choose this (`--firmware-name`).
+3. The unique ID of the device that the firmware is intended for (`--device-unique-id`). This *must* match the unique ID from `fwupdmgr get-devices`
+4. The firmware version (`--release-version`), try to match the manufacturers versioning scheme
+5. The path to the executable file to repackage (`--exe`)
+6. The path *relative to the root of the exe archive* of the .bin file to package (`--bin`). Use 7z or archive-manager to inspect the .exe file and find this path. 
+For example, if I want to package `dell-thunderbolt-firmware.exe` and I open the .exe with archive-manager and find that `Intel/tbt.bin` is the path to the
+bin file inside the archive, I would pass `--exe dell-thunderbolt-firmware.exe --bin Intel/tbt.bin`
+7. The path to the cab file to output (`--out`). 
+
+## Documentation
+
+`--firmware-id` ID for the firmware package, can be a customized [fwupd.org](http://fwupd.org/vendors.html) recommends using "a reverse-DNS prefix similar to java" and to "always use a .firmware suffix" (e.g. net.queuecumber.DellTBT.firmware) **REQUIRED**
+
+`--firmware-name` Short name of the firmware package can be customized (e.g. DellTBT) **REQUIRED**
+
+`--firmware-summary` One line description of the firmware package (e.g. Dell thunderbolt firmware)
+
+`--firmware-description` Longer description of the firmware package. Theoretically this can include HTML but I haven't tried it
+
+`--device-unique-id` Unique ID of the device this firmware will run on, this *must* match the output from `fwupdmgr get-devices` (e.g. 72533768-6a6c-5c06-994a-367374336810) **REQUIRED**
+
+`--firmware-homepage` Website for the firmware provider (e.g. http://www.dell.com)
+
+`-contact-info` Email address of the firmware developer (e.g. someone@something.net)
+
+`--developer-name` Name of the firmware developer (e.g. John Smith)
+
+`--release-version` Version number of the firmware package (e.g. 4.21.01.002) **REQUIRED**
+`--release-description` Description of the firmware release, again this can theoretically include HTML but I didnt try it.
+
+`--exe` Executable file to extract firmware from (e.g. `dell-thunderbolt-firmware.exe`) **REQUIRED**
+
+`--bin` Path to the .bin file inside the executable to use as the firmware image', relative to the root of the archive (e.g. `Intel/tbt.bin`) **REQUIRED**
+
+`--out` Output cab file path (e.g. `updates/firmware.cab`) **REQUIRED**
+
+## Example
+
+Let's say we downloaded `Intel_TBT3_FW_UPDATE_NVM21_318RY_A01_4.21.01.002.exe` (available [here](https://downloads.dell.com/FOLDER04421073M/1/Intel_TBT3_FW_UPDATE_NVM21_318RY_A01_4.21.01.002.exe)) containing updated firmware for Dell laptops thunderbolt controllers. Since Dell hasn't made this available on the LVFS yet, we want to package and install it ourselves.
+
+Opening the .exe with archive manager, we see it has a single folder: `Intel` and inside that, a set of firmware binaries (along with some microsoft junk). We pick the file `0x07BE_secure.bin` since we have a Dell XPS 9560 and that is its device string. 
+
+Next we use `fwupdmgr` to get the device ID for the thunderbolt controller:
+
+```
+$ fwupdmgr get-devices
+Thunderbolt Controller
+  Guid:                 72533768-6a6c-5c06-994a-367374336810
+  DeviceID:             08001575
+  Plugin:               thunderbolt
+  Flags:                internal|allow-online
+  DeviceVendor:         Intel
+  Version:              21.00
+  Created:              2017-08-16
+```
+The GUID field contains what we are looking for
+
+We can then run the firmware-packager with the following arguments:
+
+```
+$ firmware-packager --firmware-id net.queuecumber.DellTBT.firmware --firmware-name DellTBT --device-unique-id 72533768-6a6c-5c06-994a-367374336810 --release-version 4.21.01.002 --exe ~/Downloads/Intel_TBT3_FW_UPDATE_NVM21_318RY_A01_4.21.01.002.exe --bin Intel/0x07BE_secure.bin --out firmware.cab
+Using temp directory /tmp/tmpoey6_zx_
+Extracting firmware exe
+Locating firmware bin
+Creating metainfo
+Cabbing firmware files
+Done
+```
+And we should have a firmware.cab that contains the packaged firmware. We can then install this firmware with 
+```
+$ fwupdmgr install firmware.cab
+```
+
+## Copyright and License
+
+This script is copyright (C) 2017 Max Ehrlich (max.ehr@gmail.com)
+
+It is distributed under the GPL2 as is the rest of fwupd
+
+> The GNU General Public License Version 2
+> 
+>This program is free software; you can redistribute it and/or modify it under the terms of the GNU General  Public License as published by the Free Software Foundation; either version 2 of the License, or (at your option) any later version.
+>
+>This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+>
+>You should have received a copy of the GNU General Public License along with this program; if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+

--- a/contrib/firmware-packager/firmware-packager
+++ b/contrib/firmware-packager/firmware-packager
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2017 Max Ehrlich max.ehr@gmail.com
+#
+# Licensed under the GNU General Public License Version 2
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+import argparse
+import subprocess
+import contextlib
+import os
+import shutil
+import tempfile
+import time
+
+
+@contextlib.contextmanager
+def cd(path):
+    prev_cwd = os.getcwd()
+    os.chdir(path)
+    yield
+    os.chdir(prev_cwd)
+
+firmware_metainfo_template = """
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="firmware">
+  <id>{firmware_id}</id>
+  <name>{firmware_name}</name>
+  <summary>{firmware_summary}</summary>
+  <description>
+    {firmware_description}
+  </description>
+  <provides>
+    <firmware type="flashed">{device_unique_id}</firmware>
+  </provides>
+  <url type="homepage">{firmware_homepage}</url>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>proprietary</project_license>
+  <updatecontact>{contact_info}</updatecontact>
+  <developer_name>{developer_name}</developer_name>
+  <releases>
+    <release version="{release_version}" timestamp="{timestamp}">
+      <description>
+        {release_description}
+      </description>
+    </release>
+  </releases>
+</component>
+"""
+
+
+def make_firmware_metainfo(firmware_info, dst):
+    firmware_metainfo = firmware_metainfo_template.format(**vars(firmware_info), timestamp=time.time())
+
+    with open(os.path.join(dst, 'firmware.metainfo.xml'), 'w') as f:
+        f.write(firmware_metainfo)
+
+
+def extract_exe(exe, dst):
+    command = ['7z', 'x', '-o{}'.format(dst), exe]
+    subprocess.check_call(command, stdout=subprocess.DEVNULL)
+
+
+def get_firmware_bin(root, bin_path, dst):
+    with cd(root):
+        shutil.copy(bin_path, os.path.join(dst, 'firmware.bin'))
+
+
+def create_firmware_cab(exe, folder):
+    with cd(folder):
+        command = ['gcab', '--create', 'firmware.cab', 'firmware.bin', 'firmware.metainfo.xml']
+        subprocess.check_call(command)
+
+
+def main(args):
+    with tempfile.TemporaryDirectory() as dir:
+        print('Using temp directory {}'.format(dir))
+
+        print('Extracting firmware exe')
+        extract_exe(args.exe, dir)
+
+        print('Locating firmware bin')
+        get_firmware_bin(dir, args.bin, dir)
+
+        print('Creating metainfo')
+        make_firmware_metainfo(args, dir)
+
+        print('Cabbing firmware files')
+        create_firmware_cab(args, dir)
+
+        print('Done')
+        shutil.copy(os.path.join(dir, 'firmware.cab'), args.out)
+
+parser = argparse.ArgumentParser(description='Create fwupd packaged from windows executables')
+parser.add_argument('--firmware-id', help='ID for the firmware package, can be a customized (e.g. net.queuecumber.DellTBT.firmware)', required=True)
+parser.add_argument('--firmware-name', help='Name of the firmware package can be customized (e.g. DellTBT)', required=True)
+parser.add_argument('--firmware-summary', help='One line description of the firmware package')
+parser.add_argument('--firmware-description', help='Longer description of the firmware package')
+parser.add_argument('--device-unique-id', help='Unique ID of the device this firmware will run on, this *must* match the output from `fwupdmgr get-devices`', required=True)
+parser.add_argument('--firmware-homepage', help='Website for the firmware provider')
+parser.add_argument('--contact-info', help='Email address of the firmware developer')
+parser.add_argument('--developer-name', help='Name of the firmware developer')
+parser.add_argument('--release-version', help='Version number of the firmware package', required=True)
+parser.add_argument('--release-description', help='Description of the firmware release')
+parser.add_argument('--exe', help='Executable file to extract firmware from', required=True)
+parser.add_argument('--bin', help='Path to the .bin file inside the executable to use as the firmware image', required=True)
+parser.add_argument('--out', help='Output cab file path', required=True)
+args = parser.parse_args()
+
+main(args)

--- a/contrib/firmware-packager/meson.build
+++ b/contrib/firmware-packager/meson.build
@@ -1,0 +1,2 @@
+install_data('firmware-packager',
+             install_dir : 'share/fwupd')

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -81,6 +81,8 @@ Requires: libsoup%{?_isa} >= %{libsoup_version}
 Requires: fwupd-labels = %{version}-%{release}
 Requires: bubblewrap
 
+Recommends: python3
+
 Obsoletes: fwupd-sign < 0.1.6
 Obsoletes: libebitdo < 0.7.5-3
 
@@ -207,6 +209,7 @@ mkdir -p --mode=0700 $RPM_BUILD_ROOT%{_localstatedir}/lib/fwupd/gnupg
 %{_datadir}/dbus-1/system-services/org.freedesktop.fwupd.service
 %{_datadir}/man/man1/fwupdmgr.1.gz
 %{_datadir}/metainfo/org.freedesktop.fwupd.metainfo.xml
+%{_datadir}/fwupd/firmware-packager
 %{_unitdir}/fwupd-offline-update.service
 %{_unitdir}/fwupd.service
 %{_unitdir}/system-update.target.wants/

--- a/contrib/meson.build
+++ b/contrib/meson.build
@@ -1,0 +1,1 @@
+subdir('firmware-packager')

--- a/meson.build
+++ b/meson.build
@@ -257,6 +257,7 @@ subdir('po')
 subdir('policy')
 subdir('src')
 subdir('plugins')
+subdir('contrib')
 
 if meson.version().version_compare('<0.41.0')
   if archiver.found()


### PR DESCRIPTION
These commits add a python script to create fwupd compatible cab files from Microsoft .exe files. This allows a user to update their firmware with fwupd even if the vensor hasn't yet made firmware packages available on the LVFS. 

Resolves #103 