### PR TITLE
Reboot using logind, not directly using systemd

### DIFF
--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -552,13 +552,13 @@ fu_util_update_reboot (GError **error)
 		return FALSE;
 
 #ifdef HAVE_SYSTEMD
-	/* reboot using systemd */
+	/* reboot using logind */
 	val = g_dbus_connection_call_sync (connection,
-					   "org.freedesktop.systemd1",
-					   "/org/freedesktop/systemd1",
-					   "org.freedesktop.systemd1.Manager",
+					   "org.freedesktop.login1",
+					   "/org/freedesktop/login1",
+					   "org.freedesktop.login1.Manager",
 					   "Reboot",
-					   NULL,
+					   g_variant_new ("(b)", TRUE),
 					   NULL,
 					   G_DBUS_CALL_FLAGS_NONE,
 					   -1,


### PR DESCRIPTION
This allows us to use PolicyKit, which means we will get prompted for
authorization if logged in as a user without permissions.

Fixes https://github.com/hughsie/fwupd/issues/455