### PR TITLE
Swap out debian-clang for ubuntu-clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env:
   - OS=fedora
   - OS=debian
   - OS=arch
-  - OS=debian-clang
   - OS=debian-s390x
+  - OS=ubuntu-clang
 
 install:
   - ./contrib/ci/generate_dockerfile.py; docker build -t fwupd-$OS -f contrib/ci/Dockerfile .
@@ -18,6 +18,6 @@ install:
 script:
   - if [[ "$OS" == "fedora" ]]; then docker run -e CI=true -t -v `pwd`:/build fwupd-$OS ./contrib/ci/build_and_install_rpms.sh; fi
   - if [[ "$OS" == "debian" ]]; then docker run -e CI=true -t -v `pwd`:/build fwupd-$OS ./contrib/ci/build_and_install_debs.sh; fi
+  - if [[ "$OS" == "ubuntu-clang" ]]; then docker run -e CC=clang -e CI=true -t -v `pwd`:/build fwupd-$OS ./contrib/ci/build_and_install_debs.sh; fi
   - if [[ "$OS" == "arch" ]];   then docker run -e CI=true -t -v `pwd`:/build fwupd-$OS ./contrib/ci/build_and_install_pkgs.sh; fi
-  - if [[ "$OS" == "debian-clang" ]]; then docker run -e CC=clang -e CI=true -t -v `pwd`:/build fwupd-$OS ./contrib/ci/build_and_install_debs.sh; fi
   - if [[ "$OS" == "debian-s390x" ]]; then docker run -t -v `pwd`:/build fwupd-$OS ./contrib/ci/build_debian_s390x.sh; fi

--- a/contrib/ci/Dockerfile-ubuntu.in
+++ b/contrib/ci/Dockerfile-ubuntu.in
@@ -1,0 +1,5 @@
+FROM ubuntu:devel
+%%%ARCH_SPECIFIC_COMMAND%%%
+%%%INSTALL_DEPENDENCIES_COMMAND%%%
+RUN mkdir /build
+WORKDIR /build

--- a/contrib/ci/README.md
+++ b/contrib/ci/README.md
@@ -26,7 +26,7 @@ Debian unstable (gcc)
 * An installed testing run with the "test" plugin and pulling from LVFS.
 * All packages are removed
 
-Debian unstable (clang)
+Ubuntu devel release (clang)
 ------
 
 * A fully packaged DEB build with all plugins enabled

--- a/contrib/ci/dependencies.txt
+++ b/contrib/ci/dependencies.txt
@@ -1,4 +1,4 @@
-fedora,				arch,				debian,				debian-clang,			debian-s390x,
+fedora,				arch,				debian,				ubuntu-clang,			debian-s390x,
 ,				base-devel,			,				,				,
 adobe-source-han-sans-cn-fonts,	adobe-source-han-sans-cn-fonts,	,				,				,
 ,				,				,				,				binutils-multiarch

--- a/contrib/debian/fwupd.postinst
+++ b/contrib/debian/fwupd.postinst
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+#DEBHELPER#
+
+if dpkg-maintscript-helper supports rm_conffile 2>/dev/null; then
+	dpkg-maintscript-helper rm_conffile \
+		/etc/fwupd.conf 1.0.0~ -- "$@"
+fi

--- a/contrib/debian/fwupd.preinst
+++ b/contrib/debian/fwupd.preinst
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+#DEBHELPER#
+
+if dpkg-maintscript-helper supports rm_conffile 2>/dev/null; then
+	dpkg-maintscript-helper rm_conffile \
+		/etc/fwupd.conf 1.0.0~ -- "$@"
+fi


### PR DESCRIPTION
Thanks to @xnox confirming that the systemd postinst bug related to /etc/resolv.conf remaining immutable is fixed can turn on Ubuntu for CI instead of Debian on one of the jobs.

I was originally going to turn on a 6th job, but it seems that maximum number of parallel jobs for Travis is 5, so this increases build time. 