### PR TITLE
Correctly mark updates as successful even if the device version numbe…

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1649,6 +1649,13 @@ fu_engine_install (FuEngine *self,
 						 error);
 	}
 
+	/* ensure the new version matched what we expected */
+	if (g_strcmp0 (fu_device_get_version (device), version) != 0) {
+		g_warning ("new device version '%s' was is not '%s', fixing up",
+			   fu_device_get_version (device), version);
+		fu_device_set_version (device, version);
+	}
+
 	/* success */
 	fu_device_set_update_state (device, FWUPD_UPDATE_STATE_SUCCESS);
 	return fu_history_modify_device (self->history, device,

--- a/src/fu-history.c
+++ b/src/fu-history.c
@@ -317,7 +317,6 @@ static FwupdDeviceFlags
 fu_history_get_device_flags_filtered (FuDevice *device)
 {
 	FwupdDeviceFlags flags = fu_device_get_flags (device);
-	flags &= ~FWUPD_DEVICE_FLAG_REPORTED;
 	flags &= ~FWUPD_DEVICE_FLAG_REGISTERED;
 	flags &= ~FWUPD_DEVICE_FLAG_SUPPORTED;
 	return flags;


### PR DESCRIPTION
…r is wrong

If the device firmware was set incorrectly make then set it to the release
version so the database update works correctly. We can't do any kind of vercmp
in the database, so use a daemon warning so we can either fix the plugin or
the XML.

This fixes up the issue that the hardware reports '28.00' and the AppStream
release specifies '28.0'.

Fixes: https://github.com/hughsie/fwupd/issues/387