### PR TITLE
usb: Disable the fallback USB plugin

### DIFF
--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -20,6 +20,7 @@ build() {
         --localstatedir=/var \
         --libexecdir=/usr/lib \
         --buildtype=plain \
+        -Denable-usb-fallback=true \
         ../build
 
     ninja -v -C ../build

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -248,7 +248,6 @@ mkdir -p --mode=0700 $RPM_BUILD_ROOT%{_localstatedir}/lib/fwupd/gnupg
 %endif
 %{_libdir}/fwupd-plugins-2/libfu_plugin_unifying.so
 %{_libdir}/fwupd-plugins-2/libfu_plugin_upower.so
-%{_libdir}/fwupd-plugins-2/libfu_plugin_usb.so
 %ghost %{_localstatedir}/lib/fwupd/gnupg
 
 %files devel

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,6 +5,7 @@ option('enable-tests', type : 'boolean', value : true, description : 'enable tes
 option('enable-lvfs', type : 'boolean', value : true, description : 'enable LVFS remotes')
 option('enable-colorhug', type : 'boolean', value : true, description : 'enable ColorHug support')
 option('enable-libelf', type : 'boolean', value : true, description : 'enable libelf support')
+option('enable-usb-fallback', type : 'boolean', value : false, description : 'enable USB fallback support')
 option('enable-uefi', type : 'boolean', value : true, description : 'enable UEFI support')
 option('enable-uefi-labels', type : 'boolean', value : true, description : 'enable UEFI labels support')
 option('enable-dell', type : 'boolean', value : true, description : 'enable Dell-specific support')

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -7,7 +7,6 @@ subdir('test')
 subdir('udev')
 subdir('unifying')
 subdir('upower')
-subdir('usb')
 
 if get_option('enable-amt')
 subdir('amt')
@@ -31,5 +30,9 @@ endif
 
 if get_option('enable-uefi')
 subdir('uefi')
+endif
+
+if get_option('enable-usb-fallback')
+subdir('usb')
 endif
 


### PR DESCRIPTION
It's not super useful. If this has no bad effects for a couple of releases we
can either remove it completely or move the functionality to the test plugin.