### PR TITLE
ci: Make use of arch-meson in PKGBUILD

### DIFF
--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -19,13 +19,7 @@ build() {
         export CI="-Denable-werror=true \
                    -Denable-usb-fallback=true"
     fi
-    meson --prefix=/usr \
-        --sysconfdir=/etc \
-        --localstatedir=/var \
-        --libexecdir=/usr/lib \
-        --buildtype=plain \
-        $CI \
-        ../build
+    arch-meson -D b_lto=false $CI ../build
 
     ninja -v -C ../build
 }


### PR DESCRIPTION
The helper specify `-D b_lto=true` though, so override that since it fails to build with it.