### PR TITLE
Allow plugins to set metadata on devices created by other plugins

### DIFF
--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -78,6 +78,7 @@ typedef enum {
  * @FWUPD_DEVICE_FLAG_LOCKED:			Is locked and can be unlocked
  * @FWUPD_DEVICE_FLAG_SUPPORTED:		Is found in current metadata
  * @FWUPD_DEVICE_FLAG_NEEDS_BOOTLOADER:		Requires a bootloader mode
+ * @FWUPD_DEVICE_FLAG_REGISTERED:		Has been registered with other plugins
  *
  * FIXME: rename FU_DEVICE_ -> FWUPD_DEVICE_ when we break API
  *
@@ -91,6 +92,7 @@ typedef enum {
 #define FWUPD_DEVICE_FLAG_LOCKED		(1u << 4)	/* Since: 0.6.3 */
 #define FWUPD_DEVICE_FLAG_SUPPORTED		(1u << 5)	/* Since: 0.7.1 */
 #define FWUPD_DEVICE_FLAG_NEEDS_BOOTLOADER	(1u << 6)	/* Since: 0.7.3 */
+#define FWUPD_DEVICE_FLAG_REGISTERED		(1u << 7)	/* Since: 0.9.7 */
 #define FWUPD_DEVICE_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 0.7.3 */
 typedef guint64 FwupdDeviceFlags;
 

--- a/plugins/test/fu-plugin-test.c
+++ b/plugins/test/fu-plugin-test.c
@@ -71,8 +71,22 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 	fu_device_set_version_bootloader (device, "0.1.2");
 	fu_device_set_version (device, "1.2.3");
 	fu_device_set_version_lowest (device, "1.2.0");
+	fu_plugin_device_register (plugin, device);
+	if (fu_device_get_metadata (device, "BestDevice") == NULL) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_NOT_FOUND,
+			     "Device not set by another plugin");
+		return FALSE;
+	}
 	fu_plugin_device_add (plugin, device);
 	return TRUE;
+}
+
+void
+fu_plugin_device_registered (FuPlugin *plugin, FuDevice *device)
+{
+	fu_device_set_metadata (device, "BestDevice", "/dev/urandom");
 }
 
 gboolean

--- a/src/fu-plugin-private.h
+++ b/src/fu-plugin-private.h
@@ -50,6 +50,8 @@ gboolean	 fu_plugin_runner_update_prepare	(FuPlugin	*plugin,
 gboolean	 fu_plugin_runner_update_cleanup	(FuPlugin	*plugin,
 							 FuDevice	*device,
 							 GError		**error);
+void		 fu_plugin_runner_device_register	(FuPlugin	*plugin,
+							 FuDevice	*device);
 gboolean	 fu_plugin_runner_update		(FuPlugin	*plugin,
 							 FuDevice	*device,
 							 GBytes		*blob_cab,

--- a/src/fu-plugin-vfuncs.h
+++ b/src/fu-plugin-vfuncs.h
@@ -66,6 +66,8 @@ gboolean	 fu_plugin_update_prepare		(FuPlugin	*plugin,
 gboolean	 fu_plugin_update_cleanup		(FuPlugin	*plugin,
 							 FuDevice	*dev,
 							 GError		**error);
+void		 fu_plugin_device_registered		(FuPlugin	*plugin,
+							 FuDevice	*dev);
 
 G_END_DECLS
 

--- a/src/fu-plugin.h
+++ b/src/fu-plugin.h
@@ -51,8 +51,10 @@ struct _FuPluginClass
 	void		 (* recoldplug)			(FuPlugin	*plugin);
 	void		 (* set_coldplug_delay)		(FuPlugin	*plugin,
 							 guint		 duration);
+	void		 (* device_register)		(FuPlugin	*plugin,
+							 FuDevice	*device);
 	/*< private >*/
-	gpointer	padding[25];
+	gpointer	padding[24];
 };
 
 typedef enum {
@@ -76,6 +78,8 @@ void		 fu_plugin_device_add			(FuPlugin	*plugin,
 void		 fu_plugin_device_add_delay		(FuPlugin	*plugin,
 							 FuDevice	*device);
 void		 fu_plugin_device_remove		(FuPlugin	*plugin,
+							 FuDevice	*device);
+void		 fu_plugin_device_register		(FuPlugin	*plugin,
 							 FuDevice	*device);
 void		 fu_plugin_set_status			(FuPlugin	*plugin,
 							 FwupdStatus	 status);

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -169,6 +169,13 @@ fu_plugin_delay_func (void)
 }
 
 static void
+_plugin_device_register_cb (FuPlugin *plugin, FuDevice *device, gpointer user_data)
+{
+	/* fake being a daemon */
+	fu_plugin_runner_device_register (plugin, device);
+}
+
+static void
 fu_plugin_module_func (void)
 {
 	GError *error = NULL;
@@ -198,6 +205,9 @@ fu_plugin_module_func (void)
 	g_assert (ret);
 	g_signal_connect (plugin, "device-added",
 			  G_CALLBACK (_plugin_device_added_cb),
+			  &device);
+	g_signal_connect (plugin, "device-register",
+			  G_CALLBACK (_plugin_device_register_cb),
 			  &device);
 	g_signal_connect (plugin, "status-changed",
 			  G_CALLBACK (_plugin_status_changed_cb),


### PR DESCRIPTION
This could be used, for instance, to set a property on ThunderBolt controllers
inside Dell computers saying that they support forcing the power level during
coldplug. It could also be used to set the dock type for the synapticsmst hub.

Adding this level of complexity allows us to avoid the creep of HAVE_DELL and
HAVE_LENOVO into seemingly unrelated plugins, and also allows us to have
multiple vendor plugins providing the same end result with two different
vendor-specific mechanisms.