### PR TITLE
thunderbolt: Don't remove devices on change events

### DIFF
--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -258,6 +258,7 @@ fu_plugin_thunderbolt_change (FuPlugin *plugin, GUdevDevice *device)
 	fu_plugin_device_remove (plugin, dev);
 	version = g_udev_device_get_sysfs_attr (device, "nvm_version");
 	fu_device_set_version (dev, version);
+	fu_plugin_device_add (plugin, dev);
 }
 
 static gboolean


### PR DESCRIPTION
I found that changing the security level of a Dell dock causes
it to fall off fwupd before this change.