### PR TITLE
Test case for image validation

### DIFF
--- a/plugins/thunderbolt/fu-thunderbolt-image.c
+++ b/plugins/thunderbolt/fu-thunderbolt-image.c
@@ -94,7 +94,7 @@ read_location (const FuThunderboltFwLocation  *location,
 		g_set_error (error,
 			     FWUPD_ERROR, FWUPD_ERROR_READ,
 			     "Given location is outside of the given FW (%s)",
-			     location->description);
+			     location->description ? location->description : "N/A");
 		return NULL;
 	}
 


### PR DESCRIPTION
Add a small test case. Uncovered already two tiny glitches:
```
FuPluginThunderbolt-DEBUG: expected image validation error [ctl, ctl]: Given location is outside of the given FW ((null))
FuPluginThunderbolt-DEBUG: expected image validation error [dev, dev]: The FW image file is for a host controller
FuPluginThunderbolt-DEBUG: expected image validation error [bad, dev]: The FW image file is for a host controller
FuPluginThunderbolt-DEBUG: expected image validation error [ctl, bad]: Given location is outside of the given FW ((null))
FuPluginThunderbolt-DEBUG: expected image validation error [bad, bad]: Given location is outside of the given FW ((null))
```
NB: the `(null)` and the "for a host controller". Added two simple fixes for those. Now they read:

```
FuPluginThunderbolt-DEBUG: expected image validation error [ctl, ctl]: Given location is outside of the given FW (N/A)
FuPluginThunderbolt-DEBUG: expected image validation error [dev, dev]: The FW image file is for a device controller
FuPluginThunderbolt-DEBUG: expected image validation error [bad, dev]: The FW image file is for a device controller
FuPluginThunderbolt-DEBUG: expected image validation error [ctl, bad]: Given location is outside of the given FW (N/A)
FuPluginThunderbolt-DEBUG: expected image validation error [bad, bad]: Given location is outside of the given FW (N/A)
```
Also, three cases we return `FWUPD_ERROR_READ`, which I am not sure is better then just `FWUPD_ERROR_INVALID_FILE`. If we pass host controller image for the firmware we also don't get the "The FW image file is for a host controller" error but the "Given location is outside of the given FW". Same for the case when we pass invalid data. Maybe we should prefix those, a la "Invalid firmware file: Given location is outside .."?
