### PR TITLE
Use gzip -n

### DIFF
--- a/po/make-images.sh
+++ b/po/make-images.sh
@@ -8,5 +8,5 @@
 install -m 0755 -d ${MESON_INSTALL_DESTDIR_PREFIX}/share/locale/
 ${MESON_SOURCE_ROOT}/po/make-images "Installing firmware update…" ${MESON_INSTALL_DESTDIR_PREFIX}/share/locale/ ${MESON_SOURCE_ROOT}/po/LINGUAS
 for x in ${MESON_INSTALL_DESTDIR_PREFIX}/share/locale/*/LC_IMAGES/*.bmp ; do
-    gzip -f ${x}
+    gzip -fn9 ${x}
 done


### PR DESCRIPTION
to prevent it from adding timestamps to .gz headers
to make package builds reproducible

See https://reproducible-builds.org/ for why this is good.