### PR TITLE
uefi: Match the bootdir argument to fill in uefi.conf by default

### DIFF
--- a/plugins/uefi/meson.build
+++ b/plugins/uefi/meson.build
@@ -1,9 +1,5 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginUefi"']
 
-install_data(['uefi.conf'],
-  install_dir : join_paths(sysconfdir, 'fwupd')
-)
-
 shared_module('fu_plugin_uefi',
   sources : [
     'fu-plugin-uefi.c',
@@ -21,3 +17,16 @@ shared_module('fu_plugin_uefi',
     fwup,
   ],
 )
+
+con2 = configuration_data()
+con2.set('bootdir', get_option('bootdir'))
+
+# replace @bootdir@
+configure_file(
+  input : 'uefi.conf.in',
+  output : 'uefi.conf',
+  configuration : con2,
+  install: true,
+  install_dir : join_paths(sysconfdir, 'fwupd')
+)
+

--- a/plugins/uefi/uefi.conf.in
+++ b/plugins/uefi/uefi.conf.in
@@ -2,4 +2,4 @@
 
 # For fwupdate 10+ allow overriding
 # the compiled EFI system partition path
-#OverrideESPMountPoint=
+#OverrideESPMountPoint=@bootdir@


### PR DESCRIPTION
This will make it more obvious which path it's defaulting to