### PR TITLE
Use the right encoding for the label in make-images

### DIFF
--- a/po/make-images
+++ b/po/make-images
@@ -191,6 +191,7 @@ if __name__ == '__main__':
     if len(sys.argv) != 4:
         usage(1)
 
-    r = Rasterizer(label=sys.argv[1], modir=sys.argv[2],
+    label = os.fsencode(sys.argv[1]).decode('utf-8')
+    r = Rasterizer(label=label, modir=sys.argv[2],
                    linguas=sys.argv[3])
     r.render()


### PR DESCRIPTION
This prevents the following error:
UnicodeEncodeError: 'utf-8' codec can't encode characters in
position 26-28: surrogates not allowed