### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,39 @@
+To help us pinpoint your issue, please insert the output of the
+following commands when ran on the system with the issue:
+
+```shell
+$ fwupdgmr --version
+**INSERT OUTPUT HERE**
+```
+
+```shell
+$ fwupdmgr get-devices
+**INSERT OUTPUT HERE**
+```
+
+```shell
+$ efibootmgr -v
+**INSERT OUTPUT HERE**
+**This is only required if you use the UEFI plugin**
+```
+
+```shell
+$ efivar -l | grep fw
+**INSERT OUTPUT HERE**
+**This is only required if you use the UEFI plugin**
+```
+
+```shell
+$ tree /boot
+**INSERT OUTPUT HERE**
+**This is only required if you use the UEFI plugin**
+**We're looking for any `.cap` files and the location of `fwupx64.efi`**
+```
+
+Please answer the following questions:
+
+- Operating system and version:
+- How did you install fwupd (ex: `from source`, `pacman`, `apt-get`, etc):
+- Have you tried rebooting?
+- Are you using an NVMe disk?
+- Is secure boot enabled (only for the UEFI plugin)?


### PR DESCRIPTION
As requested by @superm1 in #255 I've created an issue template. I went that way instead of a wiki page because everyone has to see it when they enter an issue, but they can still decide to not use it if they're entering something other than an actual issue (ex: improvement, question, etc). It's just markdown anyway so it could be switched to a wiki page easily.

You can see what it looks like for users by trying to enter a new issue in my fork [here](https://github.com/FredDeschenes/fwupd/issues/new).