### PR TITLE
trivial: Use absolute-names in tar command for creating test data file

### DIFF
--- a/data/tests/builder/meson.build
+++ b/data/tests/builder/meson.build
@@ -8,7 +8,7 @@ if get_option('enable-tests')
     output : 'firmware.tar',
     command : [
       tar, '--xform', 's,.*/,,',
-           '--create', '--file', '@OUTPUT@', '@INPUT@',
+           '--absolute-names', '--create', '--file', '@OUTPUT@', '@INPUT@',
     ],
   )
 endif


### PR DESCRIPTION
Previous failure:
```
[1/182] /bin/tar --xform 's,.*/,,' --create --file data/tests/builder/firmware.tar ../fwupd-1.0.0/data/tests/builder/source.bin ../fwupd-1.0.0/data/tests/builder/startup.sh
FAILED: data/tests/builder/firmware.tar
/bin/tar --xform 's,.*/,,' --create --file data/tests/builder/firmware.tar ../fwupd-1.0.0/data/tests/builder/source.bin ../fwupd-1.0.0/data/tests/builder/startup.sh
/bin/tar: ../fwupd-1.0.0/data/tests/builder/source.bin: Member name contains '..'
/bin/tar: ../fwupd-1.0.0/data/tests/builder/startup.sh: Member name contains '..'
/bin/tar: Exiting with failure status due to previous errors
```