### PR TITLE
Set the progress and state on the FuDevice, not the FuPlugin

### DIFF
--- a/plugins/altos/fu-altos-device.h
+++ b/plugins/altos/fu-altos-device.h
@@ -61,12 +61,8 @@ gboolean	 fu_altos_device_probe			(FuAltosDevice	*device,
 gboolean	 fu_altos_device_write_firmware		(FuAltosDevice	*device,
 							 GBytes		*fw,
 							 FuAltosDeviceWriteFirmwareFlag flags,
-							 GFileProgressCallback progress_cb,
-							 gpointer	 progress_data,
 							 GError		**error);
 GBytes		*fu_altos_device_read_firmware		(FuAltosDevice	*device,
-							 GFileProgressCallback progress_cb,
-							 gpointer	 progress_data,
 							 GError		**error);
 
 G_END_DECLS

--- a/plugins/altos/fu-altos-tool.c
+++ b/plugins/altos/fu-altos-tool.c
@@ -24,13 +24,9 @@
 #include "fu-altos-device.h"
 
 static void
-fu_altos_tool_write_progress_cb (goffset current, goffset total, gpointer user_data)
+fu_altos_tool_progress_cb (FuDevice *device, GParamSpec *pspec, gpointer user_data)
 {
-	gdouble percentage = -1.f;
-	if (total > 0)
-		percentage = (100.f * (gdouble) current) / (gdouble) total;
-	g_print ("Written %" G_GOFFSET_FORMAT "/%" G_GOFFSET_FORMAT " bytes [%.1f%%]\n",
-		 current, total, percentage);
+	g_print ("Written %u%%\n", fu_device_get_progress (device));
 }
 
 int
@@ -94,9 +90,10 @@ main (int argc, char **argv)
 
 	/* update with data blob */
 	fw = g_bytes_new (data, len);
+	g_signal_connect (dev, "notify::progress",
+			  G_CALLBACK (fu_altos_tool_progress_cb), NULL);
 	if (!fu_altos_device_write_firmware (dev, fw,
 					     FU_ALTOS_DEVICE_WRITE_FIRMWARE_FLAG_NONE,
-					     fu_altos_tool_write_progress_cb, NULL,
 					     &error)) {
 		g_print ("Failed to write firmware: %s\n", error->message);
 		return 1;

--- a/plugins/colorhug/fu-colorhug-device.h
+++ b/plugins/colorhug/fu-colorhug-device.h
@@ -49,12 +49,8 @@ gboolean	 fu_colorhug_device_set_flash_success	(FuColorhugDevice	*device,
 							 GError			**error);
 gboolean	 fu_colorhug_device_write_firmware	(FuColorhugDevice	*device,
 							 GBytes			*fw,
-							 GFileProgressCallback	 progress_cb,
-							 gpointer		 progress_data,
 							 GError			**error);
 gboolean	 fu_colorhug_device_verify_firmware	(FuColorhugDevice	*device,
-							 GFileProgressCallback	 progress_cb,
-							 gpointer		 progress_data,
 							 GError			**error);
 
 G_END_DECLS

--- a/plugins/colorhug/fu-plugin-colorhug.c
+++ b/plugins/colorhug/fu-plugin-colorhug.c
@@ -49,7 +49,6 @@ fu_plugin_update_detach (FuPlugin *plugin, FuDevice *device, GError **error)
 	}
 
 	/* reset */
-	fu_plugin_set_status (plugin, FWUPD_STATUS_DEVICE_RESTART);
 	if (!fu_colorhug_device_detach (colorhug_dev, error))
 		return FALSE;
 
@@ -90,7 +89,6 @@ fu_plugin_update_attach (FuPlugin *plugin, FuDevice *device, GError **error)
 	}
 
 	/* reset */
-	fu_plugin_set_status (plugin, FWUPD_STATUS_DEVICE_RESTART);
 	if (!fu_colorhug_device_attach (colorhug_dev, error))
 		return FALSE;
 
@@ -126,13 +124,6 @@ fu_plugin_update_reload (FuPlugin *plugin, FuDevice *device, GError **error)
 	return TRUE;
 }
 
-static void
-fu_plugin_colorhug_progress_cb (goffset current, goffset total, gpointer user_data)
-{
-	FuPlugin *plugin = FU_PLUGIN (user_data);
-	fu_plugin_set_percentage (plugin, (guint) current);
-}
-
 gboolean
 fu_plugin_update (FuPlugin *plugin,
 		  FuDevice *device,
@@ -162,11 +153,7 @@ fu_plugin_update (FuPlugin *plugin,
 	locker = fu_device_locker_new (device, error);
 	if (locker == NULL)
 		return FALSE;
-	fu_plugin_set_status (plugin, FWUPD_STATUS_DEVICE_WRITE);
-	return fu_colorhug_device_write_firmware (colorhug_dev, blob_fw,
-						  fu_plugin_colorhug_progress_cb,
-						  plugin,
-						  error);
+	return fu_colorhug_device_write_firmware (colorhug_dev, blob_fw, error);
 }
 
 gboolean
@@ -182,11 +169,7 @@ fu_plugin_verify (FuPlugin *plugin,
 	locker = fu_device_locker_new (device, error);
 	if (locker == NULL)
 		return FALSE;
-	fu_plugin_set_status (plugin, FWUPD_STATUS_DEVICE_VERIFY);
-	return fu_colorhug_device_verify_firmware (colorhug_dev,
-						   fu_plugin_colorhug_progress_cb,
-						   plugin,
-						   error);
+	return fu_colorhug_device_verify_firmware (colorhug_dev, error);
 }
 
 gboolean

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -900,7 +900,7 @@ fu_plugin_update (FuPlugin *plugin,
 	 * This won't actually cause any bad behavior because the real
 	 * payload GUID is extracted later on.
 	 */
-	fu_plugin_set_status (plugin, FWUPD_STATUS_SCHEDULING);
+	fu_device_set_status (device, FWUPD_STATUS_SCHEDULING);
 	rc = fwup_set_up_update_with_buf (re, 0,
 					  g_bytes_get_data (blob_fw, NULL),
 					  g_bytes_get_size (blob_fw));

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -435,11 +435,21 @@ fu_ebitdo_device_get_serial (FuEbitdoDevice *device)
 	return priv->serial;
 }
 
+static void
+fu_ebitdo_device_set_progress (FuEbitdoDevice *device, guint32 current, guint32 total)
+{
+	gdouble percentage = -1.f;
+	if (total > 0)
+		percentage = (100.f * (gdouble) current) / (gdouble) total;
+	if (g_getenv ("FWUPD_EBITDO_VERBOSE") != NULL) {
+		g_debug ("written %" G_GUINT32_FORMAT "/%" G_GUINT32_FORMAT " bytes [%.1f%%]",
+			 current, total, percentage);
+	}
+	fu_device_set_progress (FU_DEVICE (device), (guint) percentage);
+}
+
 gboolean
-fu_ebitdo_device_write_firmware (FuEbitdoDevice *device, GBytes *fw,
-			      GFileProgressCallback progress_cb,
-			      gpointer progress_data,
-			      GError **error)
+fu_ebitdo_device_write_firmware (FuEbitdoDevice *device, GBytes *fw, GError **error)
 {
 	FuEbitdoDevicePrivate *priv = GET_PRIVATE (device);
 	FuEbitdoFirmwareHeader *hdr;
@@ -523,8 +533,7 @@ fu_ebitdo_device_write_firmware (FuEbitdoDevice *device, GBytes *fw,
 			g_debug ("writing %u bytes to 0x%04x of 0x%04x",
 				 chunk_sz, offset, payload_len);
 		}
-		if (progress_cb != NULL)
-			progress_cb (offset, payload_len, progress_data);
+		fu_ebitdo_device_set_progress (device, offset, payload_len);
 		if (!fu_ebitdo_device_send (device,
 					 FU_EBITDO_PKT_TYPE_USER_CMD,
 					 FU_EBITDO_PKT_CMD_UPDATE_FIRMWARE_DATA,
@@ -549,8 +558,7 @@ fu_ebitdo_device_write_firmware (FuEbitdoDevice *device, GBytes *fw,
 	}
 
 	/* mark as complete */
-	if (progress_cb != NULL)
-		progress_cb (payload_len, payload_len, progress_data);
+	fu_ebitdo_device_set_progress (device, payload_len, payload_len);
 
 	/* set the "encode id" which is likely a checksum, bluetooth pairing
 	 * or maybe just security-through-obscurity -- also note:

--- a/plugins/ebitdo/fu-ebitdo-device.h
+++ b/plugins/ebitdo/fu-ebitdo-device.h
@@ -64,8 +64,6 @@ const guint32	*fu_ebitdo_device_get_serial		(FuEbitdoDevice	*device);
 /* object methods */
 gboolean	 fu_ebitdo_device_write_firmware	(FuEbitdoDevice	*device,
 							 GBytes		*fw,
-							 GFileProgressCallback progress_cb,
-							 gpointer	 progress_data,
 							 GError		**error);
 
 G_END_DECLS

--- a/plugins/ebitdo/fu-ebitdo-tool.c
+++ b/plugins/ebitdo/fu-ebitdo-tool.c
@@ -26,14 +26,11 @@
 #include "fu-ebitdo-common.h"
 #include "fu-ebitdo-device.h"
 
+
 static void
-fu_ebitdo_write_progress_cb (goffset current, goffset total, gpointer user_data)
+fu_ebitdo_tool_progress_cb (FuDevice *device, GParamSpec *pspec, gpointer user_data)
 {
-	gdouble percentage = -1.f;
-	if (total > 0)
-		percentage = (100.f * (gdouble) current) / (gdouble) total;
-	g_print ("Written %" G_GOFFSET_FORMAT "/%" G_GOFFSET_FORMAT " bytes [%.1f%%]\n",
-		 current, total, percentage);
+	g_print ("Written %u%%\n", fu_device_get_progress (device));
 }
 
 int
@@ -127,9 +124,9 @@ main (int argc, char **argv)
 
 	/* update with data blob */
 	fw = g_bytes_new (data, len);
-	if (!fu_ebitdo_device_write_firmware (dev, fw,
-					      fu_ebitdo_write_progress_cb, NULL,
-					      &error)) {
+	g_signal_connect (dev, "notify::progress",
+			  G_CALLBACK (fu_ebitdo_tool_progress_cb), NULL);
+	if (!fu_ebitdo_device_write_firmware (dev, fw, &error)) {
 		g_print ("Failed to write firmware: %s\n", error->message);
 		return 1;
 	}

--- a/plugins/raspberrypi/fu-plugin-raspberrypi.c
+++ b/plugins/raspberrypi/fu-plugin-raspberrypi.c
@@ -152,12 +152,12 @@ fu_plugin_update (FuPlugin *plugin,
 	g_autofree gchar *fwfn = NULL;
 
 	/* decompress anything matching either glob */
-	fu_plugin_set_status (plugin, FWUPD_STATUS_DEVICE_WRITE);
+	fu_device_set_status (device, FWUPD_STATUS_DEVICE_WRITE);
 	if (!fu_common_extract_archive (blob_fw, data->fw_dir, error))
 		return FALSE;
 
 	/* get the new VC build info */
-	fu_plugin_set_status (plugin, FWUPD_STATUS_DEVICE_VERIFY);
+	fu_device_set_status (device, FWUPD_STATUS_DEVICE_VERIFY);
 	fwfn = g_build_filename (data->fw_dir,
 				 FU_PLUGIN_RPI_FIRMWARE_FILENAME,
 				 NULL);

--- a/plugins/raspberrypi/fu-self-test.c
+++ b/plugins/raspberrypi/fu-self-test.c
@@ -31,9 +31,12 @@
 #include "fu-test.h"
 
 static void
-_plugin_status_changed_cb (FuPlugin *plugin, FwupdStatus status, gpointer user_data)
+_plugin_status_changed_cb (FuDevice *device, GParamSpec *pspec, gpointer user_data)
 {
 	guint *cnt = (guint *) user_data;
+	g_debug ("device %s now %s",
+		 fu_device_get_id (device),
+		 fwupd_status_to_string (fu_device_get_status (device)));
 	(*cnt)++;
 }
 
@@ -74,9 +77,6 @@ fu_plugin_raspberrypi_func (void)
 	g_signal_connect (plugin, "device-added",
 			  G_CALLBACK (_plugin_device_added_cb),
 			  &device);
-	g_signal_connect (plugin, "status-changed",
-			  G_CALLBACK (_plugin_status_changed_cb),
-			  &cnt);
 	ret = fu_plugin_runner_startup (plugin, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
@@ -105,6 +105,9 @@ fu_plugin_raspberrypi_func (void)
 	g_assert_no_error (error);
 	g_assert (mapped_file != NULL);
 	blob_fw = g_mapped_file_get_bytes (mapped_file);
+	g_signal_connect (device, "notify::status",
+			  G_CALLBACK (_plugin_status_changed_cb),
+			  &cnt);
 	ret = fu_plugin_runner_update (plugin, device, NULL, blob_fw,
 				       FWUPD_INSTALL_FLAG_NONE, &error);
 	g_assert_no_error (error);

--- a/plugins/synapticsmst/fu-plugin-synapticsmst.c
+++ b/plugins/synapticsmst/fu-plugin-synapticsmst.c
@@ -285,13 +285,13 @@ fu_plugin_synapticsmst_enumerate (FuPlugin *plugin,
 static void
 fu_synapticsmst_write_progress_cb (goffset current, goffset total, gpointer user_data)
 {
-	FuPlugin *plugin = FU_PLUGIN (user_data);
+	FuDevice *device = FU_DEVICE (user_data);
 	gdouble percentage = -1.f;
 	if (total > 0)
 		percentage = (100.f * (gdouble) current) / (gdouble) total;
 	g_debug ("written %" G_GOFFSET_FORMAT "/%" G_GOFFSET_FORMAT "[%.1f%%]",
 		 current, total, percentage);
-	fu_plugin_set_percentage (plugin, (guint) percentage);
+	fu_device_set_progress (device, (guint) percentage);
 }
 
 gboolean
@@ -322,7 +322,7 @@ fu_plugin_update (FuPlugin *plugin,
 	/* sleep to allow device wakeup to complete */
 	g_debug ("waiting %d seconds for MST hub wakeup",
 		 SYNAPTICS_FLASH_MODE_DELAY);
-	fu_plugin_set_status (plugin, FWUPD_STATUS_DEVICE_BUSY);
+	fu_device_set_status (dev, FWUPD_STATUS_DEVICE_BUSY);
 	g_usleep (SYNAPTICS_FLASH_MODE_DELAY * 1000000);
 
 	device = synapticsmst_device_new (kind, aux_node, layer, rad);
@@ -331,10 +331,10 @@ fu_plugin_update (FuPlugin *plugin,
 						   data->system_type, error))
 		return FALSE;
 	if (synapticsmst_device_board_id_to_string (synapticsmst_device_get_board_id (device)) != NULL) {
-		fu_plugin_set_status (plugin, FWUPD_STATUS_DEVICE_WRITE);
+		fu_device_set_status (dev, FWUPD_STATUS_DEVICE_WRITE);
 		if (!synapticsmst_device_write_firmware (device, blob_fw,
 							 fu_synapticsmst_write_progress_cb,
-							 plugin,
+							 device,
 							 error)) {
 			g_prefix_error (error, "failed to flash firmware: ");
 			return FALSE;
@@ -348,7 +348,7 @@ fu_plugin_update (FuPlugin *plugin,
 	}
 
 	/* Re-run device enumeration to find the new device version */
-	fu_plugin_set_status (plugin, FWUPD_STATUS_DEVICE_RESTART);
+	fu_device_set_status (dev, FWUPD_STATUS_DEVICE_RESTART);
 	if (!synapticsmst_device_enumerate_device (device, data->dock_type,
 						   data->system_type, error)) {
 		return FALSE;

--- a/plugins/test/fu-plugin-test.c
+++ b/plugins/test/fu-plugin-test.c
@@ -106,20 +106,20 @@ fu_plugin_update (FuPlugin *plugin,
 		  FwupdInstallFlags flags,
 		  GError **error)
 {
-	fu_plugin_set_status (plugin, FWUPD_STATUS_DECOMPRESSING);
+	fu_device_set_status (device, FWUPD_STATUS_DECOMPRESSING);
 	for (guint i = 1; i <= 100; i++) {
 		g_usleep (1000);
-		fu_plugin_set_percentage (plugin, i);
+		fu_device_set_progress (device, i);
 	}
-	fu_plugin_set_status (plugin, FWUPD_STATUS_DEVICE_WRITE);
+	fu_device_set_status (device, FWUPD_STATUS_DEVICE_WRITE);
 	for (guint i = 1; i <= 100; i++) {
 		g_usleep (1000);
-		fu_plugin_set_percentage (plugin, i);
+		fu_device_set_progress (device, i);
 	}
-	fu_plugin_set_status (plugin, FWUPD_STATUS_DEVICE_VERIFY);
+	fu_device_set_status (device, FWUPD_STATUS_DEVICE_VERIFY);
 	for (guint i = 1; i <= 100; i++) {
 		g_usleep (1000);
-		fu_plugin_set_percentage (plugin, i);
+		fu_device_set_progress (device, i);
 	}
 
 	/* upgrade, or downgrade */

--- a/plugins/thunderbolt-power/fu-plugin-thunderbolt-power.c
+++ b/plugins/thunderbolt-power/fu-plugin-thunderbolt-power.c
@@ -241,7 +241,7 @@ fu_plugin_update_prepare (FuPlugin *plugin,
 
 	data->needs_forcepower = TRUE;
 	/* wait for the device to come back onto the bus */
-	fu_plugin_set_status (plugin, FWUPD_STATUS_DEVICE_RESTART);
+	fu_device_set_status (device, FWUPD_STATUS_DEVICE_RESTART);
 	g_usleep (TBT_NEW_DEVICE_TIMEOUT * G_USEC_PER_SEC);
 
 	return TRUE;

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -445,7 +445,7 @@ fu_plugin_thunderbolt_trigger_update (GUdevDevice  *udevice,
 }
 
 static void
-fu_plugin_thunderbolt_report_progress (FuPlugin *plugin,
+fu_plugin_thunderbolt_report_progress (FuDevice *device,
 				       gsize     nwritten,
 				       gsize     total)
 {
@@ -455,11 +455,11 @@ fu_plugin_thunderbolt_report_progress (FuPlugin *plugin,
 	g_debug ("written %" G_GSIZE_FORMAT "/%" G_GSIZE_FORMAT " bytes [%.1f%%]",
 		 nwritten, total, percentage);
 
-	fu_plugin_set_percentage (plugin, (guint) percentage);
+	fu_device_set_progress (device, (guint) percentage);
 }
 
 static gboolean
-fu_plugin_thunderbolt_write_firmware (FuPlugin     *plugin,
+fu_plugin_thunderbolt_write_firmware (FuDevice     *device,
 				      GUdevDevice  *udevice,
 				      GBytes       *blob_fw,
 				      GError      **error)
@@ -484,7 +484,7 @@ fu_plugin_thunderbolt_write_firmware (FuPlugin     *plugin,
 
 	nwritten = 0;
 	fw_size = g_bytes_get_size (blob_fw);
-	fu_plugin_thunderbolt_report_progress (plugin, nwritten, fw_size);
+	fu_plugin_thunderbolt_report_progress (device, nwritten, fw_size);
 
 	do {
 		g_autoptr(GBytes) fw_data = NULL;
@@ -501,7 +501,7 @@ fu_plugin_thunderbolt_write_firmware (FuPlugin     *plugin,
 			return FALSE;
 
 		nwritten += n;
-		fu_plugin_thunderbolt_report_progress (plugin, nwritten, fw_size);
+		fu_plugin_thunderbolt_report_progress (device, nwritten, fw_size);
 
 	} while (nwritten < fw_size);
 
@@ -799,8 +799,8 @@ fu_plugin_update (FuPlugin *plugin,
 		g_warning ("%s", msg);
 	}
 
-	fu_plugin_set_status (plugin, FWUPD_STATUS_DEVICE_WRITE);
-	if (!fu_plugin_thunderbolt_write_firmware (plugin, udevice, blob_fw, &error_local)) {
+	fu_device_set_status (dev, FWUPD_STATUS_DEVICE_WRITE);
+	if (!fu_plugin_thunderbolt_write_firmware (dev, udevice, blob_fw, &error_local)) {
 		g_set_error (error,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_WRITE,
@@ -818,7 +818,7 @@ fu_plugin_update (FuPlugin *plugin,
 		return FALSE;
 	}
 
-	fu_plugin_set_status (plugin, FWUPD_STATUS_DEVICE_RESTART);
+	fu_device_set_status (dev, FWUPD_STATUS_DEVICE_RESTART);
 
 	/* the device will disappear and we need to wait until it reappears,
 	 * and then check if we find an error */

--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -397,7 +397,7 @@ fu_plugin_update (FuPlugin *plugin,
 
 	/* perform the update */
 	g_debug ("Performing UEFI capsule update");
-	fu_plugin_set_status (plugin, FWUPD_STATUS_SCHEDULING);
+	fu_device_set_status (device, FWUPD_STATUS_SCHEDULING);
 	if (!fu_plugin_uefi_update_splash (&error_splash)) {
 		g_warning ("failed to upload BGRT splash text: %s",
 			   error_splash->message);

--- a/plugins/unifying/fu-plugin-unifying.c
+++ b/plugins/unifying/fu-plugin-unifying.c
@@ -108,13 +108,13 @@ fu_plugin_unifying_device_added (FuPlugin *plugin,
 static void
 lu_write_progress_cb (goffset current, goffset total, gpointer user_data)
 {
-	FuPlugin *plugin = FU_PLUGIN (user_data);
+	FuDevice *device = FU_DEVICE (user_data);
 	gdouble percentage = -1.f;
 	if (total > 0)
 		percentage = (100.f * (gdouble) current) / (gdouble) total;
 	g_debug ("written %" G_GOFFSET_FORMAT "/%" G_GOFFSET_FORMAT " bytes [%.1f%%]",
 		 current, total, percentage);
-	fu_plugin_set_percentage (plugin, (guint) percentage);
+	fu_device_set_progress (device, (guint) percentage);
 }
 
 static LuDevice *
@@ -179,7 +179,7 @@ fu_plugin_update_detach (FuPlugin *plugin, FuDevice *dev, GError **error)
 		return TRUE;
 
 	/* wait for device to come back */
-	fu_plugin_set_status (plugin, FWUPD_STATUS_DEVICE_RESTART);
+	fu_device_set_status (dev, FWUPD_STATUS_DEVICE_RESTART);
 	if (lu_device_has_flag (device, LU_DEVICE_FLAG_DETACH_WILL_REPLUG)) {
 		g_debug ("doing detach in idle");
 		g_idle_add_full (G_PRIORITY_DEFAULT_IDLE,
@@ -217,7 +217,7 @@ fu_plugin_update_attach (FuPlugin *plugin, FuDevice *dev, GError **error)
 		return TRUE;
 
 	/* wait for device to come back */
-	fu_plugin_set_status (plugin, FWUPD_STATUS_DEVICE_RESTART);
+	fu_device_set_status (dev, FWUPD_STATUS_DEVICE_RESTART);
 	if (lu_device_has_flag (device, LU_DEVICE_FLAG_ATTACH_WILL_REPLUG)) {
 		g_debug ("doing attach in idle");
 		g_idle_add_full (G_PRIORITY_DEFAULT_IDLE,
@@ -272,9 +272,9 @@ fu_plugin_update (FuPlugin *plugin,
 		return FALSE;
 
 	/* write the firmware */
-	fu_plugin_set_status (plugin, FWUPD_STATUS_DEVICE_WRITE);
+	fu_device_set_status (dev, FWUPD_STATUS_DEVICE_WRITE);
 	if (!lu_device_write_firmware (device, blob_fw,
-				       lu_write_progress_cb, plugin,
+				       lu_write_progress_cb, dev,
 				       error))
 		return FALSE;
 

--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -130,6 +130,12 @@ void		 fu_device_set_name			(FuDevice	*device,
 guint		 fu_device_get_remove_delay		(FuDevice	*device);
 void		 fu_device_set_remove_delay		(FuDevice	*device,
 							 guint		 remove_delay);
+FwupdStatus	 fu_device_get_status			(FuDevice	*device);
+void		 fu_device_set_status			(FuDevice	*device,
+							 FwupdStatus	 status);
+guint		 fu_device_get_progress			(FuDevice	*device);
+void		 fu_device_set_progress			(FuDevice	*device,
+							 guint		 progress);
 
 G_END_DECLS
 


### PR DESCRIPTION
This makes more sense; we're updating the device, not the plugin itself.

This also means we don't need to funnel everything through callbacks like
GFileProgressCallback and we can also update the state without adding an
explicit callback to each derived device type.