### PR TITLE
Allow the device list to take care of waiting for the device replug

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -145,6 +145,8 @@ fwupd_device_flag_to_string (FwupdDeviceFlags device_flag)
 		return "install-parent-first";
 	if (device_flag == FWUPD_DEVICE_FLAG_IS_BOOTLOADER)
 		return "is-bootloader";
+	if (device_flag == FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG)
+		return "wait-for-replug";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -195,6 +197,8 @@ fwupd_device_flag_from_string (const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_INSTALL_PARENT_FIRST;
 	if (g_strcmp0 (device_flag, "is-bootloader") == 0)
 		return FWUPD_DEVICE_FLAG_IS_BOOTLOADER;
+	if (g_strcmp0 (device_flag, "wait-for-replug") == 0)
+		return FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -78,6 +78,7 @@ typedef enum {
  * @FWUPD_DEVICE_FLAG_USE_RUNTIME_VERSION:	Always use the runtime version rather than the bootloader
  * @FWUPD_DEVICE_FLAG_INSTALL_PARENT_FIRST:	Install composite firmware on the parent before the child
  * @FWUPD_DEVICE_FLAG_IS_BOOTLOADER:		Is currently in bootloader mode
+ * @FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG:		The hardware is waiting to be replugged
  *
  * The device flags.
  **/
@@ -96,6 +97,7 @@ typedef enum {
 #define FWUPD_DEVICE_FLAG_USE_RUNTIME_VERSION	(1u << 11)	/* Since: 1.0.6 */
 #define FWUPD_DEVICE_FLAG_INSTALL_PARENT_FIRST	(1u << 12)	/* Since: 1.0.8 */
 #define FWUPD_DEVICE_FLAG_IS_BOOTLOADER		(1u << 13)	/* Since: 1.0.8 */
+#define FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG	(1u << 14)	/* Since: 1.1.2 */
 #define FWUPD_DEVICE_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 0.7.3 */
 typedef guint64 FwupdDeviceFlags;
 

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -413,6 +413,8 @@ fu_colorhug_device_init (FuColorhugDevice *self)
 {
 	/* this is the application code */
 	self->start_addr = CH_EEPROM_ADDR_RUNCODE;
+	fu_device_set_remove_delay (FU_DEVICE (self),
+				    FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
 }
 
 static void

--- a/plugins/colorhug/fu-plugin-colorhug.c
+++ b/plugins/colorhug/fu-plugin-colorhug.c
@@ -20,10 +20,7 @@ fu_plugin_init (FuPlugin *plugin)
 gboolean
 fu_plugin_update_detach (FuPlugin *plugin, FuDevice *device, GError **error)
 {
-	FuColorhugDevice *self = FU_COLORHUG_DEVICE (device);
-	GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (device));
 	g_autoptr(FuDeviceLocker) locker = NULL;
-	g_autoptr(GUsbDevice) usb_device2 = NULL;
 
 	/* open device */
 	locker = fu_device_locker_new (device, error);
@@ -41,29 +38,14 @@ fu_plugin_update_detach (FuPlugin *plugin, FuDevice *device, GError **error)
 		return FALSE;
 
 	/* wait for replug */
-	g_clear_object (&locker);
-	usb_device2 = g_usb_context_wait_for_replug (fu_plugin_get_usb_context (plugin),
-						     usb_device,
-						     10000, error);
-	if (usb_device2 == NULL) {
-		g_prefix_error (error, "device did not come back: ");
-		return FALSE;
-	}
-
-	/* set the new device until we can use a new FuDevice */
-	fu_usb_device_set_dev (FU_USB_DEVICE (self), usb_device2);
-
-	/* success */
+	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	return TRUE;
 }
 
 gboolean
 fu_plugin_update_attach (FuPlugin *plugin, FuDevice *device, GError **error)
 {
-	FuColorhugDevice *self = FU_COLORHUG_DEVICE (device);
-	GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (device));
 	g_autoptr(FuDeviceLocker) locker = NULL;
-	g_autoptr(GUsbDevice) usb_device2 = NULL;
 
 	/* open device */
 	locker = fu_device_locker_new (device, error);
@@ -81,19 +63,7 @@ fu_plugin_update_attach (FuPlugin *plugin, FuDevice *device, GError **error)
 		return FALSE;
 
 	/* wait for replug */
-	g_clear_object (&locker);
-	usb_device2 = g_usb_context_wait_for_replug (fu_plugin_get_usb_context (plugin),
-						     usb_device,
-						     10000, error);
-	if (usb_device2 == NULL) {
-		g_prefix_error (error, "device did not come back: ");
-		return FALSE;
-	}
-
-	/* set the new device until we can use a new FuDevice */
-	fu_usb_device_set_dev (FU_USB_DEVICE (self), usb_device2);
-
-	/* success */
+	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	return TRUE;
 }
 

--- a/plugins/dfu/fu-plugin-dfu.c
+++ b/plugins/dfu/fu-plugin-dfu.c
@@ -84,10 +84,9 @@ fu_plugin_update_detach (FuPlugin *plugin, FuDevice *dev, GError **error)
 	/* detach and USB reset */
 	if (!dfu_device_detach (device, error))
 		return FALSE;
-	if (!dfu_device_wait_for_replug (device, FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE, error))
-		return FALSE;
 
-	/* success */
+	/* wait for replug */
+	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	return TRUE;
 }
 
@@ -112,10 +111,9 @@ fu_plugin_update_attach (FuPlugin *plugin, FuDevice *dev, GError **error)
 	/* attach it */
 	if (!dfu_device_attach (device, error))
 		return FALSE;
-	if (!dfu_device_wait_for_replug (device, FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE, error))
-		return FALSE;
 
-	/* success */
+	/* wait for replug */
+	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	return TRUE;
 }
 

--- a/plugins/ebitdo/fu-plugin-ebitdo.c
+++ b/plugins/ebitdo/fu-plugin-ebitdo.c
@@ -45,7 +45,6 @@ fu_plugin_update (FuPlugin *plugin,
 	GUsbDevice *usb_device = fu_usb_device_get_dev (FU_USB_DEVICE (dev));
 	FuEbitdoDevice *ebitdo_dev = FU_EBITDO_DEVICE (dev);
 	g_autoptr(FuDeviceLocker) locker = NULL;
-	g_autoptr(GUsbDevice) usb_device2 = NULL;
 
 	/* get version */
 	if (!fu_device_has_flag (dev, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
@@ -70,16 +69,9 @@ fu_plugin_update (FuPlugin *plugin,
 		g_prefix_error (error, "failed to force-reset device: ");
 		return FALSE;
 	}
-	g_clear_object (&locker);
-	usb_device2 = g_usb_context_wait_for_replug (fu_plugin_get_usb_context (plugin),
-						     usb_device, 10000, error);
-	if (usb_device2 == NULL) {
-		g_prefix_error (error, "device did not come back: ");
-		return FALSE;
-	}
-	fu_usb_device_set_dev (FU_USB_DEVICE (ebitdo_dev), usb_device2);
 
-	/* success */
+	/* wait for replug */
+	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 	return TRUE;
 }
 

--- a/src/fu-device-list.h
+++ b/src/fu-device-list.h
@@ -33,6 +33,9 @@ FuDevice	*fu_device_list_get_by_id		(FuDeviceList	*self,
 FuDevice	*fu_device_list_get_by_guid		(FuDeviceList	*self,
 							 const gchar	*guid,
 							 GError		**error);
+gboolean	 fu_device_list_wait_for_replug		(FuDeviceList	*self,
+							 FuDevice	*device,
+							 GError		**error);
 
 G_END_DECLS
 

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1436,6 +1436,11 @@ fu_engine_install_blob (FuEngine *self,
 	device = fu_device_list_get_by_id (self->device_list, device_id_orig, error);
 	if (device == NULL)
 		return FALSE;
+	if (!fu_device_list_wait_for_replug (self->device_list, device, error))
+		return FALSE;
+	device = fu_device_list_get_by_id (self->device_list, device_id_orig, error);
+	if (device == NULL)
+		return FALSE;
 	if (!fu_plugin_runner_update (plugin,
 				      device,
 				      blob_cab,
@@ -1479,6 +1484,11 @@ fu_engine_install_blob (FuEngine *self,
 	device = fu_device_list_get_by_id (self->device_list, device_id_orig, error);
 	if (device == NULL)
 		return FALSE;
+	if (!fu_device_list_wait_for_replug (self->device_list, device, error))
+		return FALSE;
+	device = fu_device_list_get_by_id (self->device_list, device_id_orig, error);
+	if (device == NULL)
+		return FALSE;
 	if (!fu_plugin_runner_update_attach (plugin, device, &error_local)) {
 		fu_device_set_update_error (device, error_local->message);
 		if ((flags & FWUPD_INSTALL_FLAG_NO_HISTORY) == 0 &&
@@ -1491,6 +1501,11 @@ fu_engine_install_blob (FuEngine *self,
 		g_propagate_error (error, g_steal_pointer (&error_local));
 		return FALSE;
 	}
+	device = fu_device_list_get_by_id (self->device_list, device_id_orig, error);
+	if (device == NULL)
+		return FALSE;
+	if (!fu_device_list_wait_for_replug (self->device_list, device, error))
+		return FALSE;
 
 	/* get the new version number */
 	device = fu_device_list_get_by_id (self->device_list, device_id_orig, error);


### PR DESCRIPTION
This means that individual plugins do not have to manage thier own GUsbDevice
lifecycle and call g_usb_context_wait_for_replug().

This is only lightly tested and is for sanity review only :)