### PR TITLE
Test version of gcab to determine which tests to run (Closes: #318)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -167,6 +167,10 @@ endif
 libm = cc.find_library('m', required: false)
 udev = dependency('udev')
 uuid = dependency('uuid')
+gcab = dependency('libgcab-1.0')
+if gcab.version().version_compare('>= 0.8')
+  conf.set('HAVE_GCAB_0_8', '1')
+endif
 
 if get_option('enable-uefi-labels')
   cairo = dependency('cairo')

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -118,7 +118,7 @@ fu_engine_require_hwid_func (void)
 	return;
 #endif
 
-#ifdef __s390x__
+#if !defined(HAVE_GCAB_0_8) && defined(__s390x__)
 	/* See https://github.com/hughsie/fwupd/issues/318 for more information */
 	g_test_skip ("Skipping HWID test on s390x due to known problem with gcab");
 	return;


### PR DESCRIPTION
Adjust the disabling of the s390x CI test to only run when on newer
gcab.