### PR TITLE
Various dell changes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -199,10 +199,13 @@ if get_option('enable-uefi')
 endif
 
 if get_option('enable-dell')
-  libsmbios_c = dependency('libsmbios_c', version : '>= 2.3.0')
+  libsmbios_c = dependency('libsmbios_c', required: false)
   efivar = dependency('efivar')
   fwup = dependency('fwup', version : '>= 5')
   conf.set('HAVE_DELL', '1')
+  if libsmbios_c.found() and libsmbios_c.version().version_compare('>=2.3.0')
+    conf.set('HAVE_LIBSMBIOS', '1')
+  endif
 endif
 
 if get_option('enable-synaptics')

--- a/plugins/dell/meson.build
+++ b/plugins/dell/meson.build
@@ -1,5 +1,10 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginDell"']
 
+smbios_deps = []
+if libsmbios_c.found() and libsmbios_c.version().version_compare('>=2.3.0')
+  smbios_deps += libsmbios_c
+endif
+
 shared_module('fu_plugin_dell',
   sources : [
     'fu-plugin-dell.c',
@@ -18,8 +23,9 @@ shared_module('fu_plugin_dell',
     ],
   dependencies : [
     plugin_deps,
+    gudev,
     efivar,
-    libsmbios_c,
+    smbios_deps,
     fwup,
   ],
 )
@@ -41,11 +47,12 @@ if get_option('enable-tests')
     ],
     dependencies : [
       plugin_deps,
+      gudev,
       efivar,
       fwup,
       sqlite,
       gudev,
-      libsmbios_c,
+      smbios_deps,
       valgrind,
     ],
     link_with : [

--- a/plugins/dell/wmi.h
+++ b/plugins/dell/wmi.h
@@ -1,0 +1,73 @@
+/*
+ *  User API methods for ACPI-WMI mapping driver
+ *
+ *  Copyright (C) 2017 Dell, Inc.
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License version 2 as
+ *  published by the Free Software Foundation.
+ */
+#ifndef _LINUX_WMI_H
+#define _LINUX_WMI_H
+
+#include <linux/ioctl.h>
+#include <linux/types.h>
+
+/* WMI bus will filter all WMI vendor driver requests through this IOC */
+#define WMI_IOC 'W'
+
+/* All ioctl requests through WMI should declare their size followed by
+ * relevant data objects
+ */
+struct wmi_ioctl_buffer {
+	__u64	length;
+	__u8	data[];
+};
+
+/* This structure may be modified by the firmware when we enter
+ * system management mode through SMM, hence the volatiles
+ */
+struct calling_interface_buffer {
+	__u16 class;
+	__u16 select;
+	__volatile__ __u32 input[4];
+	__volatile__ __u32 output[4];
+} __attribute__((packed));
+
+struct dell_wmi_extensions {
+	__u32 argattrib;
+	__u32 blength;
+	__u8 data[];
+} __attribute__((packed));
+
+struct dell_wmi_smbios_buffer {
+	__u64 length;
+	struct calling_interface_buffer std;
+	struct dell_wmi_extensions	ext;
+} __attribute__((packed));
+
+/* Whitelisted smbios class/select commands */
+#define CLASS_TOKEN_READ	0
+#define CLASS_TOKEN_WRITE	1
+#define SELECT_TOKEN_STD	0
+#define SELECT_TOKEN_BAT	1
+#define SELECT_TOKEN_AC		2
+#define CLASS_FLASH_INTERFACE	7
+#define SELECT_FLASH_INTERFACE	3
+#define CLASS_ADMIN_PROP	10
+#define SELECT_ADMIN_PROP	3
+#define CLASS_INFO		17
+#define SELECT_RFKILL		11
+#define SELECT_APP_REGISTRATION	3
+#define SELECT_DOCK		22
+
+/* whitelisted tokens */
+#define CAPSULE_EN_TOKEN	0x0461
+#define CAPSULE_DIS_TOKEN	0x0462
+#define WSMT_EN_TOKEN		0x04EC
+#define WSMT_DIS_TOKEN		0x04ED
+
+/* Dell SMBIOS calling IOCTL command used by dell-smbios-wmi */
+#define DELL_WMI_SMBIOS_CMD	_IOWR(WMI_IOC, 0, struct dell_wmi_smbios_buffer)
+
+#endif


### PR DESCRIPTION
This is a bit of a big series.  The first 3 commits I want to merge sooner, the 4th is for discussion.

The first 3 commits break up all of the compile time dependence on the dell plugin and synaptics plugins.  The dependency is now runtime and uses plugin metadata to communicate.

As for the 4th commit, there is result of some work i'm doing in the kernel space to offer an alternative API to userspace SMI access than dcdbas.
It's lead to heated discussion on LKML, but (hopefully) it's getting closer.  i'm up to v7 with it, but know there will be at least one more submission.  The relevant patch at the end of the series is here: https://patchwork.kernel.org/patch/10000023/

Now assuming that actually lands in the kernel this gives options on what to do in userspace.  Either (or both!):
1. Update libsmbios to be able to talk to optionally talk to the dell-smbios WMI character device.  This is advantageous in fwupd, fwupdate, and all other software talking to the BIOS won't need to change.

2. Update various projects to talk directly to this character device.  This makes libsmbios optional, and something that can be deprecated over time, and maybe even removed by 2.0.0?

libsmbios is an aging pile of code that needs an overhaul.  So I think that the second approach will lead to higher quality code, but the transition time between the two isn't really that pretty.  I've done what's needed for the second approach in this commit, and tested it working in a few configurations.

I've also done some work on making fwupdate work directly on this interface but it hasn't been updated or v7 yet (I think that was v2's interface).  I was hoping to get [feedback ](https://github.com/rhboot/fwupdate/pull/83)from @vathpela which route he prefers too, but nothing yet.