### PR TITLE
fwupdmgr: Hide devices that aren't updatable by default

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -39,6 +39,7 @@ _fwupdmgr_opts=(
 	'--no-unreported-check'
 	'--no-metadata-check'
 	'--no-reboot-check'
+	'--show-all-devices'
 )
 
 _show_modifiers()


### PR DESCRIPTION
They are hidden from get-devices, get-updates, and get-topology
They can be viewed by adding '--show-all-devices' to command line