### PR TITLE
thunderbolt: ignore remove events on host controllers

### DIFF
--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -36,6 +36,7 @@
 #include "fu-plugin-dell.h"
 #include "fu-quirks.h"
 #include "fu-plugin-vfuncs.h"
+#include "fu-device-metadata.h"
 
 /* These are used to indicate the status of a previous DELL flash */
 #define DELL_SUCCESS			0x0000
@@ -802,6 +803,21 @@ fu_plugin_update_offline (FuPlugin *plugin,
                 return FALSE;
         }
 	return TRUE;
+}
+
+void
+fu_plugin_device_registered (FuPlugin *plugin, FuDevice *device)
+{
+	FwupdDeviceFlags flags = 0;
+	flags = fu_device_get_flags (device);
+
+	/* thunderbolt plugin */
+	if (g_strcmp0 (fu_device_get_plugin (device), "thunderbolt") == 0 &&
+	    fu_device_has_flag (device, FWUPD_DEVICE_FLAG_INTERNAL))
+		/* Prevent thunderbolt controllers in the system from going away */
+		fu_device_set_metadata (device,
+					FU_DEVICE_TBT_CAN_FORCE_POWER,
+					FU_DEVICE_TBT_FORCE_POWER_EN);
 }
 
 gboolean

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -34,6 +34,7 @@
 
 #include "fu-plugin-thunderbolt.h"
 #include "fu-plugin-vfuncs.h"
+#include "fu-device-metadata.h"
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevDevice, g_object_unref)
 
@@ -175,6 +176,9 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 	id = fu_plugin_thunderbolt_gen_id (device);
 	dev_tmp = fu_plugin_cache_lookup (plugin, id);
 	if (dev_tmp != NULL) {
+		/* When devices are force-powered they'll
+                 * come through again but be ignored
+                 */
 		g_debug ("ignoring duplicate %s", id);
 		return;
 	}
@@ -221,6 +225,9 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 	if (is_host)
 		fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_INTERNAL);
 
+	fu_device_set_metadata (dev, FU_DEVICE_TBT_CAN_FORCE_POWER,
+				FU_DEVICE_TBT_FORCE_POWER_DIS);
+
 	fu_plugin_cache_add (plugin, id, dev);
 	fu_plugin_device_add (plugin, dev);
 }
@@ -235,6 +242,17 @@ fu_plugin_thunderbolt_remove (FuPlugin *plugin, GUdevDevice *device)
 	dev = fu_plugin_cache_lookup (plugin, id);
 	if (dev == NULL)
 		return;
+
+	/* on supported systems other plugins may use a GPIO to force
+	 * power on supported devices even if in low power mode.
+	 * this will happen both in coldplug_prepare and prepare_for_update
+	 */
+	if (fu_plugin_thunderbolt_is_host (device) &&
+	    g_strcmp0 (fu_device_get_metadata (dev, FU_DEVICE_TBT_CAN_FORCE_POWER),
+		       FU_DEVICE_TBT_FORCE_POWER_EN) == 0) {
+		g_debug ("Ignoring remove event due to being force powered.");
+		return;
+	}
 
 	fu_plugin_device_remove (plugin, dev);
 	fu_plugin_cache_remove (plugin, id);

--- a/src/fu-device-metadata.h
+++ b/src/fu-device-metadata.h
@@ -22,4 +22,9 @@
 #ifndef __FU_DEVICE_METADATA_H__
 #define __FU_DEVICE_METADATA_H__
 
+/* thunderbolt plugin */
+#define FU_DEVICE_TBT_CAN_FORCE_POWER		"Thunderbolt::CanForcePower"
+#define FU_DEVICE_TBT_FORCE_POWER_DIS		"0"
+#define FU_DEVICE_TBT_FORCE_POWER_EN		"1"
+
 #endif /* __FU_DEVICE_METADATA_H__ */


### PR DESCRIPTION
Since the new plugin is strictly based off the uevents that fire, the previous coldplug_prepare magic that would allow thunderbolt to be exposed even if nothing was plugged in on Dell systems doesn't work properly.

It shows up as a device coming onto the system and then promptly going off the system shortly after.

I would argue that if the device is a host controller (as told by `fu_plugin_thunderbolt_is_host`) that the remove uvent should be ignored.

At least on my XPS 9350 this finds and keeps the TBT controller around even if nothing is plugged in.