### PR TITLE
Show a bouncing progress bar if the percentage remains at zero

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -5,4 +5,5 @@ plugins/synapticsmst/synapticsmst-tool.c
 plugins/uefi/fu-plugin-uefi.c
 src/fu-debug.c
 src/fu-main.c
+src/fu-progressbar.c
 src/fu-util.c

--- a/src/fu-progressbar.c
+++ b/src/fu-progressbar.c
@@ -107,23 +107,23 @@ fu_progressbar_refresh (FuProgressbar *self)
 	title = fu_util_status_to_string (self->status);
 	g_string_append (str, title);
 	for (i = str->len; i < self->length_status; i++)
-		g_string_append (str, " ");
+		g_string_append_c (str, ' ');
 
 	/* add progressbar */
 	g_string_append (str, "[");
 	if (self->percentage > 0) {
 		for (i = 0; i < self->length_percentage * self->percentage / 100; i++)
-			g_string_append (str, "*");
+			g_string_append_c (str, '*');
 		for (i = i + 1; i < self->length_percentage; i++)
-			g_string_append (str, " ");
+			g_string_append_c (str, ' ');
 	} else {
 		for (i = 0; i < self->spinner_idx; i++)
-			g_string_append (str, " ");
-		g_string_append (str, "*");
+			g_string_append_c (str, ' ');
+		g_string_append_c (str, '*');
 		for (i = i + 1; i < self->length_percentage; i++)
-			g_string_append (str, " ");
+			g_string_append_c (str, ' ');
 	}
-	g_string_append (str, "]");
+	g_string_append_c (str, ']');
 
 	/* dump to screen */
 	g_print ("%s", str->str);

--- a/src/fu-progressbar.c
+++ b/src/fu-progressbar.c
@@ -43,7 +43,7 @@ struct _FuProgressbar
 G_DEFINE_TYPE (FuProgressbar, fu_progressbar, G_TYPE_OBJECT)
 
 static const gchar *
-fu_util_status_to_string (FwupdStatus status)
+fu_progressbar_status_to_string (FwupdStatus status)
 {
 	switch (status) {
 	case FWUPD_STATUS_IDLE:
@@ -104,7 +104,7 @@ fu_progressbar_refresh (FuProgressbar *self)
 		self->to_erase = 0;
 		return;
 	}
-	title = fu_util_status_to_string (self->status);
+	title = fu_progressbar_status_to_string (self->status);
 	g_string_append (str, title);
 	for (i = str->len; i < self->length_status; i++)
 		g_string_append_c (str, ' ');

--- a/src/fu-progressbar.c
+++ b/src/fu-progressbar.c
@@ -93,8 +93,6 @@ fu_progressbar_refresh (FuProgressbar *self)
 	guint i;
 	g_autoptr(GString) str = g_string_new (NULL);
 
-	g_return_if_fail (FU_IS_PROGRESSBAR (self));
-
 	/* erase previous line */
 	for (i = 0; i < self->to_erase; i++)
 		g_print ("\b");
@@ -196,12 +194,16 @@ fu_progressbar_update (FuProgressbar *self, FwupdStatus status, guint percentage
 void
 fu_progressbar_set_length_status (FuProgressbar *self, guint len)
 {
+	g_return_if_fail (FU_IS_PROGRESSBAR (self));
+	g_return_if_fail (len > 3);
 	self->length_status = len;
 }
 
 void
 fu_progressbar_set_length_percentage (FuProgressbar *self, guint len)
 {
+	g_return_if_fail (FU_IS_PROGRESSBAR (self));
+	g_return_if_fail (len > 3);
 	self->length_percentage = len;
 }
 

--- a/src/fu-progressbar.c
+++ b/src/fu-progressbar.c
@@ -117,9 +117,10 @@ fu_progressbar_refresh (FuProgressbar *self)
 		for (i = i + 1; i < self->length_percentage; i++)
 			g_string_append_c (str, ' ');
 	} else {
+		const gchar chars[] = { '-', '\\', '|', '/', };
 		for (i = 0; i < self->spinner_idx; i++)
 			g_string_append_c (str, ' ');
-		g_string_append_c (str, '*');
+		g_string_append_c (str, chars[i / 4 % G_N_ELEMENTS(chars)]);
 		for (i = i + 1; i < self->length_percentage; i++)
 			g_string_append_c (str, ' ');
 	}

--- a/src/fu-progressbar.c
+++ b/src/fu-progressbar.c
@@ -1,0 +1,240 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include "config.h"
+
+#include <glib/gi18n.h>
+
+#include "fu-progressbar.h"
+
+static void fu_progressbar_finalize	 (GObject *obj);
+
+struct _FuProgressbar
+{
+	GObject			 parent_instance;
+	FwupdStatus		 status;
+	gboolean		 spinner_count_up;	/* chars */
+	guint			 spinner_idx;		/* chars */
+	guint			 length_percentage;	/* chars */
+	guint			 length_status;		/* chars */
+	guint			 percentage;
+	guint			 to_erase;		/* chars */
+	guint			 timer_id;
+};
+
+G_DEFINE_TYPE (FuProgressbar, fu_progressbar, G_TYPE_OBJECT)
+
+static const gchar *
+fu_util_status_to_string (FwupdStatus status)
+{
+	switch (status) {
+	case FWUPD_STATUS_IDLE:
+		/* TRANSLATORS: daemon is inactive */
+		return _("Idle…");
+		break;
+	case FWUPD_STATUS_DECOMPRESSING:
+		/* TRANSLATORS: decompressing the firmware file */
+		return _("Decompressing…");
+		break;
+	case FWUPD_STATUS_LOADING:
+		/* TRANSLATORS: parsing the firmware information */
+		return _("Loading…");
+		break;
+	case FWUPD_STATUS_DEVICE_RESTART:
+		/* TRANSLATORS: restarting the device to pick up new F/W */
+		return _("Restarting device…");
+		break;
+	case FWUPD_STATUS_DEVICE_WRITE:
+		/* TRANSLATORS: writing to the flash chips */
+		return _("Writing…");
+		break;
+	case FWUPD_STATUS_DEVICE_VERIFY:
+		/* TRANSLATORS: verifying we wrote the firmware correctly */
+		return _("Verifying…");
+		break;
+	case FWUPD_STATUS_SCHEDULING:
+		/* TRANSLATORS: scheduing an update to be done on the next boot */
+		return _("Scheduling…");
+		break;
+	case FWUPD_STATUS_DOWNLOADING:
+		/* TRANSLATORS: downloading from a remote server */
+		return _("Downloading…");
+		break;
+	default:
+		break;
+	}
+
+	/* TRANSLATORS: currect daemon status is unknown */
+	return _("Unknown");
+}
+
+static void
+fu_progressbar_refresh (FuProgressbar *self)
+{
+	const gchar *title;
+	guint i;
+	g_autoptr(GString) str = g_string_new (NULL);
+
+	g_return_if_fail (FU_IS_PROGRESSBAR (self));
+
+	/* erase previous line */
+	for (i = 0; i < self->to_erase; i++)
+		g_print ("\b");
+
+	/* add status */
+	if (self->status == FWUPD_STATUS_IDLE) {
+		if (self->to_erase > 0)
+			g_print ("\n");
+		self->to_erase = 0;
+		return;
+	}
+	title = fu_util_status_to_string (self->status);
+	g_string_append (str, title);
+	for (i = str->len; i < self->length_status; i++)
+		g_string_append (str, " ");
+
+	/* add progressbar */
+	g_string_append (str, "[");
+	if (self->percentage > 0) {
+		for (i = 0; i < self->length_percentage * self->percentage / 100; i++)
+			g_string_append (str, "*");
+		for (i = i + 1; i < self->length_percentage; i++)
+			g_string_append (str, " ");
+	} else {
+		for (i = 0; i < self->spinner_idx; i++)
+			g_string_append (str, " ");
+		g_string_append (str, "*");
+		for (i = i + 1; i < self->length_percentage; i++)
+			g_string_append (str, " ");
+	}
+	g_string_append (str, "]");
+
+	/* dump to screen */
+	g_print ("%s", str->str);
+	self->to_erase = str->len;
+}
+
+static gboolean
+fu_progressbar_spin_cb (gpointer user_data)
+{
+	FuProgressbar *self = FU_PROGRESSBAR (user_data);
+
+	/* move the spinner index up to down */
+	if (self->spinner_count_up) {
+		if (++self->spinner_idx > self->length_percentage - 2)
+			self->spinner_count_up = FALSE;
+	} else {
+		if (--self->spinner_idx == 0)
+			self->spinner_count_up = TRUE;
+	}
+
+	/* update the terminal */
+	fu_progressbar_refresh (self);
+
+	return G_SOURCE_CONTINUE;
+}
+
+static void
+fu_progressbar_spin_end (FuProgressbar *self)
+{
+	if (self->timer_id != 0) {
+		g_source_remove (self->timer_id);
+		self->timer_id = 0;
+	}
+
+	/* go back to the start when we next go into unknown percentage mode */
+	self->spinner_idx = 0;
+	self->spinner_count_up = TRUE;
+}
+
+static void
+fu_progressbar_spin_start (FuProgressbar *self)
+{
+	if (self->timer_id != 0)
+		g_source_remove (self->timer_id);
+	self->timer_id = g_timeout_add (40, fu_progressbar_spin_cb, self);
+}
+
+void
+fu_progressbar_update (FuProgressbar *self, FwupdStatus status, guint percentage)
+{
+	g_return_if_fail (FU_IS_PROGRESSBAR (self));
+
+	/* cache */
+	self->status = status;
+	self->percentage = percentage;
+
+	/* enable or disable the spinner timeout */
+	if (percentage > 0) {
+		fu_progressbar_spin_end (self);
+	} else {
+		fu_progressbar_spin_start (self);
+	}
+
+	/* update the terminal */
+	fu_progressbar_refresh (self);
+}
+
+void
+fu_progressbar_set_length_status (FuProgressbar *self, guint len)
+{
+	self->length_status = len;
+}
+
+void
+fu_progressbar_set_length_percentage (FuProgressbar *self, guint len)
+{
+	self->length_percentage = len;
+}
+
+static void
+fu_progressbar_class_init (FuProgressbarClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+	object_class->finalize = fu_progressbar_finalize;
+}
+
+static void
+fu_progressbar_init (FuProgressbar *self)
+{
+	self->length_percentage = 40;
+	self->length_status = 25;
+	self->spinner_count_up = TRUE;
+}
+
+static void
+fu_progressbar_finalize (GObject *obj)
+{
+	FuProgressbar *self = FU_PROGRESSBAR (obj);
+
+	if (self->timer_id != 0)
+		g_source_remove (self->timer_id);
+
+	G_OBJECT_CLASS (fu_progressbar_parent_class)->finalize (obj);
+}
+
+FuProgressbar *
+fu_progressbar_new (void)
+{
+	FuProgressbar *self;
+	self = g_object_new (FU_TYPE_PROGRESSBAR, NULL);
+	return FU_PROGRESSBAR (self);
+}

--- a/src/fu-progressbar.h
+++ b/src/fu-progressbar.h
@@ -1,0 +1,46 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef __FU_PROGRESSBAR_H
+#define __FU_PROGRESSBAR_H
+
+#include <gio/gio.h>
+
+#include "fwupd-enums.h"
+
+G_BEGIN_DECLS
+
+#define FU_TYPE_PROGRESSBAR (fu_progressbar_get_type ())
+G_DECLARE_FINAL_TYPE (FuProgressbar, fu_progressbar, FU, PROGRESSBAR, GObject)
+
+FuProgressbar	*fu_progressbar_new			(void);
+void		 fu_progressbar_update			(FuProgressbar	*self,
+							 FwupdStatus	 status,
+							 guint		 percentage);
+void		 fu_progressbar_set_length_status	(FuProgressbar	*self,
+							 guint		 len);
+void		 fu_progressbar_set_length_percentage	(FuProgressbar	*self,
+							 guint		 len);
+
+G_END_DECLS
+
+#endif /* __FU_PROGRESSBAR_H */
+

--- a/src/meson.build
+++ b/src/meson.build
@@ -53,6 +53,7 @@ libfwupdprivate = static_library(
 executable(
   'fwupdmgr',
   sources : [
+    'fu-progressbar.c',
     'fu-util.c',
   ],
   include_directories : [


### PR DESCRIPTION
Device actions like a Thunderbolt replug can take 25 seconds (!) and so it's a
good idea to show the user that the calling process is still alive.