### PR TITLE
Export fwupd_remote_get_agreement()

### DIFF
--- a/libfwupd/fwupd-remote-private.h
+++ b/libfwupd/fwupd-remote-private.h
@@ -34,6 +34,8 @@ gboolean	 fwupd_remote_load_from_filename	(FwupdRemote	*self,
 							 GError		**error);
 void		 fwupd_remote_set_priority		(FwupdRemote	*self,
 							 gint		 priority);
+void		 fwupd_remote_set_agreement		(FwupdRemote	*self,
+							 const gchar	*agreement);
 void		 fwupd_remote_set_mtime			(FwupdRemote	*self,
 							 guint64	 mtime);
 gchar		**fwupd_remote_get_order_after		(FwupdRemote	*self);

--- a/libfwupd/fwupd-remote.c
+++ b/libfwupd/fwupd-remote.c
@@ -51,6 +51,7 @@ typedef struct {
 	gchar			*username;
 	gchar			*password;
 	gchar			*title;
+	gchar			*agreement;
 	gchar			*checksum;
 	gchar			*filename_cache;
 	gchar			*filename_cache_sig;
@@ -87,6 +88,23 @@ fwupd_remote_set_title (FwupdRemote *self, const gchar *title)
 	FwupdRemotePrivate *priv = GET_PRIVATE (self);
 	g_free (priv->title);
 	priv->title = g_strdup (title);
+}
+
+/**
+ * fwupd_remote_set_agreement:
+ * @self: A #FwupdRemote
+ * @agreement: Agreement markup
+ *
+ * Sets the remote agreement in AppStream markup format
+ *
+ * Since: 1.0.7
+ **/
+void
+fwupd_remote_set_agreement (FwupdRemote *self, const gchar *agreement)
+{
+	FwupdRemotePrivate *priv = GET_PRIVATE (self);
+	g_free (priv->agreement);
+	priv->agreement = g_strdup (agreement);
 }
 
 static void
@@ -738,6 +756,24 @@ fwupd_remote_get_title (FwupdRemote *self)
 }
 
 /**
+ * fwupd_remote_get_agreement:
+ * @self: A #FwupdRemote
+ *
+ * Gets the remote agreement in AppStream markup format
+ *
+ * Returns: a string, or %NULL if unset
+ *
+ * Since: 1.0.7
+ **/
+const gchar *
+fwupd_remote_get_agreement (FwupdRemote *self)
+{
+	FwupdRemotePrivate *priv = GET_PRIVATE (self);
+	g_return_val_if_fail (FWUPD_IS_REMOTE (self), NULL);
+	return priv->agreement;
+}
+
+/**
  * fwupd_remote_get_checksum:
  * @self: A #FwupdRemote
  *
@@ -920,6 +956,8 @@ fwupd_remote_set_from_variant_iter (FwupdRemote *self, GVariantIter *iter)
 			fwupd_remote_set_password (self, g_variant_get_string (value, NULL));
 		} else if (g_strcmp0 (key, "Title") == 0) {
 			fwupd_remote_set_title (self, g_variant_get_string (value, NULL));
+		} else if (g_strcmp0 (key, "Agreement") == 0) {
+			fwupd_remote_set_agreement (self, g_variant_get_string (value, NULL));
 		} else if (g_strcmp0 (key, FWUPD_RESULT_KEY_CHECKSUM) == 0) {
 			fwupd_remote_set_checksum (self, g_variant_get_string (value, NULL));
 		} else if (g_strcmp0 (key, "Enabled") == 0) {
@@ -969,6 +1007,10 @@ fwupd_remote_to_variant (FwupdRemote *self)
 	if (priv->title != NULL) {
 		g_variant_builder_add (&builder, "{sv}", "Title",
 				       g_variant_new_string (priv->title));
+	}
+	if (priv->agreement != NULL) {
+		g_variant_builder_add (&builder, "{sv}", "Agreement",
+				       g_variant_new_string (priv->agreement));
 	}
 	if (priv->checksum != NULL) {
 		g_variant_builder_add (&builder, "{sv}", FWUPD_RESULT_KEY_CHECKSUM,
@@ -1106,6 +1148,7 @@ fwupd_remote_finalize (GObject *obj)
 	g_free (priv->username);
 	g_free (priv->password);
 	g_free (priv->title);
+	g_free (priv->agreement);
 	g_free (priv->checksum);
 	g_free (priv->filename_cache);
 	g_free (priv->filename_cache_sig);

--- a/libfwupd/fwupd-remote.h
+++ b/libfwupd/fwupd-remote.h
@@ -56,6 +56,7 @@ const gchar	*fwupd_remote_kind_to_string		(FwupdRemoteKind kind);
 FwupdRemote	*fwupd_remote_new			(void);
 const gchar	*fwupd_remote_get_id			(FwupdRemote	*self);
 const gchar	*fwupd_remote_get_title			(FwupdRemote	*self);
+const gchar	*fwupd_remote_get_agreement		(FwupdRemote	*self);
 const gchar	*fwupd_remote_get_checksum		(FwupdRemote	*self);
 const gchar	*fwupd_remote_get_username		(FwupdRemote	*self);
 const gchar	*fwupd_remote_get_password		(FwupdRemote	*self);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -239,5 +239,7 @@ LIBFWUPD_1.0.4 {
 LIBFWUPD_1.0.7 {
   global:
     fwupd_get_os_release;
+    fwupd_remote_get_agreement;
+    fwupd_remote_set_agreement;
   local: *;
 } LIBFWUPD_1.0.4;

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -5,6 +5,7 @@ policy/org.freedesktop.fwupd.policy.in
 plugins/dfu/dfu-tool.c
 plugins/synapticsmst/synapticsmst-tool.c
 plugins/uefi/fu-plugin-uefi.c
+src/fu-config.c
 src/fu-debug.c
 src/fu-main.c
 src/fu-progressbar.c


### PR DESCRIPTION
We need to show this agreement text in every fwupd frontend and exporting a
helper function allows us to do two things:

 * Share the semi-complicated code (and fallback) to avoid copy and pasting

 * Easily change the code in the future, for instance allowing merging Metainfo
   and AppStream metadata without updating all the front ends with new logic.