### PR TITLE
libdfu: Fix an incomplete cipher when using XTEA on data not in 4 byt…

### DIFF
--- a/libdfu/dfu-cipher-xtea.c
+++ b/libdfu/dfu-cipher-xtea.c
@@ -98,16 +98,42 @@ dfu_cipher_decrypt_xtea (const gchar *key,
 			 GError **error)
 {
 	guint32 sum;
-	guint32 *tmp = (guint32 *) data;
 	guint32 v0;
 	guint32 v1;
 	guint8 i;
 	guint j;
+	guint32 chunks = length / 4;
 	guint32 keys[4];
+	g_autofree guint32 *tmp = NULL;
 
+	/* sanity check */
+	if (length < 8) {
+		g_set_error (error,
+			     DFU_ERROR,
+			     DFU_ERROR_NOT_SUPPORTED,
+			     "8 bytes data required, got %" G_GUINT32_FORMAT,
+			     length);
+		return FALSE;
+	}
+	if (length % 4 != 0) {
+		g_set_error (error,
+			     DFU_ERROR,
+			     DFU_ERROR_NOT_SUPPORTED,
+			     "Multiples of 4 bytes required, got %" G_GUINT32_FORMAT,
+			     length);
+		return FALSE;
+	}
+
+	/* parse key */
 	if (!dfu_tool_parse_xtea_key (key, keys, error))
 		return FALSE;
-	for (j = 0; j < length / 4; j += 2) {
+
+	/* allocate a buffer that can be addressed in 4-byte chunks */
+	tmp = g_new0 (guint32, chunks);
+	memcpy (tmp, data, length);
+
+	/* process buffer using XTEA keys */
+	for (j = 0; j < chunks; j += 2) {
 		v0 = tmp[j];
 		v1 = tmp[j+1];
 		sum = XTEA_DELTA * XTEA_NUM_ROUNDS;
@@ -119,6 +145,9 @@ dfu_cipher_decrypt_xtea (const gchar *key,
 		tmp[j] = v0;
 		tmp[j+1] = v1;
 	}
+
+	/* copy the temp buffer back to data */
+	memcpy (data, tmp, length);
 	return TRUE;
 }
 
@@ -140,16 +169,42 @@ dfu_cipher_encrypt_xtea (const gchar *key,
 			 GError **error)
 {
 	guint32 sum;
-	guint32 *tmp = (guint32 *) data;
 	guint32 v0;
 	guint32 v1;
 	guint8 i;
 	guint j;
+	guint32 chunks = length / 4;
 	guint32 keys[4];
+	g_autofree guint32 *tmp = NULL;
 
+	/* sanity check */
+	if (length < 8) {
+		g_set_error (error,
+			     DFU_ERROR,
+			     DFU_ERROR_NOT_SUPPORTED,
+			     "8 bytes data required, got %" G_GUINT32_FORMAT,
+			     length);
+		return FALSE;
+	}
+	if (length % 4 != 0) {
+		g_set_error (error,
+			     DFU_ERROR,
+			     DFU_ERROR_NOT_SUPPORTED,
+			     "Multiples of 4 bytes required, got %" G_GUINT32_FORMAT,
+			     length);
+		return FALSE;
+	}
+
+	/* parse key */
 	if (!dfu_tool_parse_xtea_key (key, keys, error))
 		return FALSE;
-	for (j = 0; j < length / 4; j += 2) {
+
+	/* allocate a buffer that can be addressed in 4-byte chunks */
+	tmp = g_new0 (guint32, chunks);
+	memcpy (tmp, data, length);
+
+	/* process buffer using XTEA keys */
+	for (j = 0; j < chunks; j += 2) {
 		sum = 0;
 		v0 = tmp[j];
 		v1 = tmp[j+1];
@@ -161,5 +216,8 @@ dfu_cipher_encrypt_xtea (const gchar *key,
 		tmp[j] = v0;
 		tmp[j+1] = v1;
 	}
+
+	/* copy the temp buffer back to data */
+	memcpy (data, tmp, length);
 	return TRUE;
 }

--- a/libdfu/dfu-self-test.c
+++ b/libdfu/dfu-self-test.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <fnmatch.h>
 
+#include "dfu-cipher-xtea.h"
 #include "dfu-common.h"
 #include "dfu-context.h"
 #include "dfu-device.h"
@@ -102,6 +103,40 @@ _g_bytes_compare_verbose (GBytes *bytes1, GBytes *bytes2)
 		}
 	}
 	return NULL;
+}
+
+static void
+dfu_cipher_xtea_func (void)
+{
+	gboolean ret;
+	guint8 buf[] = { 'H', 'i', 'y', 'a', 'D', 'a', 'v', 'e' };
+	g_autoptr(GError) error = NULL;
+
+	ret = dfu_cipher_encrypt_xtea ("test", buf, sizeof(buf), &error);
+	g_assert_no_error (error);
+	g_assert (ret);
+
+	g_assert_cmpint (buf[0], ==, 128);
+	g_assert_cmpint (buf[1], ==, 220);
+	g_assert_cmpint (buf[2], ==, 23);
+	g_assert_cmpint (buf[3], ==, 55);
+	g_assert_cmpint (buf[4], ==, 201);
+	g_assert_cmpint (buf[5], ==, 207);
+	g_assert_cmpint (buf[6], ==, 182);
+	g_assert_cmpint (buf[7], ==, 177);
+
+	ret = dfu_cipher_decrypt_xtea ("test", buf, sizeof(buf), &error);
+	g_assert_no_error (error);
+	g_assert (ret);
+
+	g_assert_cmpint (buf[0], ==, 'H');
+	g_assert_cmpint (buf[1], ==, 'i');
+	g_assert_cmpint (buf[2], ==, 'y');
+	g_assert_cmpint (buf[3], ==, 'a');
+	g_assert_cmpint (buf[4], ==, 'D');
+	g_assert_cmpint (buf[5], ==, 'a');
+	g_assert_cmpint (buf[6], ==, 'v');
+	g_assert_cmpint (buf[7], ==, 'e');
 }
 
 static void
@@ -974,6 +1009,7 @@ main (int argc, char **argv)
 	g_test_add_func ("/libdfu/patch{apply}", dfu_patch_apply_func);
 	g_test_add_func ("/libdfu/enums", dfu_enums_func);
 	g_test_add_func ("/libdfu/target(DfuSe}", dfu_target_dfuse_func);
+	g_test_add_func ("/libdfu/cipher{xtea}", dfu_cipher_xtea_func);
 	g_test_add_func ("/libdfu/firmware{raw}", dfu_firmware_raw_func);
 	g_test_add_func ("/libdfu/firmware{dfu}", dfu_firmware_dfu_func);
 	g_test_add_func ("/libdfu/firmware{dfuse}", dfu_firmware_dfuse_func);


### PR DESCRIPTION
…e chunks

Originally found as unaligned data by Yehezkel Bernat, many thanks.

Fixes: https://github.com/hughsie/fwupd/issues/208