### PR TITLE
Add fu_plugin_get_verbose() to enable per-plugin debugging

### DIFF
--- a/docs/libfwupd/libfwupd-docs.xml
+++ b/docs/libfwupd/libfwupd-docs.xml
@@ -401,6 +401,19 @@ fu_plugin_update_reload (FuPlugin *plugin, FuDevice *device, GError **error)
         </para>
       </section>
 
+      <section>
+        <title>Debugging a Plugin</title>
+        <para>
+          If the fwupd daemon is started with <code>--plugin-verbose=$plugin</code>
+          then the environment variable <code>FWUPD_$PLUGIN_VERBOSE</code> is
+          set process-wide.
+          This allows plugins to detect when they should output detailed debugging
+          information that would normally be too verbose to keep in the journal.
+          For example, using <code>--plugin-verbose=unifying</code> would set
+          <code>FWUPD_UNIFYING_VERBOSE=1</code>.
+        </para>
+      </section>
+
     </partintro>
   </reference>
 

--- a/plugins/dfu/dfu-target.c
+++ b/plugins/dfu/dfu-target.c
@@ -700,7 +700,7 @@ dfu_target_download_chunk (DfuTarget *target, guint16 index, GBytes *bytes,
 	gsize actual_length;
 
 	/* low level packet debugging */
-	if (g_getenv ("DFU_TRACE") != NULL) {
+	if (g_getenv ("FWUPD_DFU_VERBOSE") != NULL) {
 		gsize sz = 0;
 		const guint8 *data = g_bytes_get_data (bytes, &sz);
 		for (gsize i = 0; i < sz; i++)
@@ -793,7 +793,7 @@ dfu_target_upload_chunk (DfuTarget *target, guint16 index, gsize buf_sz,
 	}
 
 	/* low level packet debugging */
-	if (g_getenv ("DFU_TRACE") != NULL) {
+	if (g_getenv ("FWUPD_DFU_VERBOSE") != NULL) {
 		for (gsize i = 0; i < actual_length; i++)
 			g_print ("Message: r[%" G_GSIZE_FORMAT "] = 0x%02x\n", i, (guint) buf[i]);
 	}

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -184,7 +184,7 @@ fu_ebitdo_device_send (FuEbitdoDevice *device,
 	}
 
 	/* debug */
-	if (g_getenv ("FU_EBITDO_DEBUG") != NULL) {
+	if (g_getenv ("FWUPD_EBITDO_VERBOSE") != NULL) {
 		fu_ebitdo_dump_raw ("->DEVICE", packet, (gsize) hdr->pkt_len + 1);
 		fu_ebitdo_dump_pkt (hdr);
 	}
@@ -246,7 +246,7 @@ fu_ebitdo_device_receive (FuEbitdoDevice *device,
 	}
 
 	/* debug */
-	if (g_getenv ("FU_EBITDO_DEBUG") != NULL) {
+	if (g_getenv ("FWUPD_EBITDO_VERBOSE") != NULL) {
 		fu_ebitdo_dump_raw ("<-DEVICE", packet, (gsize) hdr->pkt_len - 1);
 		fu_ebitdo_dump_pkt (hdr);
 	}
@@ -560,7 +560,7 @@ fu_ebitdo_device_write_firmware (FuEbitdoDevice *device, GBytes *fw,
 	payload_data = g_bytes_get_data (fw, NULL);
 	payload_data += sizeof(FuEbitdoFirmwareHeader);
 	for (guint32 offset = 0; offset < payload_len; offset += chunk_sz) {
-		if (g_getenv ("FU_EBITDO_DEBUG") != NULL) {
+		if (g_getenv ("FWUPD_EBITDO_VERBOSE") != NULL) {
 			g_debug ("writing %u bytes to 0x%04x of 0x%04x",
 				 chunk_sz, offset, payload_len);
 		}

--- a/plugins/nitrokey/fu-nitrokey-device.c
+++ b/plugins/nitrokey/fu-nitrokey-device.c
@@ -117,7 +117,7 @@ fu_nitrokey_device_class_init (FuNitrokeyDeviceClass *klass)
 static void
 _dump_to_console (const gchar *title, const guint8 *buf, gsize buf_sz)
 {
-	if (g_getenv ("NITROKEY_DEBUG") == NULL)
+	if (g_getenv ("FWUPD_NITROKEY_VERBOSE") == NULL)
 		return;
 	g_debug ("%s", title);
 	for (gsize i = 0; i < buf_sz; i++)

--- a/plugins/unifying/lu-device.c
+++ b/plugins/unifying/lu-device.c
@@ -379,7 +379,7 @@ lu_device_hidpp_send (LuDevice *device,
 	lu_device_hidpp_dump (device, "host->device", (guint8 *) msg, len);
 
 	/* detailed debugging */
-	if (g_getenv ("UNIFYING_HW_DEBUG") != NULL) {
+	if (g_getenv ("FWUPD_UNIFYING_VERBOSE") != NULL) {
 		g_autofree gchar *str = lu_device_hidpp_msg_to_string (device, msg);
 		g_print ("%s", str);
 	}
@@ -473,7 +473,7 @@ lu_device_hidpp_receive (LuDevice *device,
 	}
 
 	/* detailed debugging */
-	if (g_getenv ("UNIFYING_HW_DEBUG") != NULL) {
+	if (g_getenv ("FWUPD_UNIFYING_VERBOSE") != NULL) {
 		g_autofree gchar *str = lu_device_hidpp_msg_to_string (device, msg);
 		g_print ("%s", str);
 	}

--- a/src/fu-debug.h
+++ b/src/fu-debug.h
@@ -24,9 +24,6 @@
 
 #include <glib.h>
 
-gboolean	 fu_debug_is_verbose		(void);
 GOptionGroup	*fu_debug_get_option_group	(void);
-void		 fu_debug_setup			(gboolean	 enabled);
-void		 fu_debug_destroy		(void);
 
 #endif /* __FU_DEBUG_H__ */

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -853,7 +853,7 @@ fu_main_on_bus_acquired_cb (GDBusConnection *connection,
 	}
 
 	/* dump startup profile data */
-	if (fu_debug_is_verbose ())
+	if (g_getenv ("FWUPD_VERBOSE") != NULL)
 		fu_engine_profile_dump (priv->engine);
 }
 


### PR DESCRIPTION
This allows end-users testing a specific plugin to start fwupd with an extra
command line parameter, e.g. `--plugin-verbose=unifying` to output a lot of
debugging information to the console for that specific plugin.

Plugins can either use the environment variable, or get the verbose mode using
fu_plugin_get_verbose().

This replaces a lot of ad-hoc environment variables with different naming
conventions.