### PR TITLE
Add safe mode handling for Dell systems

### DIFF
--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -36,6 +36,7 @@
 #include "fu-plugin-dell.h"
 #include "fu-quirks.h"
 #include "fu-plugin-vfuncs.h"
+#include "fu-device-metadata.h"
 
 /* These are used to indicate the status of a previous DELL flash */
 #define DELL_SUCCESS			0x0000
@@ -802,6 +803,21 @@ fu_plugin_update_offline (FuPlugin *plugin,
                 return FALSE;
         }
 	return TRUE;
+}
+
+void
+fu_plugin_device_registered (FuPlugin *plugin, FuDevice *device)
+{
+	FwupdDeviceFlags flags = 0;
+	flags = fu_device_get_flags (device);
+
+	/* thunderbolt plugin */
+	if (g_strcmp0 (fu_device_get_plugin (device), "thunderbolt") == 0 &&
+	    (flags & FWUPD_DEVICE_FLAG_INTERNAL) == 1)
+		/* Prevent thunderbolt controllers in the system from going away */
+		fu_device_set_metadata (device,
+					FU_DEVICE_TBT_CAN_FORCE_POWER,
+					FU_DEVICE_TBT_FORCE_POWER_EN);
 }
 
 gboolean

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -154,8 +154,11 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 	const gchar *version;
 	const gchar *devpath;
 	gboolean is_host;
+	gboolean is_safemode = FALSE;
 	guint16 did;
 	guint16 vid;
+	g_autofree gchar *test_safe = NULL;
+	g_autofree gchar *safe_path = NULL;
 	g_autofree gchar *id = NULL;
 	g_autofree gchar *vendor_id = NULL;
 	g_autofree gchar *device_id = NULL;
@@ -165,7 +168,6 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 	uuid = g_udev_device_get_sysfs_attr (device, "unique_id");
 	if (uuid == NULL) {
 		/* most likely the domain itself, ignore */
-		/* TODO: handle devices in safe-mode */
 		return;
 	}
 
@@ -184,21 +186,40 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 	}
 
 	vid = fu_plugin_thunderbolt_udev_get_id (device, "vendor", &error);
-	if (vid == 0x0) {
+	if (vid == 0x0)
 		g_warning ("failed to get Vendor ID: %s", error->message);
-		return;
-	}
+
 	did = fu_plugin_thunderbolt_udev_get_id (device, "device", &error);
-	if (did == 0x0) {
+	if (did == 0x0)
 		g_warning ("failed to get Device ID: %s", error->message);
-		return;
-	}
 
 	is_host = fu_plugin_thunderbolt_is_host (device);
-	vendor_id = g_strdup_printf ("TBT:0x%04X", (guint) vid);
-	device_id = g_strdup_printf ("TBT-%04x%04x", (guint) vid, (guint) did);
+
+	version = g_udev_device_get_sysfs_attr (device, "nvm_version");
+
+	/* test for safe mode */
+	if (is_host && (version == NULL)) {
+		/* this is a bit hacky due to glib can't return a properly mapped
+		 * -ENODATA. the kernel only returns -ENODATA or -EAGAIN.
+                 * if new returns are added, those should be added to this too.
+		 */
+		safe_path = g_build_path ("/", devpath, "nvm_version", NULL);
+		if (!g_file_get_contents (safe_path, &test_safe, NULL, &error) &&
+		    !g_error_matches (error, G_IO_ERROR, G_IO_ERROR_WOULD_BLOCK)) {
+			g_warning ("%s is in safe mode.  VID/DID will need to be set by another plugin for normal use.",
+				   devpath);
+			version = "0.0";
+			is_safemode = TRUE;
+		}
+	}
+
+	if (!is_safemode) {
+		vendor_id = g_strdup_printf ("TBT:0x%04X", (guint) vid);
+		device_id = g_strdup_printf ("TBT-%04x%04x", (guint) vid, (guint) did);
+	}
 
 	dev = fu_device_new ();
+
 	fu_device_set_id (dev, uuid);
 
 	fu_device_set_metadata (dev, "sysfs-path", devpath);
@@ -216,9 +237,10 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 	vendor = g_udev_device_get_sysfs_attr (device, "vendor_name");
 	if (vendor != NULL)
 		fu_device_set_vendor (dev, vendor);
-	fu_device_set_vendor_id (dev, vendor_id);
-	fu_device_add_guid (dev, device_id);
-	version = g_udev_device_get_sysfs_attr (device, "nvm_version");
+	if (vendor_id != NULL)
+		fu_device_set_vendor_id (dev, vendor_id);
+	if (device_id != NULL)
+		fu_device_add_guid (dev, device_id);
 	if (version != NULL)
 		fu_device_set_version (dev, version);
 	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_ALLOW_ONLINE);
@@ -227,6 +249,10 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 
 	fu_device_set_metadata (dev, FU_DEVICE_TBT_CAN_FORCE_POWER,
 				FU_DEVICE_TBT_FORCE_POWER_DIS);
+
+	fu_device_set_metadata (dev, FU_DEVICE_TBT_IS_SAFE_MODE,
+				is_safemode ? FU_DEVICE_TBT_SAFE_MODE :
+					      FU_DEVICE_TBT_NORMAL_MODE);
 
 	fu_plugin_cache_add (plugin, id, dev);
 	fu_plugin_device_add (plugin, dev);

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -34,6 +34,7 @@
 
 #include "fu-plugin-thunderbolt.h"
 #include "fu-plugin-vfuncs.h"
+#include "fu-device-metadata.h"
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevDevice, g_object_unref)
 
@@ -175,6 +176,9 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 	id = fu_plugin_thunderbolt_gen_id (device);
 	dev_tmp = fu_plugin_cache_lookup (plugin, id);
 	if (dev_tmp != NULL) {
+		/* When devices are force-powered they'll
+                 * come through again but be ignored
+                 */
 		g_debug ("ignoring duplicate %s", id);
 		return;
 	}
@@ -221,6 +225,9 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 	if (is_host)
 		fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_INTERNAL);
 
+	fu_device_set_metadata (dev, FU_DEVICE_TBT_CAN_FORCE_POWER,
+				FU_DEVICE_TBT_FORCE_POWER_DIS);
+
 	fu_plugin_cache_add (plugin, id, dev);
 	fu_plugin_device_add (plugin, dev);
 }
@@ -235,6 +242,17 @@ fu_plugin_thunderbolt_remove (FuPlugin *plugin, GUdevDevice *device)
 	dev = fu_plugin_cache_lookup (plugin, id);
 	if (dev == NULL)
 		return;
+
+	/* on supported systems other plugins may use a GPIO to force
+	 * power on supported devices even if in low power mode.
+	 * this will happen both in coldplug_prepare and prepare_for_update
+	 */
+	if (fu_plugin_thunderbolt_is_host (device) &&
+	    g_strcmp0 (fu_device_get_metadata (dev, FU_DEVICE_TBT_CAN_FORCE_POWER),
+		       FU_DEVICE_TBT_FORCE_POWER_EN) == 0) {
+		g_debug ("Ignoring remove event due to being force powered.");
+		return;
+	}
 
 	fu_plugin_device_remove (plugin, dev);
 	fu_plugin_cache_remove (plugin, id);

--- a/src/fu-device-metadata.h
+++ b/src/fu-device-metadata.h
@@ -26,5 +26,8 @@
 #define FU_DEVICE_TBT_CAN_FORCE_POWER		"Thunderbolt::CanForcePower"
 #define FU_DEVICE_TBT_FORCE_POWER_DIS		"0"
 #define FU_DEVICE_TBT_FORCE_POWER_EN		"1"
+#define FU_DEVICE_TBT_IS_SAFE_MODE		"Thunderbolt::SafeMode"
+#define FU_DEVICE_TBT_SAFE_MODE			"Safe"
+#define FU_DEVICE_TBT_NORMAL_MODE		"Normal"
 
 #endif /* __FU_DEVICE_METADATA_H__ */

--- a/src/fu-device-metadata.h
+++ b/src/fu-device-metadata.h
@@ -22,4 +22,9 @@
 #ifndef __FU_DEVICE_METADATA_H__
 #define __FU_DEVICE_METADATA_H__
 
+/* thunderbolt plugin */
+#define FU_DEVICE_TBT_CAN_FORCE_POWER		"Thunderbolt::CanForcePower"
+#define FU_DEVICE_TBT_FORCE_POWER_DIS		"0"
+#define FU_DEVICE_TBT_FORCE_POWER_EN		"1"
+
 #endif /* __FU_DEVICE_METADATA_H__ */


### PR DESCRIPTION
The legacy thunderbolt plugin handled safe mode when on a Dell system by setting VID/DID from SMBIOS tables.  Restore this functionality in the new plugin.

There are some unknowns still being answered in #190 so please don't merge until they're answered.
Just posting it for review until then.