### PR TITLE
Wip/superm1/revert debian workaround

### DIFF
--- a/contrib/debian/fwupd-tests.install
+++ b/contrib/debian/fwupd-tests.install
@@ -4,3 +4,4 @@
 #https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=872458
 usr/share/installed-tests/*
 usr/lib/*/fwupd-plugins-3/libfu_plugin_test.so
+debian/lintian/fwupd-tests usr/share/lintian/overrides

--- a/contrib/debian/lintian/fwupd
+++ b/contrib/debian/lintian/fwupd
@@ -2,3 +2,5 @@
 fwupd binary: systemd-service-file-missing-install-key lib/systemd/system/fwupd-offline-update.service
 fwupd binary: systemd-service-file-missing-install-key lib/systemd/system/fwupd.service
 fwupd binary: systemd-service-file-missing-install-key lib/systemd/system/system-update.target.wants/fwupd-offline-update.service
+#see debian bug 896012
+fwupd: library-not-linked-against-libc usr/lib/*/fwupd-plugins-3/libfu_plugin_upower.so

--- a/contrib/debian/lintian/fwupd-tests
+++ b/contrib/debian/lintian/fwupd-tests
@@ -1,0 +1,2 @@
+#see debian bug 896012
+fwupd-tests: library-not-linked-against-libc usr/lib/*/fwupd-plugins-3/libfu_plugin_test.so

--- a/plugins/amt/fu-plugin-amt.c
+++ b/plugins/amt/fu-plugin-amt.c
@@ -26,6 +26,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/mei.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <uuid.h>
 

--- a/plugins/test/meson.build
+++ b/plugins/test/meson.build
@@ -1,8 +1,4 @@
-# See https://github.com/hughsie/fwupd/issues/472
-# for more details why this is compiled with -O0
-# revert it after conclusion to
-# https://bugs.launchpad.net/fwupd/+bug/D1765134
-cargs = ['-DG_LOG_DOMAIN="FuPluginTest"','-O0']
+cargs = ['-DG_LOG_DOMAIN="FuPluginTest"']
 
 install_dummy = false
 if get_option('plugin_dummy')

--- a/plugins/upower/meson.build
+++ b/plugins/upower/meson.build
@@ -1,8 +1,4 @@
-# See https://github.com/hughsie/fwupd/issues/472
-# for more details why this is compiled with -O0
-# revert it after conclusion to
-# https://bugs.launchpad.net/fwupd/+bug/1765134
-cargs = ['-DG_LOG_DOMAIN="FuPluginUpower"','-O0']
+cargs = ['-DG_LOG_DOMAIN="FuPluginUpower"']
 
 shared_module('fu_plugin_upower',
   sources : [


### PR DESCRIPTION
There was some discussion and conclusions in the debian bug that the lintian output is indeed the problem, the library shouldn't be linked with libc (linker flags changed causing this to happen).

So revert that workaround and add a linitian override.