### PR TITLE
thunderbolt: move test for mock environment (Closes #280)

### DIFF
--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -902,6 +902,12 @@ test_set_up (ThunderboltTest *tt, gconstpointer params)
 		g_assert_nonnull (tt->tree);
 	}
 
+	if (!umockdev_in_mock_environment ()) {
+		g_warning ("Need to run within umockdev wrapper (umockdev-wrapper %s)!",
+			   program_invocation_short_name);
+		return;
+	}
+
 	if (flags & TEST_ATTACH_AND_COLDPLUG) {
 		g_assert_true (flags & TEST_INITIALIZE_TREE);
 
@@ -1263,11 +1269,6 @@ main (int argc, char **argv)
 	g_test_init (&argc, &argv, NULL);
 	g_log_set_fatal_mask (NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
 
-	if (!umockdev_in_mock_environment ()) {
-		g_warning ("Need to run within umockdev wrapper (umockdev-wrapper %s)!",
-			   program_invocation_short_name);
-		return EXIT_FAILURE;
-	}
 
 	g_test_add ("/thunderbolt/basic",
 		    ThunderboltTest,


### PR DESCRIPTION
umockdev 0.9.4 changed how to test for running in mock and this
causes the assumptions on mock testing at init to fail.

Move the test for this to after the environment has been set up.