### PR TITLE
trivial: fix TBT controller safe mode handling on Dell

### DIFF
--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -822,11 +822,13 @@ fu_plugin_device_registered (FuPlugin *plugin, FuDevice *device)
 		if (fu_device_get_metadata_boolean (device, FU_DEVICE_METADATA_TBT_IS_SAFE_MODE)) {
 			g_autofree gchar *vendor_id = NULL;
 			g_autofree gchar *device_id = NULL;
-			vendor_id = g_strdup_printf ("TBT:0x%04d", 0x00d4);
-			device_id = g_strdup_printf ("TBT-%04d%04d", 0x00d4,
+			vendor_id = g_strdup ("TBT:0x00D4");
+			/* the kernel returns lowercase in sysfs, need to match it */
+			device_id = g_strdup_printf ("TBT-%04x%04x", 0x00d4,
 						     sysinfo_get_dell_system_id ());
 			fu_device_set_vendor_id (device, vendor_id);
 			fu_device_add_guid (device, device_id);
+			fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
 		}
 	}
 }

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -189,6 +189,8 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 	if (did == 0x0)
 		g_warning ("failed to get Device ID: %s", error->message);
 
+	dev = fu_device_new ();
+
 	/* test for safe mode */
 	is_host = fu_plugin_thunderbolt_is_host (device);
 	version = g_udev_device_get_sysfs_attr (device, "nvm_version");
@@ -205,14 +207,15 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 				   devpath);
 			version = "0.0";
 			is_safemode = TRUE;
+			device_id = g_strdup ("TBT-safemode");
+			fu_device_set_metadata_boolean (dev, FU_DEVICE_METADATA_TBT_IS_SAFE_MODE, TRUE);
 		}
 	}
 	if (!is_safemode) {
 		vendor_id = g_strdup_printf ("TBT:0x%04X", (guint) vid);
 		device_id = g_strdup_printf ("TBT-%04x%04x", (guint) vid, (guint) did);
+		fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_UPDATABLE);
 	}
-
-	dev = fu_device_new ();
 
 	fu_device_set_id (dev, uuid);
 
@@ -237,11 +240,8 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 		fu_device_add_guid (dev, device_id);
 	if (version != NULL)
 		fu_device_set_version (dev, version);
-	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_UPDATABLE);
 	if (is_host)
 		fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_INTERNAL);
-	if (is_safemode)
-		fu_device_set_metadata_boolean (dev, FU_DEVICE_METADATA_TBT_IS_SAFE_MODE, TRUE);
 
 	fu_plugin_cache_add (plugin, id, dev);
 	fu_plugin_device_add (plugin, dev);


### PR DESCRIPTION
- Set initial (invalid) GUID for TBT controller (otherwise device doesn't add)
- Don't set updatable unless GUID has been refreshed (otherwise someone could update from GUID TBT-safemode)
- Correct the string used for GUID in Dell plugin (was looking at decimal not hex)

I found these problems by manually setting safe mode in code.  I haven't actually tested on a system really in safe mode.  It would be appreciated if @ybernat could check on a system truly instrumented in safe mode if there are other deficiencies.