### PR TITLE
trivial: cleanup for many compilation warnings from clang

### DIFF
--- a/libdfu/dfu-cipher-xtea.c
+++ b/libdfu/dfu-cipher-xtea.c
@@ -34,7 +34,6 @@ dfu_tool_parse_xtea_key (const gchar *key, guint32 *keys, GError **error)
 {
 	guint i;
 	gsize key_len;
-	g_autofree gchar *key_pad = NULL;
 
 	/* too long */
 	key_len = strlen (key);

--- a/libdfu/dfu-device.c
+++ b/libdfu/dfu-device.c
@@ -1719,7 +1719,6 @@ gboolean
 dfu_device_attach (DfuDevice *device, GError **error)
 {
 	DfuDevicePrivate *priv = GET_PRIVATE (device);
-	g_autoptr(GError) error_local = NULL;
 
 	g_return_val_if_fail (DFU_IS_DEVICE (device), FALSE);
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
@@ -1974,7 +1973,6 @@ dfu_device_download (DfuDevice *device,
 	GPtrArray *images;
 	gboolean ret;
 	guint i;
-	g_autoptr(GPtrArray) targets = NULL;
 
 	/* no backing USB device */
 	if (priv->dev == NULL) {

--- a/libdfu/dfu-element.c
+++ b/libdfu/dfu-element.c
@@ -240,7 +240,6 @@ dfu_element_set_target_size (DfuElement *element, guint32 target_size)
 	const guint8 *data;
 	gsize length;
 	guint8 *buf;
-	g_autoptr(GBytes) contents_padded = NULL;
 
 	g_return_if_fail (DFU_IS_ELEMENT (element));
 

--- a/libdfu/dfu-patch.c
+++ b/libdfu/dfu-patch.c
@@ -168,7 +168,7 @@ dfu_patch_export (DfuPatch *self, GError **error)
 		DfuPatchChunk *chunk = g_ptr_array_index (priv->chunks, i);
 		DfuPatchChunkHeader chunkhdr;
 		gsize sz_tmp = 0;
-		guint8 *data_new = g_bytes_get_data (chunk->blob, &sz_tmp);
+		const guint8 *data_new = g_bytes_get_data (chunk->blob, &sz_tmp);
 
 		/* build chunk header and append data */
 		chunkhdr.off = GUINT32_TO_LE (chunk->off);
@@ -342,8 +342,8 @@ dfu_patch_create (DfuPatch *self, GBytes *blob1, GBytes *blob2, GError **error)
 {
 	DfuPatchPrivate *priv = GET_PRIVATE (self);
 	DfuPatchCreateHelper helper;
-	guint8 *data1;
-	guint8 *data2;
+	const guint8 *data1;
+	const guint8 *data2;
 	gsize sz1 = 0;
 	gsize sz2 = 0;
 	guint32 same_sz = 0;

--- a/libdfu/dfu-self-test.c
+++ b/libdfu/dfu-self-test.c
@@ -156,7 +156,6 @@ dfu_firmware_raw_func (void)
 	gboolean ret;
 	g_autoptr(DfuFirmware) firmware = NULL;
 	g_autoptr(GBytes) fw = NULL;
-	g_autoptr(GBytes) roundtrip_orig = NULL;
 	g_autoptr(GBytes) roundtrip = NULL;
 	g_autoptr(GError) error = NULL;
 

--- a/libdfu/dfu-target.c
+++ b/libdfu/dfu-target.c
@@ -616,7 +616,6 @@ static gboolean
 dfu_target_setup (DfuTarget *target, GError **error)
 {
 	DfuTargetPrivate *priv = GET_PRIVATE (target);
-	g_autoptr(GError) error_local = NULL;
 
 	g_return_val_if_fail (DFU_IS_TARGET (target), FALSE);
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
@@ -1405,7 +1404,6 @@ dfu_target_download_element_dfu (DfuTarget *target,
 	guint i;
 	guint nr_chunks;
 	guint16 transfer_size = dfu_device_get_transfer_size (priv->device);
-	g_autoptr(GError) error_local = NULL;
 
 	/* round up as we have to transfer incomplete blocks */
 	bytes = dfu_element_get_contents (element);
@@ -1471,7 +1469,6 @@ dfu_target_download_element_dfuse (DfuTarget *target,
 	guint nr_chunks;
 	guint zone_last = G_MAXUINT;
 	guint16 transfer_size = dfu_device_get_transfer_size (priv->device);
-	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GPtrArray) sectors_array = NULL;
 	g_autoptr(GHashTable) sectors_hash = NULL;
 

--- a/libdfu/dfu-tool.c
+++ b/libdfu/dfu-tool.c
@@ -1385,7 +1385,6 @@ dfu_tool_read (DfuToolPrivate *priv, gchar **values, GError **error)
 	g_autofree gchar *str_debug = NULL;
 	g_autoptr(DfuDevice) device = NULL;
 	g_autoptr(DfuFirmware) firmware = NULL;
-	g_autoptr(DfuImage) image = NULL;
 	g_autoptr(GFile) file = NULL;
 
 	/* check args */

--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -602,7 +602,6 @@ fwupd_client_verify (FwupdClient *client, const gchar *device_id,
 {
 	FwupdClientPrivate *priv = GET_PRIVATE (client);
 	g_autoptr(FwupdClientHelper) helper = NULL;
-	g_autoptr(GVariant) val = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (client), FALSE);
 	g_return_val_if_fail (device_id != NULL, FALSE);
@@ -651,7 +650,6 @@ fwupd_client_verify_update (FwupdClient *client, const gchar *device_id,
 {
 	FwupdClientPrivate *priv = GET_PRIVATE (client);
 	g_autoptr(FwupdClientHelper) helper = NULL;
-	g_autoptr(GVariant) val = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (client), FALSE);
 	g_return_val_if_fail (device_id != NULL, FALSE);
@@ -700,7 +698,6 @@ fwupd_client_unlock (FwupdClient *client, const gchar *device_id,
 {
 	FwupdClientPrivate *priv = GET_PRIVATE (client);
 	g_autoptr(FwupdClientHelper) helper = NULL;
-	g_autoptr(GVariant) val = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (client), FALSE);
 	g_return_val_if_fail (device_id != NULL, FALSE);
@@ -749,7 +746,6 @@ fwupd_client_clear_results (FwupdClient *client, const gchar *device_id,
 {
 	FwupdClientPrivate *priv = GET_PRIVATE (client);
 	g_autoptr(FwupdClientHelper) helper = NULL;
-	g_autoptr(GVariant) val = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (client), FALSE);
 	g_return_val_if_fail (device_id != NULL, FALSE);
@@ -798,7 +794,6 @@ fwupd_client_get_results (FwupdClient *client, const gchar *device_id,
 {
 	FwupdClientPrivate *priv = GET_PRIVATE (client);
 	g_autoptr(FwupdClientHelper) helper = NULL;
-	g_autoptr(GVariant) val = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (client), NULL);
 	g_return_val_if_fail (device_id != NULL, NULL);
@@ -878,7 +873,6 @@ fwupd_client_install (FwupdClient *client,
 	g_autoptr(FwupdClientHelper) helper = NULL;
 	g_autoptr(GDBusMessage) request = NULL;
 	g_autoptr(GUnixFDList) fd_list = NULL;
-	g_autoptr(GVariant) val = NULL;
 
 	g_return_val_if_fail (FWUPD_IS_CLIENT (client), FALSE);
 	g_return_val_if_fail (device_id != NULL, FALSE);

--- a/plugins/dfu/fu-plugin-dfu.c
+++ b/plugins/dfu/fu-plugin-dfu.c
@@ -39,7 +39,6 @@ fu_plugin_dfu_device_update (FuPlugin *plugin,
 {
 	const gchar *platform_id;
 	guint16 release;
-	g_autofree gchar *guid = NULL;
 	g_autofree gchar *version = NULL;
 	g_autofree gchar *devid1 = NULL;
 	g_autofree gchar *devid2 = NULL;
@@ -118,7 +117,6 @@ fu_plugin_dfu_device_added_cb (DfuContext *ctx,
 {
 	const gchar *platform_id;
 	const gchar *display_name;
-	g_autofree gchar *id = NULL;
 	g_autoptr(AsProfile) profile = as_profile_new ();
 	g_autoptr(AsProfileTask) ptask = NULL;
 	g_autoptr(FuDevice) dev = NULL;
@@ -219,7 +217,6 @@ fu_plugin_update (FuPlugin *plugin,
 	FuPluginData *data = fu_plugin_get_data (plugin);
 	DfuDevice *device;
 	const gchar *platform_id;
-	g_autoptr(DfuDevice) dfu_device = NULL;
 	g_autoptr(DfuFirmware) dfu_firmware = NULL;
 	g_autoptr(GError) error_local = NULL;
 
@@ -287,7 +284,6 @@ fu_plugin_verify (FuPlugin *plugin,
 	GBytes *blob_fw;
 	DfuDevice *device;
 	const gchar *platform_id;
-	g_autoptr(DfuDevice) dfu_device = NULL;
 	g_autoptr(DfuFirmware) dfu_firmware = NULL;
 	g_autoptr(GError) error_local = NULL;
 	GChecksumType checksum_types[] = {

--- a/plugins/raspberrypi/fu-plugin-raspberrypi.c
+++ b/plugins/raspberrypi/fu-plugin-raspberrypi.c
@@ -198,7 +198,6 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
 	g_autofree gchar *fwfn = NULL;
-	g_autofree gchar *fwver = NULL;
 	g_autoptr(FuDevice) device = NULL;
 
 	/* anything interesting */

--- a/plugins/synapticsmst/fu-self-test.c
+++ b/plugins/synapticsmst/fu-self-test.c
@@ -52,9 +52,6 @@ fu_plugin_synapticsmst_func (void)
 	g_autoptr(GError) error = NULL;
 	FuDevice *device = NULL;
 	g_autoptr(FuPlugin) plugin = NULL;
-	g_autoptr(GBytes) blob_fw = NULL;
-	g_autoptr(GMappedFile) mapped_file = NULL;
-	g_autofree gchar *fwfile = NULL;
 	const gchar *test_directory;
 
 	devices = g_ptr_array_new ();

--- a/plugins/udev/fu-rom-tool.c
+++ b/plugins/udev/fu-rom-tool.c
@@ -64,7 +64,6 @@ fu_fuzzer_write_files (GHashTable *hash, GError **error)
 	g_autoptr(GList) keys = g_hash_table_get_keys (hash);
 
 	for (l = keys; l != NULL; l = l->next) {
-		g_autoptr(FuRom) rom = fu_rom_new ();
 		g_autofree gchar *filename = NULL;
 		const gchar *fn = l->data;
 		filename = g_build_filename ("fuzzing", fn, NULL);

--- a/plugins/udev/fu-rom.c
+++ b/plugins/udev/fu-rom.c
@@ -571,9 +571,7 @@ fu_rom_load_data (FuRom *rom,
 	gssize sz = buffer_sz;
 	guint32 jump = 0;
 	guint32 hdr_sz = 0;
-	g_autoptr(GError) error_local = NULL;
 	g_autofree gchar *id = NULL;
-	g_autoptr(AsProfile) profile = as_profile_new ();
 	g_autoptr(GChecksum) checksum_sha1 = g_checksum_new (G_CHECKSUM_SHA1);
 	g_autoptr(GChecksum) checksum_sha256 = g_checksum_new (G_CHECKSUM_SHA256);
 

--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -176,7 +176,6 @@ fu_plugin_update (FuPlugin *plugin,
 		  FwupdInstallFlags flags,
 		  GError **error)
 {
-	g_autoptr(GError) error_local = NULL;
 	fwup_resource *re = NULL;
 	guint64 hardware_instance = 0;	/* FIXME */
 	int rc;

--- a/plugins/unifying/fu-plugin-unifying.c
+++ b/plugins/unifying/fu-plugin-unifying.c
@@ -43,7 +43,6 @@ fu_plugin_unifying_device_added (FuPlugin *plugin,
 {
 	GPtrArray *guids;
 	GUsbDevice *usb_device;
-	g_autofree gchar *name = NULL;
 	g_autoptr(AsProfile) profile = as_profile_new ();
 	g_autoptr(AsProfileTask) ptask = NULL;
 	g_autoptr(FuDevice) dev = NULL;

--- a/plugins/unifying/lu-device-bootloader.c
+++ b/plugins/unifying/lu-device-bootloader.c
@@ -259,7 +259,6 @@ lu_device_bootloader_request (LuDevice *device,
 	/* send request */
 	lu_dump_raw ("host->device", buf_request, sizeof (buf_request));
 	if (usb_device != NULL) {
-		g_autofree guint8 *data_in_buf = g_memdup (buf_request, sizeof (buf_request));
 		if (!g_usb_device_control_transfer (usb_device,
 						    G_USB_DEVICE_DIRECTION_HOST_TO_DEVICE,
 						    G_USB_DEVICE_REQUEST_TYPE_CLASS,

--- a/plugins/unifying/lu-tool.c
+++ b/plugins/unifying/lu-tool.c
@@ -410,7 +410,6 @@ lu_tool_attach (FuLuToolPrivate *priv, gchar **values, GError **error)
 static void
 lu_tool_device_added_cb (LuContext* ctx, LuDevice *device, FuLuToolPrivate *priv)
 {
-	g_autoptr(GError) error = NULL;
 	g_print ("ADDED\tLogitech Unifying device %s {%p} [%s]\n",
 		 lu_device_kind_to_string (lu_device_get_kind (device)),
 		 device, lu_device_get_platform_id (device));
@@ -472,7 +471,6 @@ main (int argc, char **argv)
 	g_autofree gchar *emulation_kind = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GOptionContext) context = NULL;
-	g_autoptr(LuDevice) device = NULL;
 	g_autoptr(FuLuToolPrivate) priv = g_new0 (FuLuToolPrivate, 1);
 	const GOptionEntry options[] = {
 		{ "verbose", 'v', 0, G_OPTION_ARG_NONE, &verbose,

--- a/src/fu-common.c
+++ b/src/fu-common.c
@@ -247,7 +247,6 @@ fu_common_extract_archive (GBytes *blob, const gchar *dir, GError **error)
 	}
 	for (;;) {
 		gboolean valid;
-		g_autofree gchar *path = NULL;
 		r = archive_read_next_header (arch, &entry);
 		if (r == ARCHIVE_EOF)
 			break;
@@ -283,6 +282,9 @@ out:
 	}
 	return ret;
 }
+
+static void
+fu_common_add_argv (GPtrArray *argv, const gchar *fmt, ...) G_GNUC_PRINTF (2, 3);
 
 static void
 fu_common_add_argv (GPtrArray *argv, const gchar *fmt, ...)

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1494,7 +1494,6 @@ fu_engine_update_metadata (FuEngine *self, const gchar *remote_id,
 	g_autoptr(GBytes) bytes_raw = NULL;
 	g_autoptr(GBytes) bytes_sig = NULL;
 	g_autoptr(GInputStream) stream_fd = NULL;
-	g_autoptr(GInputStream) stream = NULL;
 	g_autoptr(GInputStream) stream_sig = NULL;
 
 	g_return_val_if_fail (FU_IS_ENGINE (self), FALSE);

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -80,7 +80,6 @@ fu_hwids_func (void)
 	g_autoptr(FuHwids) hwids = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autofree gchar *sysfsdir = NULL;
-	g_autofree gchar *testdir = NULL;
 	gboolean ret;
 
 	struct {
@@ -610,12 +609,12 @@ fu_common_spawn_func (void)
 	guint lines = 0;
 	g_autoptr(GError) error = NULL;
 	g_autofree gchar *fn = NULL;
-	gchar *argv[3] = { "replace", "test", NULL };
+	const gchar *argv[3] = { "replace", "test", NULL };
 
 	fn = fu_test_get_filename (TESTDATADIR, "spawn.sh");
 	g_assert (fn != NULL);
 	argv[0] = fn;
-	ret = fu_common_spawn_sync ((const gchar * const *) argv,
+	ret = fu_common_spawn_sync (argv,
 				    fu_test_stdout_cb, &lines, NULL, &error);
 	g_assert_no_error (error);
 	g_assert (ret);


### PR DESCRIPTION
Many unused variables and const-correctness warnings.
There are some more serious/complicated issues that I'm not sure what is the correct way to fix, so adding them as issues to discuss.