### PR TITLE
Enable a clang build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,16 @@ env:
   - OS=Fedora
   - OS=Debian
   - OS=Arch
+  - OS=Debian-clang
 
 install:
   - if [[ "$OS" == "Fedora" ]]; then docker build -t fwupd-fedora -f contrib/ci/Dockerfile-fedora .; fi
   - if [[ "$OS" == "Debian" ]]; then docker build -t fwupd-debian -f contrib/ci/Dockerfile-debian .; fi
   - if [[ "$OS" == "Arch" ]];   then docker build -t fwupd-arch -f contrib/ci/Dockerfile-arch .; fi
+  - if [[ "$OS" == "Debian-clang" ]]; then docker build -t fwupd-debian -f contrib/ci/Dockerfile-debian .; fi
 
 script:
   - if [[ "$OS" == "Fedora" ]]; then docker run -e CI=true -t -v `pwd`:/build fwupd-fedora ./contrib/ci/build_and_install_rpms.sh; fi
   - if [[ "$OS" == "Debian" ]]; then docker run -e CI=true -t -v `pwd`:/build fwupd-debian ./contrib/ci/build_and_install_debs.sh; fi
   - if [[ "$OS" == "Arch" ]];   then docker run -e CI=true -t -v `pwd`:/build fwupd-arch ./contrib/ci/build_and_install_pkgs.sh; fi
+  - if [[ "$OS" == "Debian-clang" ]]; then docker run -e CC=clang -e CI=true -t -v `pwd`:/build fwupd-debian ./contrib/ci/build_and_install_debs.sh; fi

--- a/contrib/ci/Dockerfile-debian
+++ b/contrib/ci/Dockerfile-debian
@@ -2,6 +2,7 @@ FROM debian:unstable
 
 RUN apt-get update -qq
 RUN apt-get install -yq --no-install-recommends \
+	clang \
 	debhelper \
 	devscripts \
 	fakeroot \

--- a/contrib/ci/README.md
+++ b/contrib/ci/README.md
@@ -1,6 +1,6 @@
 Continuous Integration
 ======================
-Continuous integration for fwupd is provided by (Travis CI)[www.travis-ci.org].
+Continuous integration for fwupd is provided by [Travis CI](https://travis-ci.org/hughsie/fwupd).
 
 By using Travis CI, builds are exercised across a variety of environments attempting to maximize code coverage.
 For every commit or pull request 4 builds are performed:

--- a/contrib/ci/README.md
+++ b/contrib/ci/README.md
@@ -1,0 +1,34 @@
+Continuous Integration
+======================
+Continuous integration for fwupd is provided by (Travis CI)[www.travis-ci.org].
+
+By using Travis CI, builds are exercised across a variety of environments attempting to maximize code coverage.
+For every commit or pull request 3 builds are performed:
+
+Fedora
+------
+
+* A fully packaged RPM build with all plugins enabled
+* Tests with -Werror enabled
+* Tests with the built in local test suite for all plugins.
+* All packages are installed
+* An installed testing run with the "test" plugin and pulling from LVFS.
+
+Debian unstable
+------
+
+* A fully packaged DEB build with all plugins enabled
+* Tests with -Werror enabled
+* Tests with the built in local test suite for all plugins.
+* All packages are installed
+* An installed testing run with the "test" plugin and pulling from LVFS.
+* All packages are removed
+
+Arch Linux
+------
+
+* A fully packaged pkg build with all plugins enabled
+* Tests with -Werror enabled
+* Compile with the deprecated USB plugin enabled
+* Tests with the built in local test suite for all plugins.
+* All packages are installed

--- a/contrib/ci/README.md
+++ b/contrib/ci/README.md
@@ -3,32 +3,47 @@ Continuous Integration
 Continuous integration for fwupd is provided by (Travis CI)[www.travis-ci.org].
 
 By using Travis CI, builds are exercised across a variety of environments attempting to maximize code coverage.
-For every commit or pull request 3 builds are performed:
+For every commit or pull request 4 builds are performed:
 
 Fedora
 ------
 
-* A fully packaged RPM build with all plugins enabled
+* A fully packaged RPM build with all plugins enabled\
+* Compiled under gcc
 * Tests with -Werror enabled
 * Tests with the built in local test suite for all plugins.
 * All packages are installed
 * An installed testing run with the "test" plugin and pulling from LVFS.
 
-Debian unstable
+Debian unstable (gcc)
 ------
 
 * A fully packaged DEB build with all plugins enabled
+* Compiled under gcc
 * Tests with -Werror enabled
 * Tests with the built in local test suite for all plugins.
 * All packages are installed
 * An installed testing run with the "test" plugin and pulling from LVFS.
 * All packages are removed
 
-Arch Linux
+Debian unstable (clang)
 ------
 
+* A fully packaged DEB build with all plugins enabled
+* Compiled under clang
+* Tests without -Werror enabled
+* Tests with the built in local test suite for all plugins.
+* All packages are installed
+* An installed testing run with the "test" plugin and pulling from LVFS.
+* All packages are removed
+
+Arch Linux
+----------
+
 * A fully packaged pkg build with all plugins enabled
+* Compiled under gcc
 * Tests with -Werror enabled
 * Compile with the deprecated USB plugin enabled
 * Tests with the built in local test suite for all plugins.
 * All packages are installed
+

--- a/contrib/ci/README.md
+++ b/contrib/ci/README.md
@@ -8,7 +8,7 @@ For every commit or pull request 4 builds are performed:
 Fedora
 ------
 
-* A fully packaged RPM build with all plugins enabled\
+* A fully packaged RPM build with all plugins enabled
 * Compiled under gcc
 * Tests with -Werror enabled
 * Tests with the built in local test suite for all plugins.

--- a/contrib/ci/build_and_install_debs.sh
+++ b/contrib/ci/build_and_install_debs.sh
@@ -31,7 +31,7 @@ lintian ../*changes \
 	--allow-root
 
 #test the packages install
-dpkg -i `ls ../*.deb | grep -v fwupd-tests`
+dpkg -i `ls ../*.deb | grep -v 'fwupd-tests\|dbgsym'`
 
 # run the installed tests
 if [ "$CI" = "true" ]; then
@@ -44,7 +44,5 @@ fi
 #test the packages remove
 apt purge -y fwupd \
 	     fwupd-doc \
-	     fwupd-dbgsym \
 	     libfwupd1 \
-	     libfwupd1-dbgsym \
 	     libfwupd-dev

--- a/contrib/ci/build_and_install_debs.sh
+++ b/contrib/ci/build_and_install_debs.sh
@@ -15,7 +15,7 @@ pushd build
 mv contrib/debian .
 sed s/quilt/native/ debian/source/format -i
 EDITOR=/bin/true dch --create --package fwupd -v $VERSION "CI Build"
-debuild --no-lintian --preserve-envvar CI
+debuild --no-lintian --preserve-envvar CI --preserve-envvar CC
 
 #check lintian output
 #suppress tags that are side effects of building in docker this way

--- a/meson.build
+++ b/meson.build
@@ -117,8 +117,8 @@ add_global_link_arguments(
   language: 'c'
 )
 
-# ONLY for CI, do not enable this for distro builds
-if get_option('enable-werror')
+# ONLY for CI and only when using gcc, do not enable this for distro builds
+if get_option('enable-werror') and meson.get_compiler('c').get_id() == 'gcc'
   add_project_arguments('-Werror', language : 'c')
   add_project_arguments('-Wno-error=cpp', language : 'c')
 endif


### PR DESCRIPTION
Enable a clang build in Debian.

I'm also wanting to do a cross compile using clang, but having various challenges with that.  I'll submit that separately if I get it working.