### PR TITLE
thunderbolt: only build tests if glib >= 2.52

### DIFF
--- a/plugins/thunderbolt/meson.build
+++ b/plugins/thunderbolt/meson.build
@@ -18,7 +18,8 @@ shared_module('fu_plugin_thunderbolt',
   ],
 )
 
-if get_option('enable-tests') and umockdev.found()
+# we use functions from 2.52 in the tests
+if get_option('enable-tests') and umockdev.found() and gio.version().version_compare('>= 2.52')
   cargs += '-DFU_OFFLINE_DESTDIR="/tmp/fwupd-self-test"'
   cargs += '-DPLUGINBUILDDIR="' + meson.current_build_dir() + '"'
   testdatadir_src = join_paths(meson.source_root(), 'data', 'tests')


### PR DESCRIPTION
This change should restore building fwupd with the new thunderbolt
plugin on older systems.