### PR TITLE
Add fwupd_device_get_id_parent()

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -12,6 +12,7 @@ _fwupdmgr_cmd_list=(
 	'get-releases'
 	'get-remotes'
 	'get-results'
+	'get-topology'
 	'get-updates'
 	'hwids'
 	'install'

--- a/libfwupd/fwupd-device.c
+++ b/libfwupd/fwupd-device.c
@@ -44,6 +44,7 @@ static void fwupd_device_finalize	 (GObject *object);
 
 typedef struct {
 	gchar				*id;
+	gchar				*parent_id;
 	guint64				 created;
 	guint64				 modified;
 	guint64				 flags;
@@ -65,6 +66,7 @@ typedef struct {
 	FwupdUpdateState		 update_state;
 	gchar				*update_error;
 	GPtrArray			*releases;
+	FwupdDevice			*parent;
 } FwupdDevicePrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE (FwupdDevice, fwupd_device, G_TYPE_OBJECT)
@@ -181,6 +183,77 @@ fwupd_device_set_id (FwupdDevice *device, const gchar *id)
 	g_return_if_fail (FWUPD_IS_DEVICE (device));
 	g_free (priv->id);
 	priv->id = g_strdup (id);
+}
+
+/**
+ * fwupd_device_get_parent_id:
+ * @device: A #FwupdDevice
+ *
+ * Gets the ID.
+ *
+ * Returns: the parent ID, or %NULL if unset
+ *
+ * Since: 1.0.8
+ **/
+const gchar *
+fwupd_device_get_parent_id (FwupdDevice *device)
+{
+	FwupdDevicePrivate *priv = GET_PRIVATE (device);
+	g_return_val_if_fail (FWUPD_IS_DEVICE (device), NULL);
+	return priv->parent_id;
+}
+
+/**
+ * fwupd_device_set_parent_id:
+ * @device: A #FwupdDevice
+ * @parent_id: the device ID, e.g. `USB:foo`
+ *
+ * Sets the parent ID.
+ *
+ * Since: 1.0.8
+ **/
+void
+fwupd_device_set_parent_id (FwupdDevice *device, const gchar *parent_id)
+{
+	FwupdDevicePrivate *priv = GET_PRIVATE (device);
+	g_return_if_fail (FWUPD_IS_DEVICE (device));
+	g_free (priv->parent_id);
+	priv->parent_id = g_strdup (parent_id);
+}
+
+/**
+ * fwupd_device_get_parent:
+ * @device: A #FwupdDevice
+ *
+ * Gets the parent.
+ *
+ * Returns: (transfer none): the parent device, or %NULL if unset
+ *
+ * Since: 1.0.8
+ **/
+FwupdDevice *
+fwupd_device_get_parent (FwupdDevice *device)
+{
+	FwupdDevicePrivate *priv = GET_PRIVATE (device);
+	g_return_val_if_fail (FWUPD_IS_DEVICE (device), NULL);
+	return priv->parent;
+}
+
+/**
+ * fwupd_device_set_parent:
+ * @device: A #FwupdDevice
+ * @parent: another #FwupdDevice, or %NULL
+ *
+ * Sets the parent. Only used internally.
+ *
+ * Since: 1.0.8
+ **/
+void
+fwupd_device_set_parent (FwupdDevice *device, FwupdDevice *parent)
+{
+	FwupdDevicePrivate *priv = GET_PRIVATE (device);
+	g_return_if_fail (FWUPD_IS_DEVICE (device));
+	g_set_object (&priv->parent, parent);
 }
 
 /**
@@ -825,6 +898,11 @@ fwupd_device_to_variant (FwupdDevice *device)
 				       FWUPD_RESULT_KEY_DEVICE_ID,
 				       g_variant_new_string (priv->id));
 	}
+	if (priv->parent_id != NULL) {
+		g_variant_builder_add (&builder, "{sv}",
+				       FWUPD_RESULT_KEY_PARENT_DEVICE_ID,
+				       g_variant_new_string (priv->parent_id));
+	}
 	if (priv->guids->len > 0) {
 		const gchar * const *tmp = (const gchar * const *) priv->guids->pdata;
 		g_variant_builder_add (&builder, "{sv}",
@@ -960,6 +1038,10 @@ fwupd_device_from_key_value (FwupdDevice *device, const gchar *key, GVariant *va
 	}
 	if (g_strcmp0 (key, FWUPD_RESULT_KEY_DEVICE_ID) == 0) {
 		fwupd_device_set_id (device, g_variant_get_string (value, NULL));
+		return;
+	}
+	if (g_strcmp0 (key, FWUPD_RESULT_KEY_PARENT_DEVICE_ID) == 0) {
+		fwupd_device_set_parent_id (device, g_variant_get_string (value, NULL));
 		return;
 	}
 	if (g_strcmp0 (key, FWUPD_RESULT_KEY_FLAGS) == 0) {
@@ -1260,6 +1342,7 @@ fwupd_device_to_string (FwupdDevice *device)
 	else
 		str = g_string_append (str, "Unknown Device\n");
 	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_DEVICE_ID, priv->id);
+	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_PARENT_DEVICE_ID, priv->parent_id);
 	for (guint i = 0; i < priv->guids->len; i++) {
 		const gchar *guid = g_ptr_array_index (priv->guids, i);
 		fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_GUID, guid);
@@ -1327,8 +1410,11 @@ fwupd_device_finalize (GObject *object)
 	FwupdDevice *device = FWUPD_DEVICE (object);
 	FwupdDevicePrivate *priv = GET_PRIVATE (device);
 
+	if (priv->parent != NULL)
+		g_object_unref (priv->parent);
 	g_free (priv->description);
 	g_free (priv->id);
+	g_free (priv->parent_id);
 	g_free (priv->name);
 	g_free (priv->summary);
 	g_free (priv->vendor);

--- a/libfwupd/fwupd-device.h
+++ b/libfwupd/fwupd-device.h
@@ -51,6 +51,12 @@ gchar		*fwupd_device_to_string			(FwupdDevice	*device);
 const gchar	*fwupd_device_get_id			(FwupdDevice	*device);
 void		 fwupd_device_set_id			(FwupdDevice	*device,
 							 const gchar	*id);
+const gchar	*fwupd_device_get_parent_id		(FwupdDevice	*device);
+void		 fwupd_device_set_parent_id		(FwupdDevice	*device,
+							 const gchar	*parent_id);
+FwupdDevice	*fwupd_device_get_parent		(FwupdDevice	*device);
+void		 fwupd_device_set_parent		(FwupdDevice	*device,
+							 FwupdDevice	*parent);
 const gchar	*fwupd_device_get_name			(FwupdDevice	*device);
 void		 fwupd_device_set_name			(FwupdDevice	*device,
 							 const gchar	*name);

--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -27,6 +27,7 @@
 #define FWUPD_RESULT_KEY_CREATED		"Created"	/* t */
 #define FWUPD_RESULT_KEY_DESCRIPTION		"Description"	/* s */
 #define FWUPD_RESULT_KEY_DEVICE_ID		"DeviceId"	/* s */
+#define FWUPD_RESULT_KEY_PARENT_DEVICE_ID	"ParentDeviceId"/* s */
 #define FWUPD_RESULT_KEY_FILENAME		"Filename"	/* s */
 #define FWUPD_RESULT_KEY_FLAGS			"Flags"		/* t */
 #define FWUPD_RESULT_KEY_FLASHES_LEFT		"FlashesLeft"	/* u */

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -243,3 +243,12 @@ LIBFWUPD_1.0.7 {
     fwupd_remote_set_agreement;
   local: *;
 } LIBFWUPD_1.0.4;
+
+LIBFWUPD_1.0.8 {
+  global:
+    fwupd_device_get_parent;
+    fwupd_device_get_parent_id;
+    fwupd_device_set_parent;
+    fwupd_device_set_parent_id;
+  local: *;
+} LIBFWUPD_1.0.7;

--- a/plugins/amt/fu-plugin-amt.c
+++ b/plugins/amt/fu-plugin-amt.c
@@ -435,6 +435,7 @@ fu_plugin_amt_create_device (GError **error)
 	fu_device_set_vendor (dev, "Intel Corporation");
 	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_icon (dev, "computer");
+	fu_device_add_parent_guid (dev, "main-system-firmware");
 	if (!amt_get_provisioning_state (ctx, &state, error))
 		return NULL;
 	switch (state) {

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -763,6 +763,7 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 		fu_device_add_flag (dev_alt, FWUPD_DEVICE_FLAG_LOCKED);
 		fu_device_add_icon (dev_alt, "computer");
 		fu_device_set_alternate (dev_alt, dev);
+		fu_device_add_parent_guid (dev_alt, tpm_guid);
 
 		/* If TPM is not owned and at least 1 flash left allow mode switching
 		 *

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -56,7 +56,7 @@
 
 typedef struct _DOCK_DESCRIPTION
 {
-	const efi_guid_t	guid;
+	const gchar *		guid;
 	const gchar *		query;
 	const gchar *		desc;
 } DOCK_DESCRIPTION;
@@ -72,15 +72,15 @@ typedef struct _DOCK_DESCRIPTION
 #define TBT_CBL_STR		"2 2 2 3 0"
 
 /* supported dock related GUIDs */
-#define DOCK_FLASH_GUID		EFI_GUID (0xE7CA1F36, 0xBF73, 0x4574, 0xAFE6, 0xA4, 0xCC, 0xAC, 0xAB, 0xF4, 0x79)
-#define WD15_EC_GUID		EFI_GUID (0xE8445370, 0x0211, 0x449D, 0x9FAA, 0x10, 0x79, 0x06, 0xAB, 0x18, 0x9F)
-#define TB16_EC_GUID		EFI_GUID (0x33CC8870, 0xB1FC, 0x4EC7, 0x948A, 0xC0, 0x74, 0x96, 0x87, 0x4F, 0xAF)
-#define TB16_PC2_GUID		EFI_GUID (0x1B52C630, 0x86F6, 0x4AEE, 0x9F0C, 0x47, 0x4D, 0xC6, 0xBE, 0x49, 0xB6)
-#define TB16_PC1_GUID		EFI_GUID (0x8FE183DA, 0xC94E, 0x4804, 0xB319, 0x0F, 0x1B, 0xA5, 0x45, 0x7A, 0x69)
-#define WD15_PC1_GUID		EFI_GUID (0x8BA2B709, 0x6F97, 0x47FC, 0xB7E7, 0x6A, 0x87, 0xB5, 0x78, 0xFE, 0x25)
-#define LEGACY_CBL_GUID		EFI_GUID (0xFECE1537, 0xD683, 0x4EA8, 0xB968, 0x15, 0x45, 0x30, 0xBB, 0x6F, 0x73)
-#define UNIV_CBL_GUID		EFI_GUID (0xE2BF3AAD, 0x61A3, 0x44BF, 0x91EF, 0x34, 0x9B, 0x39, 0x51, 0x5D, 0x29)
-#define TBT_CBL_GUID		EFI_GUID (0x6DC832FC, 0x5BB0, 0x4E63, 0xA2FF, 0x02, 0xAA, 0xBA, 0x5B, 0xC1, 0xDC)
+#define DOCK_FLASH_GUID		"e7ca1f36-bf73-4574-afe6-a4ccacabf479"
+#define WD15_EC_GUID		"e8445370-0211-449d-9faa-107906ab189f"
+#define TB16_EC_GUID		"33cc8870-b1fc-4ec7-948a-c07496874faf"
+#define TB16_PC2_GUID		"1b52c630-86f6-4aee-9f0c-474dc6be49b6"
+#define TB16_PC1_GUID		"8fe183da-c94e-4804-b319-0f1ba5457a69"
+#define WD15_PC1_GUID		"8ba2b709-6f97-47fc-b7e7-6a87b578fe25"
+#define LEGACY_CBL_GUID		"fece1537-d683-4ea8-b968-154530bb6f73"
+#define UNIV_CBL_GUID		"e2bf3aad-61a3-44bf-91ef-349b39515d29"
+#define TBT_CBL_GUID		"6dc832fc-5bb0-4e63-a2ff-02aaba5bc1dc"
 
 #define EC_DESC			"EC"
 #define PC1_DESC		"Port Controller 1"
@@ -238,7 +238,7 @@ fu_dell_supported (FuPlugin *plugin)
 
 static gboolean
 fu_plugin_dell_match_dock_component (const gchar *query_str,
-				     efi_guid_t *guid_out,
+				     const gchar **guid_out,
 				     const gchar **name_out)
 {
 	const DOCK_DESCRIPTION list[] = {
@@ -255,7 +255,7 @@ fu_plugin_dell_match_dock_component (const gchar *query_str,
 	for (guint i = 0; i < G_N_ELEMENTS (list); i++) {
 		if (g_strcmp0 (query_str,
 			       list[i].query) == 0) {
-			memcpy (guid_out, &list[i].guid, sizeof (efi_guid_t));
+			*guid_out = list[i].guid;
 			*name_out = list[i].desc;
 			return TRUE;
 		}
@@ -325,12 +325,11 @@ fu_plugin_dell_capsule_supported (FuPlugin *plugin)
 
 static gboolean
 fu_plugin_dock_node (FuPlugin *plugin, GUsbDevice *device,
-		     guint8 type, const efi_guid_t *guid_raw,
+		     guint8 type, const gchar *component_guid,
 		     const gchar *component_desc, const gchar *version)
 {
 	const gchar *dock_type;
 	g_autofree gchar *dock_id = NULL;
-	g_autofree gchar *guid_str = NULL;
 	g_autofree gchar *dock_key = NULL;
 	g_autofree gchar *dock_name = NULL;
 	g_autoptr(FuDevice) dev = NULL;
@@ -341,23 +340,21 @@ fu_plugin_dock_node (FuPlugin *plugin, GUsbDevice *device,
 		return FALSE;
 	}
 
-	guid_str = g_strdup ("00000000-0000-0000-0000-000000000000");
-	if (efi_guid_to_str (guid_raw, &guid_str) < 0) {
-		g_debug ("Failed to convert GUID.");
-		return FALSE;
-	}
-
-	dock_key = fu_plugin_get_dock_key (plugin, device,
-						  guid_str);
+	dock_key = fu_plugin_get_dock_key (plugin, device, component_guid);
 	if (fu_plugin_cache_lookup (plugin, dock_key) != NULL) {
 		g_debug ("%s is already registered.", dock_key);
 		return FALSE;
 	}
 
 	dev = fu_device_new ();
-	dock_id = g_strdup_printf ("DELL-%s" G_GUINT64_FORMAT, guid_str);
-	dock_name = g_strdup_printf ("Dell %s %s", dock_type,
-				     component_desc);
+	dock_id = g_strdup_printf ("DELL-%s" G_GUINT64_FORMAT, component_guid);
+	if (component_desc != NULL) {
+		dock_name = g_strdup_printf ("Dell %s %s", dock_type,
+					     component_desc);
+		fu_device_add_parent_guid (dev, DOCK_FLASH_GUID);
+	} else {
+		dock_name = g_strdup_printf ("Dell %s", dock_type);
+	}
 	fu_device_set_id (dev, dock_id);
 	fu_device_set_vendor (dev, "Dell Inc.");
 	fu_device_set_name (dev, dock_name);
@@ -368,7 +365,7 @@ fu_plugin_dock_node (FuPlugin *plugin, GUsbDevice *device,
 		fu_device_set_summary (dev, "A USB type-C docking station");
 	}
 	fu_device_add_icon (dev, "computer");
-	fu_device_add_guid (dev, guid_str);
+	fu_device_add_guid (dev, component_guid);
 	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	if (version != NULL) {
 		fu_device_set_version (dev, version);
@@ -394,12 +391,12 @@ fu_plugin_dell_device_added_cb (GUsbContext *ctx,
 	guint16 pid;
 	guint16 vid;
 	const gchar *query_str;
+	const gchar *component_guid = NULL;
 	const gchar *component_name = NULL;
 	DOCK_UNION buf;
 	DOCK_INFO *dock_info;
-	efi_guid_t guid_raw;
-	efi_guid_t tmpguid;
 	gboolean old_ec = FALSE;
+	g_autofree gchar *flash_ver_str = NULL;
 
 	/* don't look up immediately if a dock is connected as that would
 	   mean a SMI on every USB device that showed up on the system */
@@ -454,7 +451,7 @@ fu_plugin_dell_device_added_cb (GUsbContext *ctx,
 			return;
 		}
 		if (!fu_plugin_dell_match_dock_component (query_str + 6,
-							  &guid_raw,
+							  &component_guid,
 							  &component_name)) {
 			g_debug ("Unable to match dock component %s",
 				query_str);
@@ -479,7 +476,7 @@ fu_plugin_dell_device_added_cb (GUsbContext *ctx,
 		if (!fu_plugin_dock_node (plugin,
 						 device,
 						 buf.record->dock_info_header.dock_type,
-						 &guid_raw,
+						 component_guid,
 						 component_name,
 						 fw_str)) {
 			g_debug ("Failed to create %s", component_name);
@@ -488,20 +485,17 @@ fu_plugin_dell_device_added_cb (GUsbContext *ctx,
 	}
 
 	/* if an old EC or invalid EC version found, create updatable parent */
-	if (old_ec) {
-		g_autofree gchar *fw_str = NULL;
-		tmpguid = DOCK_FLASH_GUID;
-		fw_str = as_utils_version_from_uint32 (dock_info->flash_pkg_version,
-						       parse_flags);
-		if (!fu_plugin_dock_node (plugin,
-						 device,
-						 buf.record->dock_info_header.dock_type,
-						 &tmpguid,
-						 "",
-						 fw_str)) {
-			g_debug ("Failed to create top dock node");
-			return;
-		}
+	if (old_ec)
+		flash_ver_str = as_utils_version_from_uint32 (dock_info->flash_pkg_version,
+							      parse_flags);
+	if (!fu_plugin_dock_node (plugin,
+				  device,
+				  buf.record->dock_info_header.dock_type,
+				  DOCK_FLASH_GUID,
+				  NULL,
+				  flash_ver_str)) {
+		g_debug ("Failed to create top dock node");
+		return;
 	}
 
 #if defined (HAVE_SYNAPTICS)
@@ -515,11 +509,10 @@ fu_plugin_dell_device_removed_cb (GUsbContext *ctx,
 				  FuPlugin *plugin)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
-	const efi_guid_t guids[] = { WD15_EC_GUID, TB16_EC_GUID, TB16_PC2_GUID,
-				     TB16_PC1_GUID, WD15_PC1_GUID,
-				     LEGACY_CBL_GUID, UNIV_CBL_GUID,
-				     TBT_CBL_GUID, DOCK_FLASH_GUID};
-	const efi_guid_t *guid_raw;
+	const gchar *guids[] = { WD15_EC_GUID, TB16_EC_GUID, TB16_PC2_GUID,
+				 TB16_PC1_GUID, WD15_PC1_GUID,
+				 LEGACY_CBL_GUID, UNIV_CBL_GUID,
+				 TBT_CBL_GUID, DOCK_FLASH_GUID};
 	guint16 pid;
 	guint16 vid;
 	FuDevice *dev = NULL;
@@ -539,12 +532,8 @@ fu_plugin_dell_device_removed_cb (GUsbContext *ctx,
 	/* remove any components already in database? */
 	for (guint i = 0; i < G_N_ELEMENTS (guids); i++) {
 		g_autofree gchar *dock_key = NULL;
-		g_autofree gchar *guid_str = NULL;
-		guid_raw = &guids[i];
-		guid_str = g_strdup ("00000000-0000-0000-0000-000000000000");
-		efi_guid_to_str (guid_raw, &guid_str);
 		dock_key = fu_plugin_get_dock_key (plugin, device,
-							  guid_str);
+							  guids[i]);
 		dev = fu_plugin_cache_lookup (plugin, dock_key);
 		if (dev != NULL) {
 			fu_plugin_device_remove (plugin,

--- a/plugins/synapticsmst/fu-plugin-synapticsmst.c
+++ b/plugins/synapticsmst/fu-plugin-synapticsmst.c
@@ -31,6 +31,7 @@
 #define SYNAPTICS_FLASH_MODE_DELAY 3
 
 #define HWID_DELL_INC	"85d38fda-fc0e-5c6f-808f-076984ae7978"
+#define DELL_DOCK_FLASH_GUID	"e7ca1f36-bf73-4574-afe6-a4ccacabf479"
 
 struct FuPluginData {
 	gchar		*dock_type;
@@ -139,6 +140,10 @@ fu_plugin_synaptics_add_device (FuPlugin *plugin,
 	fu_device_add_icon (dev, "computer");
 	fu_device_set_version (dev, synapticsmst_device_get_version (device));
 	fu_device_add_guid (dev, guid_str);
+
+	/* Currently recognizes TB16/WD15 */
+	if (data->dock_type != NULL)
+		fu_device_add_parent_guid (dev, DELL_DOCK_FLASH_GUID);
 
 	fu_plugin_device_add (plugin, dev);
 	fu_plugin_cache_add (plugin, dev_id_str, dev);

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -36,6 +36,7 @@
 #include "fu-plugin-vfuncs.h"
 #include "fu-device-metadata.h"
 #include "fu-thunderbolt-image.h"
+#include "fu-thunderbolt-known-devices.h"
 
 #ifndef HAVE_GUDEV_232
 #pragma clang diagnostic push
@@ -222,6 +223,23 @@ fu_plugin_thunderbolt_parse_version (const gchar *version_raw)
 }
 
 static void
+fu_plugin_thunderbolt_add_known_parents (FuDevice *device, guint16 vid, guint16 did)
+{
+	const gchar *parent = NULL;
+
+	if (vid == THUNDERBOLT_VENDOR_DELL) {
+		if (did == THUNDERBOLT_DEVICE_DELL_TB16_CABLE ||
+		    did == THUNDERBOLT_DEVICE_DELL_TB16_DOCK)
+			parent = PARENT_GUID_DELL_TB16;
+	}
+
+	if (parent != NULL ) {
+		fu_device_add_parent_guid (device, parent);
+		g_debug ("Add known parent %s to %u:%u", parent, vid, did);
+	}
+}
+
+static void
 fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 {
 	FuDevice *dev_tmp;
@@ -316,6 +334,7 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 					     (guint) did,
 					     is_native ? "-native" : "");
 		fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_UPDATABLE);
+		fu_plugin_thunderbolt_add_known_parents (dev, vid, did);
 	}
 
 	fu_device_set_platform_id (dev, uuid);

--- a/plugins/thunderbolt/fu-thunderbolt-known-devices.h
+++ b/plugins/thunderbolt/fu-thunderbolt-known-devices.h
@@ -1,0 +1,32 @@
+/* -*- mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2018 Dell Inc.
+ *
+ * Licensed under the GNU General Public License Version 2
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef __FU_THUNDERBOLT_KNOWN_DEVICES_H__
+#define __FU_THUNDERBOLT_KNOWN_DEVICES_H__
+
+#define THUNDERBOLT_VENDOR_DELL			0x00d4
+
+/* Dell TB16 dock */
+#define THUNDERBOLT_DEVICE_DELL_TB16_CABLE	0xb051
+#define THUNDERBOLT_DEVICE_DELL_TB16_DOCK	0xb054
+#define PARENT_GUID_DELL_TB16			"e7ca1f36-bf73-4574-afe6-a4ccacabf479"
+
+#endif /* __FU_THUNDERBOLT_KNOWN_DEVICES_H__ */

--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -589,6 +589,7 @@ fu_plugin_uefi_coldplug_resource (FuPlugin *plugin, fwup_resource *re)
 	} else {
 		/* this is probably system firmware */
 		fu_device_add_icon (dev, "computer");
+		fu_device_add_guid (dev, "main-system-firmware");
 	}
 	fu_device_set_id (dev, id);
 	fu_device_add_guid (dev, guid);

--- a/plugins/unifying/lu-device-peripheral.c
+++ b/plugins/unifying/lu-device-peripheral.c
@@ -795,4 +795,5 @@ lu_device_peripheral_class_init (LuDevicePeripheralClass *klass)
 static void
 lu_device_peripheral_init (LuDevicePeripheral *self)
 {
+	fu_device_add_parent_guid (FU_DEVICE (self), "USB\\VID_046D&PID_C52B");
 }

--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -25,6 +25,7 @@
 #include <string.h>
 
 #include "fu-device-list.h"
+#include "fu-device-private.h"
 
 #include "fwupd-error.h"
 

--- a/src/fu-device-private.h
+++ b/src/fu-device-private.h
@@ -26,6 +26,10 @@
 
 G_BEGIN_DECLS
 
+GPtrArray	*fu_device_get_parent_guids		(FuDevice	*device);
+gboolean	 fu_device_has_parent_guid		(FuDevice	*device,
+							 const gchar	*guid);
+
 G_END_DECLS
 
 #endif /* __FU_DEVICE_PRIVATE_H */

--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
  *
- * Copyright (C) 2015-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015-2018 Richard Hughes <richard@hughsie.com>
  *
  * Licensed under the GNU General Public License Version 2
  *
@@ -109,6 +109,12 @@ void		 fu_device_add_guid			(FuDevice	*device,
 FuDevice	*fu_device_get_alternate		(FuDevice	*device);
 void		 fu_device_set_alternate		(FuDevice	*device,
 							 FuDevice	*alternate);
+FuDevice	*fu_device_get_parent			(FuDevice	*device);
+GPtrArray	*fu_device_get_children			(FuDevice	*device);
+void		 fu_device_add_child			(FuDevice	*device,
+							 FuDevice	*child);
+void		 fu_device_add_parent_guid		(FuDevice	*device,
+							 const gchar	*guid);
 const gchar	*fu_device_get_metadata			(FuDevice	*device,
 							 const gchar	*key);
 gboolean	 fu_device_get_metadata_boolean		(FuDevice	*device,

--- a/src/fu-plugin.c
+++ b/src/fu-plugin.c
@@ -344,6 +344,8 @@ fu_plugin_open (FuPlugin *plugin, const gchar *filename, GError **error)
 void
 fu_plugin_device_add (FuPlugin *plugin, FuDevice *device)
 {
+	GPtrArray *children;
+
 	g_return_if_fail (FU_IS_PLUGIN (plugin));
 	g_return_if_fail (FU_IS_DEVICE (device));
 
@@ -353,6 +355,13 @@ fu_plugin_device_add (FuPlugin *plugin, FuDevice *device)
 	fu_device_set_created (device, (guint64) g_get_real_time () / G_USEC_PER_SEC);
 	fu_device_set_plugin (device, fu_plugin_get_name (plugin));
 	g_signal_emit (plugin, signals[SIGNAL_DEVICE_ADDED], 0, device);
+
+	/* add children */
+	children = fu_device_get_children (device);
+	for (guint i = 0; i < children->len; i++) {
+		FuDevice *child = g_ptr_array_index (children, i);
+		fu_plugin_device_add (plugin, child);
+	}
 }
 
 /**

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -167,6 +167,38 @@ fu_engine_requirements_device_func (void)
 }
 
 static void
+fu_engine_device_parent_func (void)
+{
+	g_autoptr(FuDevice) device1 = fu_device_new ();
+	g_autoptr(FuDevice) device2 = fu_device_new ();
+	g_autoptr(FuDevice) device3 = fu_device_new ();
+	g_autoptr(FuEngine) engine = fu_engine_new ();
+
+	/* add child */
+	fu_device_set_id (device1, "child");
+	fu_device_add_guid (device1, "child-GUID-1");
+	fu_device_add_parent_guid (device1, "parent-GUID");
+	fu_engine_add_device (engine, device1);
+
+	/* parent */
+	fu_device_set_id (device2, "parent");
+	fu_device_add_guid (device2, "parent-GUID");
+
+	/* add another child */
+	fu_device_set_id (device3, "child2");
+	fu_device_add_guid (device3, "child-GUID-2");
+	fu_device_add_parent_guid (device3, "parent-GUID");
+	fu_device_add_child (device2, device3);
+
+	/* add two together */
+	fu_engine_add_device (engine, device2);
+
+	/* verify both children were adopted */
+	g_assert (fu_device_get_parent (device3) == device2);
+	g_assert (fu_device_get_parent (device1) == device2);
+}
+
+static void
 fu_engine_partial_hash_func (void)
 {
 	gboolean ret;
@@ -2122,6 +2154,7 @@ main (int argc, char **argv)
 	g_test_add_func ("/fwupd/engine{requirements-missing}", fu_engine_requirements_missing_func);
 	g_test_add_func ("/fwupd/engine{requirements-unsupported}", fu_engine_requirements_unsupported_func);
 	g_test_add_func ("/fwupd/engine{requirements-device}", fu_engine_requirements_device_func);
+	g_test_add_func ("/fwupd/engine{device-auto-parent}", fu_engine_device_parent_func);
 	g_test_add_func ("/fwupd/hwids", fu_hwids_func);
 	g_test_add_func ("/fwupd/smbios", fu_smbios_func);
 	g_test_add_func ("/fwupd/smbios3", fu_smbios3_func);

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -523,6 +523,80 @@ fu_util_modify_remote (FuUtilPrivate *priv,
 					   NULL, error);
 }
 
+static void
+fu_util_build_device_tree (GNode *root, GPtrArray *devs, FwupdDevice *dev)
+{
+	for (guint i = 0; i < devs->len; i++) {
+		FwupdDevice *dev_tmp = g_ptr_array_index (devs, i);
+		if (fwupd_device_get_parent (dev_tmp) == dev) {
+			GNode *child = g_node_append_data (root, dev_tmp);
+			fu_util_build_device_tree (child, devs, dev_tmp);
+		}
+	}
+}
+
+static gboolean
+fu_util_print_device_tree (GNode *n, gpointer data)
+{
+	FwupdDevice *dev = FWUPD_DEVICE (n->data);
+	const gchar *name;
+	g_autoptr(GString) str = g_string_new (NULL);
+
+	/* root node */
+	if (dev == NULL) {
+		g_print ("○\n");
+		return FALSE;
+	}
+
+	/* add previous branches */
+	for (GNode *c = n->parent; c->parent != NULL; c = c->parent) {
+		if (g_node_next_sibling (c) == NULL)
+			g_string_prepend (str, "  ");
+		else
+			g_string_prepend (str, "│ ");
+	}
+
+	/* add this branch */
+	if (g_node_last_sibling (n) == n)
+		g_string_append (str, "└─ ");
+	else
+		g_string_append (str, "├─ ");
+
+	/* dump to the console */
+	name = fwupd_device_get_name (dev);
+	if (name == NULL)
+		name = "Unknown device";
+	g_string_append (str, name);
+	for (guint i = strlen (name) + 2 * g_node_depth (n); i < 45; i++)
+		g_string_append_c (str, ' ');
+	g_print ("%s %s\n", str->str, fu_device_get_id (dev));
+	return FALSE;
+}
+
+static gboolean
+fu_util_get_topology (FuUtilPrivate *priv, gchar **values, GError **error)
+{
+	g_autoptr(GNode) root = g_node_new (NULL);
+	g_autoptr(GPtrArray) devs = NULL;
+
+	/* get results from daemon */
+	devs = fwupd_client_get_devices (priv->client, NULL, error);
+	if (devs == NULL)
+		return FALSE;
+
+	/* print */
+	if (devs->len == 0) {
+		/* TRANSLATORS: nothing attached that can be upgraded */
+		g_print ("%s\n", _("No hardware detected with firmware update capability"));
+		return TRUE;
+	}
+	fu_util_build_device_tree (root, devs, NULL);
+	g_node_traverse (root, G_PRE_ORDER, G_TRAVERSE_ALL, -1,
+			 fu_util_print_device_tree, priv);
+
+	return TRUE;
+}
+
 static gboolean
 fu_util_get_devices (FuUtilPrivate *priv, gchar **values, GError **error)
 {
@@ -2286,6 +2360,12 @@ main (int argc, char *argv[])
 		     /* TRANSLATORS: command description */
 		     _("Get all devices that support firmware updates"),
 		     fu_util_get_devices);
+	fu_util_add (priv->cmd_array,
+		     "get-topology",
+		     NULL,
+		     /* TRANSLATORS: command description */
+		     _("Get all devices according to the system topology"),
+		     fu_util_get_topology);
 	fu_util_add (priv->cmd_array,
 		     "hwids",
 		     NULL,


### PR DESCRIPTION
This allows us to find out the logical parent device, for instance in composite
devices with more than one firmware image for a single device.