### PR TITLE
Allow plugins to depend on each other

### DIFF
--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -30,6 +30,12 @@
 #include "fu-plugin.h"
 #include "fu-plugin-vfuncs.h"
 
+void
+fu_plugin_init (FuPlugin *plugin)
+{
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_RUN_AFTER, "upower");
+}
+
 static fwup_resource *
 fu_plugin_uefi_find (fwup_resource_iter *iter, const gchar *guid_str, GError **error)
 {

--- a/src/fu-plugin-private.h
+++ b/src/fu-plugin-private.h
@@ -36,6 +36,11 @@ void		 fu_plugin_set_hwids			(FuPlugin	*plugin,
 							 FuHwids	*hwids);
 void		 fu_plugin_set_smbios			(FuPlugin	*plugin,
 							 FuSmbios	*smbios);
+guint		 fu_plugin_get_order			(FuPlugin	*plugin);
+void		 fu_plugin_set_order			(FuPlugin	*plugin,
+							 guint		 order);
+GPtrArray	*fu_plugin_get_rules			(FuPlugin	*plugin,
+							 FuPluginRule	 rule);
 gboolean	 fu_plugin_open				(FuPlugin	*plugin,
 							 const gchar	*filename,
 							 GError		**error);

--- a/src/fu-plugin.h
+++ b/src/fu-plugin.h
@@ -63,6 +63,22 @@ typedef enum {
 	FU_PLUGIN_VERIFY_FLAG_LAST
 } FuPluginVerifyFlags;
 
+/**
+ * FuPluginRule:
+ * @FU_PLUGIN_RULE_CONFLICTS:		The plugin conflicts with another
+ * @FU_PLUGIN_RULE_RUN_AFTER:		Order the plugin after another
+ * @FU_PLUGIN_RULE_RUN_BEFORE:		Order the plugin before another
+ *
+ * The rules used for ordering plugins.
+ * Plugins are expected to add rules in fu_plugin_initialize().
+ **/
+typedef enum {
+	FU_PLUGIN_RULE_CONFLICTS,
+	FU_PLUGIN_RULE_RUN_AFTER,
+	FU_PLUGIN_RULE_RUN_BEFORE,
+	FU_PLUGIN_RULE_LAST
+} FuPluginRule;
+
 typedef struct	FuPluginData	FuPluginData;
 
 /* for plugins to use */
@@ -106,6 +122,9 @@ const gchar	*fu_plugin_get_smbios_string		(FuPlugin	*plugin,
 							 guint8		 offset);
 GBytes		*fu_plugin_get_smbios_data		(FuPlugin	*plugin,
 							 guint8		 structure_type);
+void		 fu_plugin_add_rule			(FuPlugin	*plugin,
+							 FuPluginRule	 rule,
+							 const gchar	*name);
 
 G_END_DECLS
 


### PR DESCRIPTION
The only things that plugins can declare is that they should be run before,
after or never with regard to another plugin.