### PR TITLE
There was a crash reported in the dell plugin recently

### DIFF
--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -438,9 +438,14 @@ fu_plugin_dell_device_added_cb (GUsbContext *ctx,
 			 dock_info->components[i].description,
 			 dock_info->components[i].fw_version);
 		query_str = g_strrstr (dock_info->components[i].description,
-				       "Query ") + 6;
-		if (!fu_plugin_dell_match_dock_component (query_str, &guid_raw,
-							    &component_name)) {
+				       "Query ");
+		if (query_str == NULL) {
+			g_debug ("Invalid dock component request");
+			return;
+		}
+		if (!fu_plugin_dell_match_dock_component (query_str + 6,
+							  &guid_raw,
+							  &component_name)) {
 			g_debug ("Unable to match dock component %s",
 				query_str);
 			return;

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -310,25 +310,8 @@ static gboolean
 fu_plugin_dell_capsule_supported (FuPlugin *plugin)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
-	gint uefi_supported;
 
-	if (data->smi_obj->fake_smbios)
-		return TRUE;
-
-	/* If ESRT is not turned on, fwupd will have already created an
-	 * unlock device (if compiled with support).
-	 *
-	 * Once unlocked, that will enable flashing capsules here too.
-	 *
-	 * that means we should only look for supported = 1
-	 */
-	uefi_supported = fwup_supported ();
-	if (uefi_supported != 1) {
-		g_debug ("UEFI capsule firmware updating not supported (%x)",
-			 (guint) uefi_supported);
-		return FALSE;
-	}
-	return TRUE;
+	return data->smi_obj->fake_smbios || data->capsule_supported;
 }
 
 static gboolean
@@ -1070,6 +1053,7 @@ fu_plugin_startup (FuPlugin *plugin, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
 	GUsbContext *usb_ctx = fu_plugin_get_usb_context (plugin);
+	gint uefi_supported;
 
 	if (data->smi_obj->fake_smbios) {
 		g_debug ("Called with fake SMBIOS implementation. "
@@ -1084,6 +1068,20 @@ fu_plugin_startup (FuPlugin *plugin, GError **error)
 			     FWUPD_ERROR_NOT_SUPPORTED,
 			     "Firmware updating not supported");
 		return FALSE;
+	}
+
+	/* If ESRT is not turned on, fwupd will have already created an
+	 * unlock device (if compiled with support).
+	 *
+	 * Once unlocked, that will enable flashing capsules here too.
+	 *
+	 * that means we should only look for supported = 1
+	 */
+	uefi_supported = fwup_supported ();
+	data->capsule_supported = (uefi_supported == 1);
+	if (!data->capsule_supported) {
+		g_debug ("UEFI capsule firmware updating not supported (%x)",
+			 (guint) uefi_supported);
 	}
 
 	if (usb_ctx != NULL) {

--- a/plugins/dell/fu-plugin-dell.h
+++ b/plugins/dell/fu-plugin-dell.h
@@ -31,6 +31,7 @@ struct FuPluginData {
 	guint16			fake_vid;
 	guint16			fake_pid;
 	gboolean		can_switch_modes;
+	gboolean		capsule_supported;
 };
 
 void


### PR DESCRIPTION
It's due to multiple uses of libsmbios in a single application (fwupd and libfwup both using it).  Adjust behavior to prevent this from happening.