### PR TITLE
Wip/superm1/ci deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,15 @@ install:
 
 script:
   - docker run -e OS=$OS -e CI=true -t -v `pwd`/dist:/build/dist fwupd-$OS
+
+deploy:
+  provider: releases
+  api_key:
+    secure: fill_me_in
+  file_glob: true
+  file: dist/*
+  skip_cleanup:  true
+  on:
+    tags: true
+    repo: hughsie/fwupd
+


### PR DESCRIPTION
This makes all contrib builds end up directly in dist/ rather than root of the build tree. 

There is also a skeleton of a Travis deploy rule. I'm not sure if this is a good idea because it might still be dependency hell for yesterday, but I'll be interested to hear your thoughts.
If it sticks all it's missing is an encrypted API key as mentioned on the Travis page. I think you need to create it as admin of the repo.