### PR TITLE
Meson build fixes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -203,7 +203,7 @@ if get_option('enable-consolekit')
 endif
 
 systemdunitdir = get_option('with-systemdunitdir')
-if systemdunitdir == ''
+if systemdunitdir == '' and get_option('enable-systemd')
   systemdunitdir = systemd.get_pkgconfig_variable('systemdsystemunitdir')
 endif
 

--- a/plugins/thunderbolt/meson.build
+++ b/plugins/thunderbolt/meson.build
@@ -15,7 +15,6 @@ shared_module('fu_plugin_thunderbolt',
   dependencies : [
     plugin_deps,
     gudev,
-    fwup,
   ],
 )
 
@@ -38,7 +37,6 @@ if get_option('enable-tests') and umockdev.found()
     ],
     dependencies : [
       plugin_deps,
-      fwup,
       gudev,
       umockdev,
     ],


### PR DESCRIPTION
A couple of fixes when building with `-Denable-systemd=false -Denable-thunderbolt=true`.