### PR TITLE
Support AppStream metadata with relative <location> URLs

### DIFF
--- a/data/remotes.d/README.md
+++ b/data/remotes.d/README.md
@@ -38,3 +38,29 @@ Ideally, the metadata and firmware should be signed by either GPG or a PKCS7
 certificate. If this is the case also change `Keyring=gpg` or `Keyring=pkcs7`
 in `/etc/fwupd/remotes.d/vendor.conf` and ensure the correct public key or
 signing certificate is installed in the `/etc/pki/fwupd` location.
+
+Mirroring a Repository
+======================
+
+The LVFS currently outputs XML with absolute URI locations, e.g.
+`<location>http://foo/bar.cab</location>` rather than `<location>bar.cab</location>`
+
+This makes mirroring the master LVFS (or other slave instance) somewhat tricky.
+To work around this issue client remotes can specify `FirmwareBaseURI` to
+replace the URI of the firmware before it is downloaded.
+
+For mirroring the LVFS content to a new CDN, you could use:
+
+    [fwupd Remote]
+    Enabled=true
+    Type=download
+    Keyring=gpg
+    MetadataURI=https://my.new.cdn/mirror/firmware.xml.gz
+    FirmwareBaseURI=https://my.new.cdn/mirror
+
+New instances of the LVFS can actually output a relative URL for firmware files,
+e.g. `<location>bar.cab</location>` and when downloading the `MetadataURI` name
+and path prefix is used in this case.
+This is not enabled for the "upstream" LVFS instance as versions of fwupd older
+than 1.0.3 are unable to automatically use the `MetadataURI` value for firmware
+downloads.

--- a/data/tests/firmware-nopath.conf
+++ b/data/tests/firmware-nopath.conf
@@ -1,0 +1,5 @@
+[fwupd Remote]
+Enabled=true
+Type=download
+Keyring=gpg
+MetadataURI=https://s3.amazonaws.com/lvfsbucket/downloads/firmware.xml.gz

--- a/libfwupd/fwupd-remote.c
+++ b/libfwupd/fwupd-remote.c
@@ -180,6 +180,24 @@ fwupd_remote_build_uri (FwupdRemote *self, const gchar *url, GError **error)
 				     "Failed to parse URI '%s'", url2);
 			return NULL;
 		}
+
+	/* use the base URI of the metadata to build the full path */
+	} else if (g_strstr_len (url, -1, "/") == NULL) {
+		g_autofree gchar *basename = NULL;
+		g_autofree gchar *path = NULL;
+		uri = soup_uri_new (priv->metadata_uri);
+		if (uri == NULL) {
+			g_set_error (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_INVALID_FILE,
+				     "Failed to parse metadata URI '%s'", url);
+			return NULL;
+		}
+		basename = g_path_get_dirname (soup_uri_get_path (uri));
+		path = g_build_filename (basename, url, NULL);
+		soup_uri_set_path (uri, path);
+
+	/* a normal URI */
 	} else {
 		uri = soup_uri_new (url);
 		if (uri == NULL) {


### PR DESCRIPTION
If a remote like LVFS outputs <location>foo.cab</location> without a prepended
hostname and path then we should use the metadata URI hostname and path instead.

This allows us to trivially mirror a firmware repository, although clients using
older versions of libfwupd will not work without this patch. We should encourage
people to use `FirmwareBaseURI` for a long time yet.