### PR TITLE
plugins/ebitdo: Stop matching DS4 controller VID/PID

### DIFF
--- a/plugins/ebitdo/ebitdo.quirk
+++ b/plugins/ebitdo/ebitdo.quirk
@@ -40,6 +40,4 @@ USB\VID_2DC8&PID_6000=none
 USB\VID_2DC8&PID_6001=none
 ## Xinput mode (Start + X)
 USB\VID_045E&PID_028E=none
-# macOS mode (Start + A)
-USB\VID_054C&PID_05C4=none
 

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -269,14 +269,6 @@ fu_ebitdo_device_validate (FuEbitdoDevice *device, GError **error)
 	    g_usb_device_get_pid (usb_device) == 0x2009)
 		return TRUE;
 
-	/* SF30/SN30 Pro when started with "START + A"
-	 * Emulates a Sony Dualshock 4 controller
-	 * Unknown if real DS4 controller will also match */
-
-	if (g_usb_device_get_vid (usb_device) == 0x054c &&
-	    g_usb_device_get_pid (usb_device) == 0x05c4)
-		return TRUE;
-
 	/* verify the vendor prefix against a whitelist */
 	idx = g_usb_device_get_manufacturer_index (usb_device);
 	ven = g_usb_device_get_string_descriptor (usb_device, idx, error);

--- a/plugins/ebitdo/fu-ebitdo-tool.c
+++ b/plugins/ebitdo/fu-ebitdo-tool.c
@@ -122,7 +122,6 @@ main (int argc, char **argv)
 		case 0x6000: /* SF30 pro: Dinput mode */
 		case 0x6001: /* SN30 pro: Dinput mode */
 		case 0x028e: /* SF30/SN30 pro: Xinput mode */
-		case 0x05c4: /* SF30/SN30 pro: macOS  mode */
 			g_print ("2. Press and hold L1+R1+START for 3 seconds "
 				 "until the LED on top blinks red.\n");
 			break;


### PR DESCRIPTION
This causes problems with the real DS4 controller.
Furthermore in MacOS mode fwupd doesn't actually work properly
anyhow (Closes #381)