### PR TITLE
po/make-images: Drop unnecessary fontmap

### DIFF
--- a/po/make-images
+++ b/po/make-images
@@ -56,7 +56,6 @@ class Rasterizer:
         self.domain = "fwupd"
         self.font_face = "sans-serif"
         self.pattern = "{directory}/{language}/LC_IMAGES/fwupd-{width}-{height}.{suffix}"
-        self.fontmap = PangoCairo.font_map_get_default()
 
         gettext.textdomain(self.domain)
         gettext.bind_textdomain_codeset(self.domain, 'UTF8')


### PR DESCRIPTION
This was causing problems building on Jessie, and turns out to be unused
anyway:
   AttributeError: 'gi.repository.PangoCairo' object has no attribute 'font_map_get_default'

Signed-off-by: Philip Withnall <withnall@endlessm.com>