### PR TITLE
Add FuDeviceLocker to simplify device open/close lifecycles

### DIFF
--- a/plugins/dfu/dfu-device.h
+++ b/plugins/dfu/dfu-device.h
@@ -126,6 +126,8 @@ struct _DfuDeviceClass
 
 DfuDevice	*dfu_device_new				(GUsbDevice	*dev);
 gboolean	 dfu_device_open			(DfuDevice	*device,
+							 GError		**error);
+gboolean	 dfu_device_open_full			(DfuDevice	*device,
 							 DfuDeviceOpenFlags flags,
 							 GCancellable	*cancellable,
 							 GError		**error);
@@ -183,6 +185,7 @@ guint16		 dfu_device_get_version			(DfuDevice	*device);
 guint		 dfu_device_get_timeout			(DfuDevice	*device);
 gboolean	 dfu_device_can_upload			(DfuDevice	*device);
 gboolean	 dfu_device_can_download		(DfuDevice	*device);
+gboolean	 dfu_device_is_open			(DfuDevice	*device);
 
 gboolean	 dfu_device_has_attribute		(DfuDevice	*device,
 							 DfuDeviceAttributes attribute);

--- a/plugins/dfu/dfu-self-test.c
+++ b/plugins/dfu/dfu-self-test.c
@@ -534,7 +534,7 @@ dfu_device_func (void)
 	g_assert (target1 != NULL);
 
 	/* ensure open */
-	ret = dfu_device_open (device, DFU_DEVICE_OPEN_FLAG_NONE, NULL, &error);
+	ret = dfu_device_open (device, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 
@@ -574,7 +574,7 @@ dfu_colorhug_plus_func (void)
 						     0x1002,
 						     NULL);
 	if (device2 != NULL) {
-		ret = dfu_device_open (device2, DFU_DEVICE_OPEN_FLAG_NONE, NULL, &error);
+		ret = dfu_device_open (device2, &error);
 		g_assert_no_error (error);
 		g_assert (ret);
 		ret = dfu_device_detach (device2, NULL, &error);
@@ -607,7 +607,7 @@ dfu_colorhug_plus_func (void)
 	}
 
 	/* open it */
-	ret = dfu_device_open (device, DFU_DEVICE_OPEN_FLAG_NONE, NULL, &error);
+	ret = dfu_device_open (device, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 

--- a/plugins/dfu/meson.build
+++ b/plugins/dfu/meson.build
@@ -29,6 +29,10 @@ dfu = static_library(
   c_args : cargs,
   include_directories : [
     include_directories('../..'),
+    include_directories('../../src'),
+  ],
+  link_with : [
+    libfwupdprivate,
   ],
 )
 
@@ -61,6 +65,7 @@ executable(
   include_directories : [
     include_directories('..'),
     include_directories('../..'),
+    include_directories('../../src'),
   ],
   dependencies : [
     appstream_glib,
@@ -68,7 +73,10 @@ executable(
     libm,
     gusb,
   ],
-  link_with : dfu,
+  link_with : [
+    dfu,
+    libfwupdprivate,
+  ],
   c_args : cargs,
   install : true,
   install_dir : get_option('bindir')

--- a/plugins/steelseries/fu-plugin-steelseries.c
+++ b/plugins/steelseries/fu-plugin-steelseries.c
@@ -44,6 +44,7 @@ fu_plugin_steelseries_device_added_cb (GUsbContext *ctx,
 	g_autoptr(AsProfile) profile = as_profile_new ();
 	g_autoptr(AsProfileTask) ptask = NULL;
 	g_autoptr(FuDevice) dev = NULL;
+	g_autoptr(FuDeviceLocker) locker = NULL;
 	g_autoptr(GError) error_local = NULL;
 
 	/* not the right kind of device */
@@ -67,7 +68,8 @@ fu_plugin_steelseries_device_added_cb (GUsbContext *ctx,
 	}
 
 	/* get exclusive access */
-	if (!g_usb_device_open (usb_device, &error_local)) {
+	locker = fu_device_locker_new (usb_device, &error_local);
+	if (locker == NULL) {
 		g_warning ("failed to open device: %s", error_local->message);
 		return;
 	}
@@ -75,7 +77,6 @@ fu_plugin_steelseries_device_added_cb (GUsbContext *ctx,
 					   G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
 					   &error_local)) {
 		g_warning ("failed to claim interface: %s", error_local->message);
-		g_usb_device_close (usb_device, NULL);
 		return;
 	}
 
@@ -97,7 +98,6 @@ fu_plugin_steelseries_device_added_cb (GUsbContext *ctx,
 					     &error_local);
 	if (!ret) {
 		g_debug ("failed to do control transfer: %s", error_local->message);
-		g_usb_device_close (usb_device, NULL);
 		return;
 	}
 	if (actual_len != 32) {
@@ -114,12 +114,10 @@ fu_plugin_steelseries_device_added_cb (GUsbContext *ctx,
 					       &error_local);
 	if (!ret) {
 		g_debug ("failed to do EP1 transfer: %s", error_local->message);
-		g_usb_device_close (usb_device, NULL);
 		return;
 	}
 	if (actual_len != 32) {
 		g_warning ("only read %" G_GSIZE_FORMAT "bytes", actual_len);
-		g_usb_device_close (usb_device, NULL);
 		return;
 	}
 
@@ -142,11 +140,8 @@ fu_plugin_steelseries_device_added_cb (GUsbContext *ctx,
 					     G_USB_DEVICE_CLAIM_INTERFACE_BIND_KERNEL_DRIVER,
 					     &error_local)) {
 		g_warning ("failed to release interface: %s", error_local->message);
-		g_usb_device_close (usb_device, NULL);
 		return;
 	}
-	if (!g_usb_device_close (usb_device, &error_local))
-		g_debug ("Failed to close: %s", error_local->message);
 	fu_plugin_device_add (plugin, dev);
 	fu_plugin_cache_add (plugin, platform_id, dev);
 }

--- a/plugins/unifying/meson.build
+++ b/plugins/unifying/meson.build
@@ -52,6 +52,7 @@ executable(
   ],
   link_with : [
     fwupd,
+    libfwupdprivate,
   ],
   c_args : cargs,
 )

--- a/src/fu-device-locker.c
+++ b/src/fu-device-locker.c
@@ -1,0 +1,151 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include "config.h"
+
+#include <gio/gio.h>
+#include <gusb.h>
+
+#include "fu-device-locker.h"
+
+struct _FuDeviceLocker {
+	GObject			 parent_instance;
+	GObject			*device;
+	gboolean		 device_open;
+	FuDeviceLockerFunc	 open_func;
+	FuDeviceLockerFunc	 close_func;
+};
+
+G_DEFINE_TYPE (FuDeviceLocker, fu_device_locker, G_TYPE_OBJECT)
+
+static void
+fu_device_locker_finalize (GObject *obj)
+{
+	FuDeviceLocker *self = FU_DEVICE_LOCKER (obj);
+
+	/* close device */
+	if (self->device_open) {
+		g_autoptr(GError) error = NULL;
+		if (!self->close_func (self->device, &error))
+			g_warning ("failed to close device: %s", error->message);
+	}
+
+	g_object_unref (self->device);
+	G_OBJECT_CLASS (fu_device_locker_parent_class)->finalize (obj);
+}
+
+static void
+fu_device_locker_class_init (FuDeviceLockerClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+	object_class->finalize = fu_device_locker_finalize;
+}
+
+static void
+fu_device_locker_init (FuDeviceLocker *self)
+{
+}
+
+/**
+ * fu_device_locker_new:
+ * @device: A #GObject
+ * @error: A #GError, or %NULL
+ *
+ * Opens the device for use. When the #FuDeviceLocker is deallocated the device
+ * will be closed and any error will just be directed to the console.
+ * This object is typically called using g_autoptr() but the device can also be
+ * manually closed using g_clear_object().
+ *
+ * The functions used for opening and closing the device are set automatically.
+ * If the @device is not a type or supertype of @GUsbDevice then this function
+ * will not work. For custom objects please use fu_device_locker_new_full().
+ *
+ * NOTE: If the @open_func failed then the @close_func will not be called.
+ *
+ * Think of this object as the device ownership.
+ *
+ * Returns: a #FuDeviceLocker, or %NULL if the @open_func failed.
+ **/
+FuDeviceLocker *
+fu_device_locker_new (gpointer device, GError **error)
+{
+	g_return_val_if_fail (device != NULL, NULL);
+	g_return_val_if_fail (error != NULL, NULL);
+
+	/* GUsbDevice */
+	if (G_USB_IS_DEVICE (device)) {
+		return fu_device_locker_new_full (device,
+						  (FuDeviceLockerFunc) g_usb_device_open,
+						  (FuDeviceLockerFunc) g_usb_device_close,
+						  error);
+	}
+	g_set_error_literal (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_NOT_SUPPORTED,
+			     "device object type not supported");
+	return NULL;
+}
+
+/**
+ * fu_device_locker_new_full:
+ * @device: A #GObject
+ * @open_func: A function to open the device
+ * @close_func: A function to close the device
+ * @error: A #GError, or %NULL
+ *
+ * Opens the device for use. When the #FuDeviceLocker is deallocated the device
+ * will be closed and any error will just be directed to the console.
+ * This object is typically called using g_autoptr() but the device can also be
+ * manually closed using g_clear_object().
+ *
+ * NOTE: If the @open_func failed then the @close_func will not be called.
+ *
+ * Think of this object as the device ownership.
+ *
+ * Returns: a #FuDeviceLocker, or %NULL if the @open_func failed.
+ **/
+FuDeviceLocker *
+fu_device_locker_new_full (gpointer device,
+		      FuDeviceLockerFunc open_func,
+		      FuDeviceLockerFunc close_func,
+		      GError **error)
+{
+	g_autoptr(FuDeviceLocker) self = NULL;
+
+	g_return_val_if_fail (device != NULL, NULL);
+	g_return_val_if_fail (open_func != NULL, NULL);
+	g_return_val_if_fail (close_func != NULL, NULL);
+	g_return_val_if_fail (error != NULL, NULL);
+
+	/* create object */
+	self = g_object_new (FU_TYPE_DEVICE_LOCKER, NULL);
+	self->device = g_object_ref (device);
+	self->open_func = open_func;
+	self->close_func = close_func;
+
+	/* open device */
+	if (!self->open_func (device, error))
+		return NULL;
+
+	/* success */
+	self->device_open = TRUE;
+	return g_steal_pointer (&self);
+}

--- a/src/fu-device-locker.h
+++ b/src/fu-device-locker.h
@@ -1,0 +1,45 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef __FU_DEVICE_LOCKER_H
+#define __FU_DEVICE_LOCKER_H
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define FU_TYPE_DEVICE_LOCKER (fu_device_locker_get_type ())
+
+G_DECLARE_FINAL_TYPE (FuDeviceLocker, fu_device_locker, FU, DEVICE_LOCKER, GObject)
+
+typedef gboolean (*FuDeviceLockerFunc)		(GObject		*device,
+						GError			**error);
+
+FuDeviceLocker	*fu_device_locker_new		(gpointer		 device,
+						 GError			**error);
+FuDeviceLocker	*fu_device_locker_new_full	(gpointer		 device,
+						 FuDeviceLockerFunc	 open_func,
+						 FuDeviceLockerFunc	 close_func,
+						 GError			**error);
+
+G_END_DECLS
+
+#endif /* __FU_DEVICE_LOCKER_H */

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2563,10 +2563,6 @@ fu_engine_load (FuEngine *self, GError **error)
 		g_prefix_error (error, "Failed to get USB context: ");
 		return FALSE;
 	}
-#if G_USB_CHECK_VERSION(0,2,11)
-	g_usb_context_set_flags (self->usb_ctx,
-				 G_USB_CONTEXT_FLAGS_AUTO_OPEN_DEVICES);
-#endif
 
 	/* load SMBIOS and the hwids */
 	if (!fu_smbios_setup (self->smbios, NULL, &error_smbios))

--- a/src/fu-plugin.h
+++ b/src/fu-plugin.h
@@ -29,6 +29,7 @@
 
 #include "fu-common.h"
 #include "fu-device.h"
+#include "fu-device-locker.h"
 #include "fu-hwids.h"
 
 G_BEGIN_DECLS

--- a/src/meson.build
+++ b/src/meson.build
@@ -23,6 +23,7 @@ libfwupdprivate = static_library(
   sources : [
     'fu-common.c',
     'fu-device.c',
+    'fu-device-locker.c',
     'fu-hwids.c',
     'fu-pending.c',
     'fu-plugin.c',
@@ -105,6 +106,7 @@ executable(
     'fu-hwids.c',
     'fu-debug.c',
     'fu-device.c',
+    'fu-device-locker.c',
     'fu-keyring.c',
     'fu-pending.c',
     'fu-plugin.c',
@@ -153,6 +155,7 @@ if get_option('enable-tests')
       'fu-keyring.c',
       'fu-hwids.c',
       'fu-device.c',
+      'fu-device-locker.c',
       'fu-pending.c',
       'fu-keyring.c',
       'fu-keyring-result.c',


### PR DESCRIPTION
We can use the power of g_autoptr() to automatically close devices that have
gone out of scope. This allows us to drop the AUTO_OPEN_DEVICES flag which was
making us look bad in powertop.

This is WIP, but I figured it would be good to get some early review.