### PR TITLE
Add a fu_plugin_device_added_usb() dedicated vfunc

### DIFF
--- a/src/fu-plugin-private.h
+++ b/src/fu-plugin-private.h
@@ -75,6 +75,9 @@ gboolean	 fu_plugin_runner_update_detach		(FuPlugin	*plugin,
 gboolean	 fu_plugin_runner_update_reload		(FuPlugin	*plugin,
 							 FuDevice	*device,
 							 GError		**error);
+gboolean	 fu_plugin_runner_usb_device_added	(FuPlugin	*plugin,
+							 GUsbDevice	*usb_device,
+							 GError		**error);
 void		 fu_plugin_runner_device_register	(FuPlugin	*plugin,
 							 FuDevice	*device);
 gboolean	 fu_plugin_runner_update		(FuPlugin	*plugin,

--- a/src/fu-plugin-vfuncs.h
+++ b/src/fu-plugin-vfuncs.h
@@ -70,6 +70,9 @@ gboolean	 fu_plugin_update_prepare		(FuPlugin	*plugin,
 gboolean	 fu_plugin_update_cleanup		(FuPlugin	*plugin,
 							 FuDevice	*dev,
 							 GError		**error);
+gboolean	 fu_plugin_usb_device_added		(FuPlugin	*plugin,
+							 GUsbDevice	*usb_device,
+							 GError		**error);
 void		 fu_plugin_device_registered		(FuPlugin	*plugin,
 							 FuDevice	*dev);
 

--- a/src/fu-plugin.c
+++ b/src/fu-plugin.c
@@ -98,6 +98,9 @@ typedef gboolean	 (*FuPluginUpdateFunc)		(FuPlugin	*plugin,
 							 GBytes		*blob_fw,
 							 FwupdInstallFlags flags,
 							 GError		**error);
+typedef gboolean	 (*FuPluginUsbDeviceAddedFunc)	(FuPlugin	*plugin,
+							 GUsbDevice	*usb_device,
+							 GError		**error);
 
 /**
  * fu_plugin_get_name:
@@ -996,6 +999,27 @@ fu_plugin_runner_update_reload (FuPlugin *plugin, FuDevice *device, GError **err
 {
 	return fu_plugin_runner_device_generic (plugin, device,
 						"fu_plugin_update_reload", error);
+}
+
+gboolean
+fu_plugin_runner_usb_device_added (FuPlugin *plugin, GUsbDevice *usb_device, GError **error)
+{
+	FuPluginPrivate *priv = GET_PRIVATE (plugin);
+	FuPluginUsbDeviceAddedFunc func = NULL;
+
+	/* not enabled */
+	if (!priv->enabled)
+		return TRUE;
+	if (priv->module == NULL)
+		return TRUE;
+
+	/* optional */
+	g_module_symbol (priv->module, "fu_plugin_usb_device_added", (gpointer *) &func);
+	if (func != NULL) {
+		g_debug ("performing usb_device_added() on %s", priv->name);
+		return func (plugin, usb_device, error);
+	}
+	return TRUE;
 }
 
 void


### PR DESCRIPTION
This saves all the USB plugins from connecting to the context and managing the
device lifecycle and allows devices that uses FuUsbDevice to be removed
automatically.

This makes supported plugins *much* smaller indeed.