### PR TITLE
Use a SHA1 hash for the internal DeviceID

### DIFF
--- a/plugins/altos/fu-altos-device.c
+++ b/plugins/altos/fu-altos-device.c
@@ -770,8 +770,11 @@ fu_altos_device_init_real (FuAltosDevice *device)
 	g_autofree gchar *vendor_id = NULL;
 
 	/* allowed, but requires manual bootloader step */
-	fu_device_add_flag (FU_DEVICE (device),
-			    FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_UPDATABLE);
+
+	/* set USB platform ID */
+	fu_device_set_platform_id (FU_DEVICE (device),
+				   g_usb_device_get_platform_id (priv->usb_device));
 
 	/* set default vendor */
 	fu_device_set_vendor (FU_DEVICE (device), "altusmetrum.org");

--- a/plugins/altos/fu-plugin-altos.c
+++ b/plugins/altos/fu-plugin-altos.c
@@ -55,15 +55,12 @@ fu_plugin_altos_device_added (FuPlugin *plugin,
 		return FALSE;
 	}
 
-	/* create the device */
-	platform_id = g_usb_device_get_platform_id (usb_device);
-	fu_device_set_id (FU_DEVICE (dev), platform_id);
-
 	/* get device properties */
 	if (!fu_altos_device_probe (dev, error))
 		return FALSE;
 
 	/* only the bootloader can do the update */
+	platform_id = g_usb_device_get_platform_id (usb_device);
 	runtime_id = g_strdup_printf ("%s-runtime", platform_id);
 	if (fu_altos_device_get_kind (dev) == FU_ALTOS_DEVICE_KIND_BOOTLOADER) {
 		FuDevice *dev_runtime;

--- a/plugins/dfu/fu-plugin-dfu.c
+++ b/plugins/dfu/fu-plugin-dfu.c
@@ -163,7 +163,7 @@ fu_plugin_dfu_device_added_cb (DfuContext *ctx,
 
 	/* create new device */
 	dev = fu_device_new ();
-	fu_device_set_id (dev, platform_id);
+	fu_device_set_platform_id (dev, platform_id);
 	if (!fu_plugin_dfu_device_update (plugin, dev, device, &error)) {
 		g_debug ("ignoring device: %s", error->message);
 		return;
@@ -245,7 +245,7 @@ fu_plugin_update_detach (FuPlugin *plugin, FuDevice *dev, GError **error)
 
 	/* get device */
 	device = dfu_context_get_device_by_platform_id (data->context,
-							fu_device_get_id (dev),
+							fu_device_get_platform_id (dev),
 							error);
 	if (device == NULL)
 		return FALSE;
@@ -290,7 +290,7 @@ fu_plugin_update_attach (FuPlugin *plugin, FuDevice *dev, GError **error)
 
 	/* get device */
 	device = dfu_context_get_device_by_platform_id (data->context,
-							fu_device_get_id (dev),
+							fu_device_get_platform_id (dev),
 							error);
 	if (device == NULL)
 		return FALSE;
@@ -342,7 +342,7 @@ fu_plugin_update (FuPlugin *plugin,
 
 	/* get device */
 	device = dfu_context_get_device_by_platform_id (data->context,
-							fu_device_get_id (dev),
+							fu_device_get_platform_id (dev),
 							error);
 	if (device == NULL)
 		return FALSE;
@@ -390,7 +390,6 @@ fu_plugin_verify (FuPlugin *plugin,
 	FuPluginData *data = fu_plugin_get_data (plugin);
 	GBytes *blob_fw;
 	DfuDevice *device;
-	const gchar *platform_id;
 	g_autoptr(DfuFirmware) dfu_firmware = NULL;
 	g_autoptr(FuDeviceLocker) locker  = NULL;
 	g_autoptr(GError) error_local = NULL;
@@ -400,18 +399,11 @@ fu_plugin_verify (FuPlugin *plugin,
 		0 };
 
 	/* get device */
-	platform_id = fu_device_get_id (dev);
 	device = dfu_context_get_device_by_platform_id (data->context,
-							platform_id,
-							&error_local);
-	if (device == NULL) {
-		g_set_error (error,
-			     FWUPD_ERROR,
-			     FWUPD_ERROR_INTERNAL,
-			     "cannot find device %s: %s",
-			     platform_id, error_local->message);
+							fu_device_get_platform_id (dev),
+							error);
+	if (device == NULL)
 		return FALSE;
-	}
 
 	/* open it */
 	locker = fu_device_locker_new_full (device,
@@ -423,7 +415,8 @@ fu_plugin_verify (FuPlugin *plugin,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_INTERNAL,
 			     "failed to open DFU device %s: %s",
-			     platform_id, error_local->message);
+			     fu_device_get_id (dev),
+			     error_local->message);
 		return FALSE;
 	}
 	g_signal_connect (device, "state-changed",

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -651,8 +651,11 @@ fu_ebitdo_device_init_real (FuEbitdoDevice *device)
 	g_autofree gchar *vendor_id = NULL;
 
 	/* allowed, but requires manual bootloader step */
-	fu_device_add_flag (FU_DEVICE (device),
-			    FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_UPDATABLE);
+
+	/* set USB platform ID */
+	fu_device_set_platform_id (FU_DEVICE (device),
+				   g_usb_device_get_platform_id (priv->usb_device));
 
 	/* set name and vendor */
 	name = g_strdup_printf ("%s Gamepad",
@@ -665,6 +668,9 @@ fu_ebitdo_device_init_real (FuEbitdoDevice *device)
 	/* set vendor ID */
 	vendor_id = g_strdup_printf ("USB:0x%04X", g_usb_device_get_vid (priv->usb_device));
 	fu_device_set_vendor_id (FU_DEVICE (device), vendor_id);
+
+	/* add a hardcoded icon name */
+	fu_device_add_icon (FU_DEVICE (device), "input-gaming");
 
 	/* add USB\VID_0000&PID_0000 */
 	devid1 = g_strdup_printf ("USB\\VID_%04X&PID_%04X",

--- a/plugins/ebitdo/fu-plugin-ebitdo.c
+++ b/plugins/ebitdo/fu-plugin-ebitdo.c
@@ -48,7 +48,6 @@ fu_plugin_ebitdo_device_added (FuPlugin *plugin,
 	g_assert (ptask != NULL);
 
 	/* create the device */
-	platform_id = g_usb_device_get_platform_id (usb_device);
 	dev = fu_ebitdo_device_new (usb_device);
 	if (dev == NULL) {
 		g_set_error_literal (error,
@@ -57,10 +56,6 @@ fu_plugin_ebitdo_device_added (FuPlugin *plugin,
 				     "invalid 8Bitdo device type detected");
 		return FALSE;
 	}
-	fu_device_set_id (dev, platform_id);
-
-	/* add a hardcoded icon name */
-	fu_device_add_icon (dev, "input-gaming");
 
 	/* open the device */
 	locker = fu_device_locker_new_full (dev,
@@ -72,6 +67,7 @@ fu_plugin_ebitdo_device_added (FuPlugin *plugin,
 	ebitdo_kind = fu_ebitdo_device_get_kind (dev);
 
 	/* only the bootloader can do the update */
+	platform_id = g_usb_device_get_platform_id (usb_device);
 	runtime_id = g_strdup_printf ("%s-runtime", platform_id);
 	if (ebitdo_kind == FU_EBITDO_DEVICE_KIND_BOOTLOADER) {
 		FuEbitdoDevice *dev_runtime;
@@ -114,15 +110,13 @@ fu_plugin_update (FuPlugin *plugin,
 {
 	GUsbContext *usb_ctx = fu_plugin_get_usb_context (plugin);
 	FuEbitdoDevice *ebitdo_dev = FU_EBITDO_DEVICE (dev);
-	const gchar *platform_id;
 	g_autoptr(FuDeviceLocker) locker = NULL;
 	g_autoptr(GUsbDevice) usb_device = NULL;
 	g_autoptr(GUsbDevice) usb_device2 = NULL;
 
 	/* get version */
-	platform_id = fu_device_get_id (dev);
 	usb_device = g_usb_context_find_by_platform_id (usb_ctx,
-							platform_id,
+							fu_device_get_platform_id (dev),
 							error);
 	if (usb_device == NULL)
 		return FALSE;

--- a/plugins/nitrokey/fu-nitrokey-device.c
+++ b/plugins/nitrokey/fu-nitrokey-device.c
@@ -304,7 +304,7 @@ fu_nitrokey_device_open (FuNitrokeyDevice *device, GError **error)
 	 * handled by multiple plugins this won't be required... */
 	platform_id = g_usb_device_get_platform_id (priv->usb_device);
 	platform_id_fixed = g_strdup_printf ("%s_workaround", platform_id);
-	fu_device_set_id (FU_DEVICE (device), platform_id_fixed);
+	fu_device_set_platform_id (FU_DEVICE (device), platform_id_fixed);
 	fu_device_set_name (FU_DEVICE (device), "Nitrokey Storage");
 	fu_device_set_vendor (FU_DEVICE (device), "Nitrokey");
 	fu_device_set_summary (FU_DEVICE (device), "A secure memory stick");

--- a/plugins/raspberrypi/fu-self-test.c
+++ b/plugins/raspberrypi/fu-self-test.c
@@ -87,7 +87,8 @@ fu_plugin_raspberrypi_func (void)
 	/* check we did the right thing */
 	g_assert_cmpint (cnt, ==, 0);
 	g_assert (device != NULL);
-	g_assert_cmpstr (fu_device_get_id (device), ==, "raspberry-pi");
+	g_assert_cmpstr (fu_device_get_id (device), ==,
+			 "94f01ac16574856944fb7e7583db423360430f97");
 	g_assert_cmpstr (fu_device_get_guid_default (device), ==,
 			 "91dd7368-8640-5d72-a217-a505c034dd0b");
 	g_assert_cmpstr (fu_device_get_version (device), ==,

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -219,7 +219,7 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 		fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_UPDATABLE);
 	}
 
-	fu_device_set_id (dev, uuid);
+	fu_device_set_platform_id (dev, uuid);
 
 	fu_device_set_metadata (dev, "sysfs-path", devpath);
 	name = g_udev_device_get_sysfs_attr (device, "device_name");
@@ -589,7 +589,7 @@ on_wait_for_device_removed (FuPlugin    *plugin,
 		return;
 
 	fu_plugin_cache_remove (plugin, id);
-	uuid = fu_device_get_id (dev);
+	uuid = fu_device_get_platform_id (dev);
 	g_hash_table_insert (up_data->changes,
 			     (gpointer) uuid,
 			     g_object_ref (dev));
@@ -647,7 +647,7 @@ fu_plugin_thunderbolt_wait_for_device (FuPlugin  *plugin,
 	g_autoptr(GHashTable) changes = NULL;
 
 	up_data.mainloop = mainloop = g_main_loop_new (NULL, FALSE);
-	up_data.target_uuid = fu_device_get_id (dev);
+	up_data.target_uuid = fu_device_get_platform_id (dev);
 
 	/* this will limit the maximum amount of time we wait for
 	 * the device (i.e. 'dev') to re-appear. */

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -470,7 +470,7 @@ sync_device_added (FuPlugin *plugin, FuDevice *device, gpointer user_data)
 {
 	SyncContext *ctx = (SyncContext *) user_data;
 	MockTree *tree = ctx->tree;
-	const char *uuid = fu_device_get_id (device);
+	const gchar *uuid = fu_device_get_platform_id (device);
 	MockTree *target;
 
 	target = (MockTree *) mock_tree_find_uuid (tree, uuid);
@@ -491,7 +491,7 @@ sync_device_removed (FuPlugin *plugin, FuDevice *device, gpointer user_data)
 {
 	SyncContext *ctx = (SyncContext *) user_data;
 	MockTree *tree = ctx->tree;
-	const char *uuid = fu_device_get_id (device);
+	const gchar *uuid = fu_device_get_platform_id (device);
 	MockTree *target;
 
 	target = (MockTree *) mock_tree_find_uuid (tree, uuid);
@@ -551,7 +551,7 @@ mock_tree_plugin_device_added (FuPlugin *plugin, FuDevice *device, gpointer user
 {
 	AttachContext *ctx = (AttachContext *) user_data;
 	MockTree *tree = ctx->tree;
-	const char *uuid = fu_device_get_id (device);
+	const gchar *uuid = fu_device_get_platform_id (device);
 	MockTree *target;
 
 	target = (MockTree *) mock_tree_find_uuid (tree, uuid);

--- a/plugins/unifying/fu-plugin-unifying.c
+++ b/plugins/unifying/fu-plugin-unifying.c
@@ -61,7 +61,7 @@ fu_plugin_unifying_device_added (FuPlugin *plugin,
 	dev = fu_device_new ();
 	if (lu_device_has_flag (device, LU_DEVICE_FLAG_CAN_FLASH))
 		fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_UPDATABLE);
-	fu_device_set_id (dev, lu_device_get_platform_id (device));
+	fu_device_set_platform_id (dev, lu_device_get_platform_id (device));
 	fu_device_set_name (dev, lu_device_get_product (device));
 	if (lu_device_get_kind (device) == LU_DEVICE_KIND_PERIPHERAL) {
 		const gchar *tmp;
@@ -123,7 +123,9 @@ fu_plugin_unifying_get_device (FuPlugin *plugin,
 			       GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
-	return lu_context_find_by_platform_id (data->ctx, fu_device_get_id (dev), error);
+	return lu_context_find_by_platform_id (data->ctx,
+					       fu_device_get_platform_id (dev),
+					       error);
 }
 
 static gboolean

--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -47,7 +47,6 @@ FuDevice	*fu_device_new				(void);
 #define fu_device_set_description(d,v)		fwupd_device_set_description(FWUPD_DEVICE(d),v)
 #define fu_device_set_flags(d,v)		fwupd_device_set_flags(FWUPD_DEVICE(d),v)
 #define fu_device_has_guid(d,v)			fwupd_device_has_guid(FWUPD_DEVICE(d),v)
-#define fu_device_set_id(d,v)			fwupd_device_set_id(FWUPD_DEVICE(d),v)
 #define fu_device_set_modified(d,v)		fwupd_device_set_modified(FWUPD_DEVICE(d),v)
 #define fu_device_set_plugin(d,v)		fwupd_device_set_plugin(FWUPD_DEVICE(d),v)
 #define fu_device_set_summary(d,v)		fwupd_device_set_summary(FWUPD_DEVICE(d),v)
@@ -99,6 +98,11 @@ void		 fu_device_set_metadata_boolean		(FuDevice	*device,
 void		 fu_device_set_metadata_integer		(FuDevice	*device,
 							 const gchar	*key,
 							 guint		 value);
+void		 fu_device_set_id			(FuDevice	*device,
+							 const gchar	*id);
+const gchar	*fu_device_get_platform_id		(FuDevice	*device);
+void		 fu_device_set_platform_id		(FuDevice	*device,
+							 const gchar	*platform_id);
 void		 fu_device_set_name			(FuDevice	*device,
 							 const gchar	*value);
 

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -412,6 +412,21 @@ fu_main_authorize_install_cb (GObject *source, GAsyncResult *res, gpointer user_
 	g_dbus_method_invocation_return_value (helper->invocation, NULL);
 }
 
+static gboolean
+fu_main_device_id_valid (const gchar *device_id, GError **error)
+{
+	if (g_strcmp0 (device_id, FWUPD_DEVICE_ID_ANY) == 0)
+		return TRUE;
+	if (device_id != NULL && strlen (device_id) >= 4)
+		return TRUE;
+	g_set_error (error,
+		     FWUPD_ERROR,
+		     FWUPD_ERROR_INTERNAL,
+		     "invalid device ID: %s",
+		     device_id);
+	return FALSE;
+}
+
 static void
 fu_main_daemon_method_call (GDBusConnection *connection, const gchar *sender,
 			    const gchar *object_path, const gchar *interface_name,
@@ -439,6 +454,10 @@ fu_main_daemon_method_call (GDBusConnection *connection, const gchar *sender,
 		g_autoptr(GPtrArray) releases = NULL;
 		g_variant_get (parameters, "(&s)", &device_id);
 		g_debug ("Called %s(%s)", method_name, device_id);
+		if (!fu_main_device_id_valid (device_id, &error)) {
+			g_dbus_method_invocation_return_gerror (invocation, error);
+			return;
+		}
 		releases = fu_engine_get_releases (priv->engine, device_id, &error);
 		if (releases == NULL) {
 			g_dbus_method_invocation_return_gerror (invocation, error);
@@ -453,6 +472,10 @@ fu_main_daemon_method_call (GDBusConnection *connection, const gchar *sender,
 		g_autoptr(GPtrArray) releases = NULL;
 		g_variant_get (parameters, "(&s)", &device_id);
 		g_debug ("Called %s(%s)", method_name, device_id);
+		if (!fu_main_device_id_valid (device_id, &error)) {
+			g_dbus_method_invocation_return_gerror (invocation, error);
+			return;
+		}
 		releases = fu_engine_get_downgrades (priv->engine, device_id, &error);
 		if (releases == NULL) {
 			g_dbus_method_invocation_return_gerror (invocation, error);
@@ -467,6 +490,10 @@ fu_main_daemon_method_call (GDBusConnection *connection, const gchar *sender,
 		g_autoptr(GPtrArray) releases = NULL;
 		g_variant_get (parameters, "(&s)", &device_id);
 		g_debug ("Called %s(%s)", method_name, device_id);
+		if (!fu_main_device_id_valid (device_id, &error)) {
+			g_dbus_method_invocation_return_gerror (invocation, error);
+			return;
+		}
 		releases = fu_engine_get_upgrades (priv->engine, device_id, &error);
 		if (releases == NULL) {
 			g_dbus_method_invocation_return_gerror (invocation, error);
@@ -504,6 +531,10 @@ fu_main_daemon_method_call (GDBusConnection *connection, const gchar *sender,
 		g_autoptr(FwupdDevice) result = NULL;
 		g_variant_get (parameters, "(&s)", &device_id);
 		g_debug ("Called %s(%s)", method_name, device_id);
+		if (!fu_main_device_id_valid (device_id, &error)) {
+			g_dbus_method_invocation_return_gerror (invocation, error);
+			return;
+		}
 		result = fu_engine_get_results (priv->engine, device_id, &error);
 		if (result == NULL) {
 			g_dbus_method_invocation_return_gerror (invocation, error);
@@ -563,6 +594,10 @@ fu_main_daemon_method_call (GDBusConnection *connection, const gchar *sender,
 
 		g_variant_get (parameters, "(&s)", &device_id);
 		g_debug ("Called %s(%s)", method_name, device_id);
+		if (!fu_main_device_id_valid (device_id, &error)) {
+			g_dbus_method_invocation_return_gerror (invocation, error);
+			return;
+		}
 
 		/* authenticate */
 		fu_main_set_status (priv, FWUPD_STATUS_WAITING_FOR_AUTH);
@@ -619,6 +654,10 @@ fu_main_daemon_method_call (GDBusConnection *connection, const gchar *sender,
 		/* check the id exists */
 		g_variant_get (parameters, "(&s)", &device_id);
 		g_debug ("Called %s(%s)", method_name, device_id);
+		if (!fu_main_device_id_valid (device_id, &error)) {
+			g_dbus_method_invocation_return_gerror (invocation, error);
+			return;
+		}
 
 		/* create helper object */
 		helper = g_new0 (FuMainAuthHelper, 1);
@@ -642,6 +681,10 @@ fu_main_daemon_method_call (GDBusConnection *connection, const gchar *sender,
 		const gchar *device_id = NULL;
 		g_variant_get (parameters, "(&s)", &device_id);
 		g_debug ("Called %s(%s)", method_name, device_id);
+		if (!fu_main_device_id_valid (device_id, &error)) {
+			g_dbus_method_invocation_return_gerror (invocation, error);
+			return;
+		}
 		if (!fu_engine_verify (priv->engine, device_id, &error)) {
 			g_dbus_method_invocation_return_gerror (invocation, error);
 			return;
@@ -665,6 +708,10 @@ fu_main_daemon_method_call (GDBusConnection *connection, const gchar *sender,
 		/* check the id exists */
 		g_variant_get (parameters, "(&sha{sv})", &device_id, &fd_handle, &iter);
 		g_debug ("Called %s(%s,%i)", method_name, device_id, fd_handle);
+		if (!fu_main_device_id_valid (device_id, &error)) {
+			g_dbus_method_invocation_return_gerror (invocation, error);
+			return;
+		}
 
 		/* create helper object */
 		helper = g_new0 (FuMainAuthHelper, 1);

--- a/src/fu-pending.c
+++ b/src/fu-pending.c
@@ -268,7 +268,8 @@ fu_pending_device_sqlite_cb (void *data,
 	g_debug ("FuPending: got sql result %s", argv[0]);
 	for (gint i = 0; i < argc; i++) {
 		if (g_strcmp0 (col_name[i], "device_id") == 0) {
-			fu_device_set_id (device, argv[i]);
+			/* we don't want to hash-the-hash */
+			fwupd_device_set_id (FWUPD_DEVICE (device), argv[i]);
 			continue;
 		}
 		if (g_strcmp0 (col_name[i], "filename") == 0) {


### PR DESCRIPTION
It's actually less scary to see a SHA1 hash than it is to see a path like
/sys/devices/pci0000:00/0000:00:1d.0/usb1/1-1/1-1.2. It's also way easier to
copy and paste into the various fwupdmgr command that require a device ID.

If we also move to a model where plugins can be changed during different stages
of the update (e.g. during detach) then the device might change connection type
and then the sysfs path not only becomes difficult to paste, but incorrect.

Session software doesn't care about the format of the device ID (it is supposed
to be an implementation detail) and so there's no API or ABI break here.