### PR TITLE
Use a CNAME to redirect to the correct CDN for metadata

### DIFF
--- a/data/remotes.d/lvfs-testing.conf
+++ b/data/remotes.d/lvfs-testing.conf
@@ -4,7 +4,7 @@
 Enabled=false
 Title=Linux Vendor Firmware Service (testing)
 Keyring=gpg
-MetadataURI=https://s3.amazonaws.com/lvfsbucket/downloads/firmware-testing.xml.gz
+MetadataURI=https://cdn.fwupd.org/downloads/firmware-testing.xml.gz
 ReportURI=https://fwupd.org/lvfs/firmware/report
 Username=
 Password=

--- a/data/remotes.d/lvfs.conf
+++ b/data/remotes.d/lvfs.conf
@@ -4,6 +4,6 @@
 Enabled=true
 Title=Linux Vendor Firmware Service
 Keyring=gpg
-MetadataURI=https://s3.amazonaws.com/lvfsbucket/downloads/firmware.xml.gz
+MetadataURI=https://cdn.fwupd.org/downloads/firmware.xml.gz
 ReportURI=https://fwupd.org/lvfs/firmware/report
 OrderBefore=fwupd


### PR DESCRIPTION
The current CDN (~$100/month) is kindly sponsored by Amazon, but that won't
last forever. In the future we can switch to a 'dumb' provider like BunnyCDN
for 1/10th of the cost.

Use a CNAME we control to make switching CDN providers easy in the future.