### PR TITLE
trivial: Compile upower and test plugins with -O0 (Closes: #472)

### DIFF
--- a/plugins/test/meson.build
+++ b/plugins/test/meson.build
@@ -1,4 +1,8 @@
-cargs = ['-DG_LOG_DOMAIN="FuPluginTest"']
+# See https://github.com/hughsie/fwupd/issues/472
+# for more details why this is compiled with -O0
+# revert it after conclusion to
+# https://bugs.launchpad.net/fwupd/+bug/D1765134
+cargs = ['-DG_LOG_DOMAIN="FuPluginTest"','-O0']
 
 install_dummy = false
 if get_option('plugin_dummy')

--- a/plugins/upower/meson.build
+++ b/plugins/upower/meson.build
@@ -1,4 +1,8 @@
-cargs = ['-DG_LOG_DOMAIN="FuPluginUpower"']
+# See https://github.com/hughsie/fwupd/issues/472
+# for more details why this is compiled with -O0
+# revert it after conclusion to
+# https://bugs.launchpad.net/fwupd/+bug/1765134
+cargs = ['-DG_LOG_DOMAIN="FuPluginUpower"','-O0']
 
 shared_module('fu_plugin_upower',
   sources : [


### PR DESCRIPTION
This is a workaround for what looks like a compiler bug introduced
in Debian and Ubuntu gcc-7.

After the compiler bug is sorted in Debian testing it should be
reverted.