### PR TITLE
thunderbolt: add new devices without delay

### DIFF
--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -222,7 +222,7 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 		fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_INTERNAL);
 
 	fu_plugin_cache_add (plugin, id, dev);
-	fu_plugin_device_add_delay (plugin, dev);
+	fu_plugin_device_add (plugin, dev);
 }
 
 static void


### PR DESCRIPTION
We want thunderbolt to claim the device and not to race with the
udev plugin.