### PR TITLE
Disable -Wunused-function on clang builds (Closes #467)

### DIFF
--- a/libfwupd/fwupd-client.c
+++ b/libfwupd/fwupd-client.c
@@ -110,7 +110,10 @@ fwupd_client_helper_new (void)
 	return helper;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(FwupdClientHelper, fwupd_client_helper_free)
+#pragma clang diagnostic pop
 
 static void
 fwupd_client_set_daemon_version (FwupdClient *client, const gchar *daemon_version)

--- a/meson.build
+++ b/meson.build
@@ -78,6 +78,7 @@ test_args = [
   '-Wnested-externs',
   '-Wno-cast-function-type',
   '-Wno-error=cpp',
+  '-Wno-unknown-pragmas',
   '-Wno-discarded-qualifiers',
   '-Wno-missing-field-initializers',
   '-Wno-strict-aliasing',

--- a/meson.build
+++ b/meson.build
@@ -76,7 +76,6 @@ test_args = [
   '-Wmissing-parameter-type',
   '-Wmissing-prototypes',
   '-Wnested-externs',
-  '-Wno-cast-function-type',
   '-Wno-error=cpp',
   '-Wno-unknown-pragmas',
   '-Wno-discarded-qualifiers',

--- a/plugins/altos/fu-altos-device.c
+++ b/plugins/altos/fu-altos-device.c
@@ -50,7 +50,10 @@ G_DEFINE_TYPE_WITH_PRIVATE (FuAltosDevice, fu_altos_device, FU_TYPE_USB_DEVICE)
 #define GET_PRIVATE(o) (fu_altos_device_get_instance_private (o))
 
 #ifndef HAVE_GUDEV_232
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevClient, g_object_unref)
+#pragma clang diagnostic pop
 #endif
 
 /**

--- a/plugins/altos/fu-altos-firmware.c
+++ b/plugins/altos/fu-altos-firmware.c
@@ -36,7 +36,10 @@ struct _FuAltosFirmware {
 
 G_DEFINE_TYPE (FuAltosFirmware, fu_altos_firmware, G_TYPE_OBJECT)
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(Elf, elf_end);
+#pragma clang diagnostic pop
 
 GBytes *
 fu_altos_firmware_get_data (FuAltosFirmware *self)

--- a/plugins/amt/fu-plugin-amt.c
+++ b/plugins/amt/fu-plugin-amt.c
@@ -378,7 +378,10 @@ amt_get_provisioning_state (mei_context *mei_cl, guint8 *state, GError **error)
 	return TRUE;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(mei_context, mei_context_free)
+#pragma clang diagnostic pop
 
 static FuDevice *
 fu_plugin_amt_create_device (GError **error)

--- a/plugins/csr/fu-csr-tool.c
+++ b/plugins/csr/fu-csr-tool.c
@@ -47,7 +47,10 @@ fu_csr_tool_private_free (FuCsrToolPrivate *priv)
 		g_ptr_array_unref (priv->cmd_array);
 	g_free (priv);
 }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuCsrToolPrivate, fu_csr_tool_private_free)
+#pragma clang diagnostic pop
 
 typedef gboolean (*FuCsrToolPrivateCb)	(FuCsrToolPrivate	*util,
 					 gchar			**values,

--- a/plugins/dell/fu-dell-smi.c
+++ b/plugins/dell/fu-dell-smi.c
@@ -53,7 +53,10 @@ _dell_smi_obj_free (FuDellSmiObj *obj)
 	g_free(obj);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (FuDellSmiObj, _dell_smi_obj_free);
+#pragma clang diagnostic pop
 
 /* don't actually clear if we're testing */
 gboolean

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -152,7 +152,10 @@ _fwup_resource_iter_free (fwup_resource_iter *iter)
 	fwup_resource_iter_destroy (&iter);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (fwup_resource_iter, _fwup_resource_iter_free);
+#pragma clang diagnostic pop
 
 static guint16
 fu_dell_get_system_id (FuPlugin *plugin)

--- a/plugins/dfu/dfu-tool.c
+++ b/plugins/dfu/dfu-tool.c
@@ -71,7 +71,10 @@ dfu_tool_private_free (DfuToolPrivate *priv)
 		g_ptr_array_unref (priv->cmd_array);
 	g_free (priv);
 }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(DfuToolPrivate, dfu_tool_private_free)
+#pragma clang diagnostic pop
 
 typedef gboolean (*FuUtilPrivateCb)	(DfuToolPrivate	*util,
 					 gchar		**values,

--- a/plugins/synapticsmst/synapticsmst-common.h
+++ b/plugins/synapticsmst/synapticsmst-common.h
@@ -118,6 +118,9 @@ guint8		 synapticsmst_common_enable_remote_control	(SynapticsMSTConnection *conn
 
 guint8		 synapticsmst_common_disable_remote_control	(SynapticsMSTConnection *connection);
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(SynapticsMSTConnection, synapticsmst_common_free)
+#pragma clang diagnostic pop
 
 #endif /* __SYNAPTICSMST_COMMON_H */

--- a/plugins/synapticsmst/synapticsmst-tool.c
+++ b/plugins/synapticsmst/synapticsmst-tool.c
@@ -51,7 +51,10 @@ synapticsmst_tool_private_free (SynapticsMSTToolPrivate *priv)
 	g_free (priv);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(SynapticsMSTToolPrivate, synapticsmst_tool_private_free)
+#pragma clang diagnostic pop
 
 typedef gboolean (*FuUtilPrivateCb)     (SynapticsMSTToolPrivate *util,
 					 gchar			**values,

--- a/plugins/thunderbolt-power/fu-plugin-thunderbolt-power.c
+++ b/plugins/thunderbolt-power/fu-plugin-thunderbolt-power.c
@@ -32,7 +32,10 @@
 #include "fu-device-metadata.h"
 
 #ifndef HAVE_GUDEV_232
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevDevice, g_object_unref)
+#pragma clang diagnostic pop
 #endif
 
 /* empirically measured amount of time for the TBT device to come and go */

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -38,7 +38,10 @@
 #include "fu-thunderbolt-image.h"
 
 #ifndef HAVE_GUDEV_232
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevDevice, g_object_unref)
+#pragma clang diagnostic pop
 #endif
 
 typedef void (*UEventNotify) (FuPlugin	  *plugin,

--- a/plugins/thunderbolt/fu-self-test.c
+++ b/plugins/thunderbolt/fu-self-test.c
@@ -188,8 +188,10 @@ mock_tree_free (MockTree *tree)
 	g_slice_free (MockTree, tree);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (MockTree, mock_tree_free);
-
+#pragma clang diagnostic pop
 
 static GPtrArray *
 mock_tree_init_children (MockTree *node, int *id)
@@ -695,7 +697,10 @@ update_context_free (UpdateContext *ctx)
 	g_free (ctx);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (UpdateContext, update_context_free);
+#pragma clang diagnostic pop
 
 static gboolean
 reattach_tree (gpointer user_data)

--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -120,7 +120,10 @@ _fwup_resource_iter_free (fwup_resource_iter *iter)
 	fwup_resource_iter_destroy (&iter);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(fwup_resource_iter, _fwup_resource_iter_free);
+#pragma clang diagnostic pop
 
 gboolean
 fu_plugin_clear_results (FuPlugin *plugin, FuDevice *device, GError **error)

--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -308,7 +308,6 @@ fu_plugin_uefi_update_splash (GError **error)
 #endif
 	guint32 screen_height = 768;
 	guint32 screen_width = 1024;
-	g_autoptr(fwup_resource_iter) iter = NULL;
 	g_autoptr(GBytes) image_bmp = NULL;
 
 	struct {

--- a/plugins/unifying/lu-context.c
+++ b/plugins/unifying/lu-context.c
@@ -267,7 +267,10 @@ lu_context_remove_device (LuContext *ctx, LuDevice *device)
 }
 
 #ifndef HAVE_GUDEV_232
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevDevice, g_object_unref)
+#pragma clang diagnostic pop
 #endif
 
 static const gchar *
@@ -392,7 +395,10 @@ g_usb_context_replug_helper_free (GUsbContextReplugHelper *replug_helper)
 	g_free (replug_helper);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUsbContextReplugHelper, g_usb_context_replug_helper_free);
+#pragma clang diagnostic pop
 
 gboolean
 lu_context_wait_for_replug (LuContext *ctx,

--- a/plugins/unifying/lu-device-bootloader.h
+++ b/plugins/unifying/lu-device-bootloader.h
@@ -79,7 +79,10 @@ typedef struct __attribute__((packed)) {
 
 LuDeviceBootloaderRequest	*lu_device_bootloader_request_new	(void);
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(LuDeviceBootloaderRequest, g_free);
+#pragma clang diagnostic pop
 
 GPtrArray	*lu_device_bootloader_parse_requests	(LuDevice	*device,
 							 GBytes		*fw,

--- a/plugins/unifying/lu-device.c
+++ b/plugins/unifying/lu-device.c
@@ -935,8 +935,11 @@ lu_device_write_firmware (LuDevice *device, GBytes *fw, GError **error)
 }
 
 #ifndef HAVE_GUDEV_232
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevDevice, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevClient, g_object_unref)
+#pragma clang diagnostic pop
 #endif
 
 static GUdevDevice *

--- a/plugins/unifying/lu-hidpp-msg.h
+++ b/plugins/unifying/lu-hidpp-msg.h
@@ -49,7 +49,10 @@ typedef struct __attribute__((packed)) {
 /* this is specific to fwupd */
 #define LU_HIDPP_MSG_SW_ID		0x07
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(LuHidppMsg, g_free);
+#pragma clang diagnostic pop
 
 LuHidppMsg	*lu_hidpp_msg_new			(void);
 void		 lu_hidpp_msg_copy			(LuHidppMsg	*msg_dst,

--- a/plugins/unifying/lu-tool.c
+++ b/plugins/unifying/lu-tool.c
@@ -47,7 +47,10 @@ lu_tool_private_free (FuLuToolPrivate *priv)
 		g_ptr_array_unref (priv->cmd_array);
 	g_free (priv);
 }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuLuToolPrivate, lu_tool_private_free)
+#pragma clang diagnostic pop
 
 typedef gboolean (*FuLuToolPrivateCb)	(FuLuToolPrivate	*util,
 					 gchar			**values,

--- a/src/fu-common.c
+++ b/src/fu-common.c
@@ -547,7 +547,10 @@ fu_common_spawn_helper_free (FuCommonSpawnHelper *helper)
 	g_free (helper);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuCommonSpawnHelper, fu_common_spawn_helper_free)
+#pragma clang diagnostic pop
 
 /**
  * fu_common_spawn_sync:

--- a/src/fu-history.c
+++ b/src/fu-history.c
@@ -40,7 +40,10 @@ struct _FuHistory
 
 G_DEFINE_TYPE (FuHistory, fu_history, G_TYPE_OBJECT)
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(sqlite3_stmt, sqlite3_finalize);
+#pragma clang diagnostic pop
 
 static FuDevice *
 fu_history_device_from_stmt (sqlite3_stmt *stmt)

--- a/src/fu-keyring-pkcs7.c
+++ b/src/fu-keyring-pkcs7.c
@@ -35,9 +35,12 @@ struct _FuKeyringPkcs7
 
 G_DEFINE_TYPE (FuKeyringPkcs7, fu_keyring_pkcs7, FU_TYPE_KEYRING)
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gnutls_pkcs7_t, gnutls_pkcs7_deinit, NULL)
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gnutls_x509_crt_t, gnutls_x509_crt_deinit, NULL)
 G_DEFINE_AUTO_CLEANUP_FREE_FUNC(gnutls_x509_dn_t, gnutls_x509_dn_deinit, NULL)
+#pragma clang diagnostic pop
 
 static gboolean
 fu_keyring_pkcs7_add_public_key (FuKeyringPkcs7 *self,
@@ -164,7 +167,10 @@ _gnutls_datum_deinit (gnutls_datum_t *d)
 	gnutls_free (d);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(gnutls_datum_t, _gnutls_datum_deinit)
+#pragma clang diagnostic pop
 
 static gchar *
 fu_keyring_pkcs7_datum_to_dn_str (const gnutls_datum_t *raw)

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -670,7 +670,7 @@ fu_main_daemon_method_call (GDBusConnection *connection, const gchar *sender,
 		/* authenticate */
 		fu_main_set_status (priv, FWUPD_STATUS_WAITING_FOR_AUTH);
 		subject = polkit_system_bus_name_new (sender);
-		polkit_authority_check_authorization (helper->priv->authority, subject,
+		polkit_authority_check_authorization (priv->authority, subject,
 						      "org.freedesktop.fwupd.modify-remote",
 						      NULL,
 						      POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
@@ -701,7 +701,7 @@ fu_main_daemon_method_call (GDBusConnection *connection, const gchar *sender,
 		/* authenticate */
 		fu_main_set_status (priv, FWUPD_STATUS_WAITING_FOR_AUTH);
 		subject = polkit_system_bus_name_new (sender);
-		polkit_authority_check_authorization (helper->priv->authority, subject,
+		polkit_authority_check_authorization (priv->authority, subject,
 						      "org.freedesktop.fwupd.verify-update",
 						      NULL,
 						      POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -40,8 +40,11 @@
 #include "fu-engine.h"
 
 #ifndef HAVE_POLKIT_0_114
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(PolkitAuthorizationResult, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(PolkitSubject, g_object_unref)
+#pragma clang diagnostic pop
 #endif
 
 typedef struct {
@@ -268,7 +271,10 @@ fu_main_auth_helper_free (FuMainAuthHelper *helper)
 	g_free (helper);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuMainAuthHelper, fu_main_auth_helper_free)
+#pragma clang diagnostic pop
 
 /* error may or may not already have been set */
 static gboolean
@@ -1023,7 +1029,10 @@ fu_main_private_free (FuMainPrivate *priv)
 	g_free (priv);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuMainPrivate, fu_main_private_free)
+#pragma clang diagnostic pop
 
 int
 main (int argc, char *argv[])

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -2209,7 +2209,10 @@ fu_util_private_free (FuUtilPrivate *priv)
 	g_free (priv);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(FuUtilPrivate, fu_util_private_free)
+#pragma clang diagnostic pop
 
 int
 main (int argc, char *argv[])

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -466,7 +466,7 @@ fu_util_perhaps_show_unreported (FuUtilPrivate *priv, GError **error)
 static gboolean
 fu_util_modify_remote_warning (FuUtilPrivate *priv, FwupdRemote *remote, GError **error)
 {
-	g_autofree gchar *warning_markup = NULL;
+	const gchar *warning_markup = NULL;
 	g_autofree gchar *warning_plain = NULL;
 
 	/* get formatted text */


### PR DESCRIPTION
GLib creates two static inline functions for paramaters that may
not be used that set off warnings in clang but not gcc.

Ignore these on clang builds.