### PR TITLE
thunderbolt: refer to the wiki on image validation failure

### DIFF
--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -776,7 +776,8 @@ fu_plugin_update (FuPlugin *plugin,
 			g_set_error (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_INVALID_FILE,
-				     "%s",
+				     "%s. "
+				     "See https://github.com/hughsie/fwupd/wiki/Thunderbolt:-Validation-failed-or-unknown-device for more information.",
 				     msg);
 			return FALSE;
 		}


### PR DESCRIPTION
Following @superm1 steps [here](https://github.com/hughsie/fwupd/commit/1790115c933f57670ec5250ce6d4d5faa0987293), I added a similar message for Thudnerbolt.
A review also for [the wiki page itself](https://github.com/hughsie/fwupd/wiki/Thunderbolt:-Validation-failed-or-unknown-device) would be much appreciated.