### PR TITLE
trivial: fix compilation warning

### DIFF
--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -824,8 +824,8 @@ fu_plugin_device_registered (FuPlugin *plugin, FuDevice *device)
 			g_autofree gchar *device_id = NULL;
 			vendor_id = g_strdup ("TBT:0x00D4");
 			/* the kernel returns lowercase in sysfs, need to match it */
-			device_id = g_strdup_printf ("TBT-%04x%04x", 0x00d4,
-						     sysinfo_get_dell_system_id ());
+			device_id = g_strdup_printf ("TBT-%04x%04x", 0x00d4u,
+						     (unsigned) sysinfo_get_dell_system_id ());
 			fu_device_set_vendor_id (device, vendor_id);
 			fu_device_add_guid (device, device_id);
 			fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);


### PR DESCRIPTION
Currently, when compiling I get the following warnings:
```
[150/178] Compiling C object 'plugins/dell/fu_plugin_dell@sha/fu-plugin-dell.c.o'.
../thunderbolt_sw_2-fwupd/plugins/dell/fu-plugin-dell.c: In function ‘fu_plugin_device_registered’:
../thunderbolt_sw_2-fwupd/plugins/dell/fu-plugin-dell.c:827:41: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘int’ [-Wformat=]
    device_id = g_strdup_printf ("TBT-%04x%04x", 0x00d4,
                                      ~~~^
                                      %04x
../thunderbolt_sw_2-fwupd/plugins/dell/fu-plugin-dell.c:827:45: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 3 has type ‘int’ [-Wformat=]
    device_id = g_strdup_printf ("TBT-%04x%04x", 0x00d4,
                                          ~~~^
                                          %04x
            sysinfo_get_dell_system_id ());
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     
[164/178] Compiling C object 'plugins/dell/dell-self-test@exe/fu-plugin-dell.c.o'.
../thunderbolt_sw_2-fwupd/plugins/dell/fu-plugin-dell.c: In function ‘fu_plugin_device_registered’:
../thunderbolt_sw_2-fwupd/plugins/dell/fu-plugin-dell.c:827:41: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 2 has type ‘int’ [-Wformat=]
    device_id = g_strdup_printf ("TBT-%04x%04x", 0x00d4,
                                      ~~~^
                                      %04x
../thunderbolt_sw_2-fwupd/plugins/dell/fu-plugin-dell.c:827:45: warning: format ‘%x’ expects argument of type ‘unsigned int’, but argument 3 has type ‘int’ [-Wformat=]
    device_id = g_strdup_printf ("TBT-%04x%04x", 0x00d4,
                                          ~~~^
                                          %04x
            sysinfo_get_dell_system_id ());
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     
```