### PR TITLE
thunderbolt plugin can be tested on Arch Linux now

### DIFF
--- a/contrib/ci/Dockerfile-arch
+++ b/contrib/ci/Dockerfile-arch
@@ -25,6 +25,7 @@ RUN pacman -S --noconfirm \
               python-gobject \
               python-pillow \
               ttf-dejavu \
+              umockdev \
               valgrind
 # CI dep
 RUN pacman -S --noconfirm git


### PR DESCRIPTION
umockdev package is now available in the community repository
of Arch Linux

https://github.com/hughsie/fwupd/issues/187