### PR TITLE
ebitdo: Stop matching Nintendo Switch Pro VID/PID

### DIFF
--- a/plugins/ebitdo/ebitdo.quirk
+++ b/plugins/ebitdo/ebitdo.quirk
@@ -33,8 +33,6 @@ USB\VID_8000&PID_1002=none
 USB\VID_2DC8&PID_1002=none
 
 # SF30 PRO/SN30 PRO
-## Nintendo Switch mode (Start + Y)
-USB\VID_057E&PID_2009=none
 ## Dinput mode (Start + B)
 USB\VID_2DC8&PID_6000=none
 USB\VID_2DC8&PID_6001=none

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -262,13 +262,6 @@ fu_ebitdo_device_validate (FuEbitdoDevice *device, GError **error)
 	if (g_usb_device_get_vid (usb_device) == 0x2dc8)
 		return TRUE;
 
-	/* SF30/SN30 Pro when started with "START + Y"
-	 * Emulates a "Nintendo Switch Pro Controller"
-	 * "Real" Nintendo Switch controllers don't work over USB */
-	if (g_usb_device_get_vid (usb_device) == 0x057e &&
-	    g_usb_device_get_pid (usb_device) == 0x2009)
-		return TRUE;
-
 	/* verify the vendor prefix against a whitelist */
 	idx = g_usb_device_get_manufacturer_index (usb_device);
 	ven = g_usb_device_get_string_descriptor (usb_device, idx, error);

--- a/plugins/ebitdo/fu-ebitdo-tool.c
+++ b/plugins/ebitdo/fu-ebitdo-tool.c
@@ -118,7 +118,6 @@ main (int argc, char **argv)
 			g_print ("2. Hold down L1+R1+HOME for 3 seconds until "
 				 "both blue LED and green LED blink.\n");
 			break;
-		case 0x2009: /* SF30/SN30 pro: switch mode */
 		case 0x6000: /* SF30 pro: Dinput mode */
 		case 0x6001: /* SN30 pro: Dinput mode */
 		case 0x028e: /* SF30/SN30 pro: Xinput mode */


### PR DESCRIPTION
Unfortuantely similar to ead5bf392 this is causing problems with
real Nintendo Switch controllers.