### PR TITLE
Offer to reboot when processing an offline update

### DIFF
--- a/data/installed-tests/fwupdmgr.sh
+++ b/data/installed-tests/fwupdmgr.sh
@@ -60,7 +60,7 @@ rc=$?; if [[ $rc != 2 ]]; then exit $rc; fi
 
 # ---
 echo "Updating all devices to latest release (requires network access)"
-fwupdmgr --no-unreported-check --no-metadata-check update
+fwupdmgr --no-unreported-check --no-metadata-check --no-reboot-check update
 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 
 # ---


### PR DESCRIPTION
In real user tests this was a pain point where we had to manually explain that
they needed to reboot.