### PR TITLE
thunderbolt-power: If a timer is still running from coldplug, stop it…

### DIFF
--- a/plugins/thunderbolt-power/fu-plugin-thunderbolt-power.c
+++ b/plugins/thunderbolt-power/fu-plugin-thunderbolt-power.c
@@ -193,8 +193,10 @@ void
 fu_plugin_destroy (FuPlugin *plugin)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
-	if (data->timeout_id != 0)
+	if (data->timeout_id != 0) {
 		g_source_remove (data->timeout_id);
+		data->timeout_id = 0;
+	}
 	g_object_unref (data->udev);
 	g_free (data->force_path);
 }

--- a/plugins/thunderbolt-power/fu-plugin-thunderbolt-power.c
+++ b/plugins/thunderbolt-power/fu-plugin-thunderbolt-power.c
@@ -229,6 +229,12 @@ fu_plugin_update_prepare (FuPlugin *plugin,
 	if (g_strcmp0 (fu_device_get_plugin (device), "thunderbolt") != 0)
 		return TRUE;
 
+	/* reset any timers that might still be running from coldplug */
+	if (data->timeout_id != 0) {
+		g_source_remove (data->timeout_id);
+		data->timeout_id = 0;
+	}
+
 	devpath = fu_device_get_metadata (device, "sysfs-path");
 
 	udevice = g_udev_client_query_by_sysfs_path (data->udev, devpath);


### PR DESCRIPTION
… (#457)

A race condition is hypothesized in the following scenario:

1. User starts up the system and fwupd doesn't start automatically.
2. User manually calls fwupdmgr install blah.cab (or fwupdmgr update really) which uses dbus activation to start fwupd systemd unit.
3. This runs coldplug on thunderbolt plugin, no devices found. Thunderbolt power runs coldplug routine.
  a. This sets forcepower with a timeout to turn off after 20 seconds.
  b. Coldplug exits.
4. update routine starts
  a. Thunderbolt plugin starts flash routine.
  b. Thunderbolt power plugin turns off force power in middle of flash routine.
  c. Issue described happens.