### PR TITLE
Allow plugins to define the order composite firmwares are installed

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -156,6 +156,8 @@ fwupd_device_flag_to_string (FwupdDeviceFlags device_flag)
 		return "notified";
 	if (device_flag == FWUPD_DEVICE_FLAG_USE_RUNTIME_VERSION)
 		return "use-runtime-version";
+	if (device_flag == FWUPD_DEVICE_FLAG_INSTALL_PARENT_FIRST)
+		return "install-parent-first";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -202,6 +204,8 @@ fwupd_device_flag_from_string (const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_NOTIFIED;
 	if (g_strcmp0 (device_flag, "use-runtime-version") == 0)
 		return FWUPD_DEVICE_FLAG_USE_RUNTIME_VERSION;
+	if (g_strcmp0 (device_flag, "install-parent-first") == 0)
+		return FWUPD_DEVICE_FLAG_INSTALL_PARENT_FIRST;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -91,6 +91,7 @@ typedef enum {
  * @FWUPD_DEVICE_FLAG_REPORTED:			Has been reported to a metadata server
  * @FWUPD_DEVICE_FLAG_NOTIFIED:			User has been notified
  * @FWUPD_DEVICE_FLAG_USE_RUNTIME_VERSION:	Always use the runtime version rather than the bootloader
+ * @FWUPD_DEVICE_FLAG_INSTALL_PARENT_FIRST:	Install composite firmware on the parent before the child
  *
  * The device flags.
  **/
@@ -107,6 +108,7 @@ typedef enum {
 #define FWUPD_DEVICE_FLAG_REPORTED		(1u << 9)	/* Since: 1.0.4 */
 #define FWUPD_DEVICE_FLAG_NOTIFIED		(1u << 10)	/* Since: 1.0.5 */
 #define FWUPD_DEVICE_FLAG_USE_RUNTIME_VERSION	(1u << 11)	/* Since: 1.0.6 */
+#define FWUPD_DEVICE_FLAG_INSTALL_PARENT_FIRST	(1u << 12)	/* Since: 1.0.8 */
 #define FWUPD_DEVICE_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 0.7.3 */
 typedef guint64 FwupdDeviceFlags;
 

--- a/src/fu-device-private.h
+++ b/src/fu-device-private.h
@@ -29,6 +29,9 @@ G_BEGIN_DECLS
 GPtrArray	*fu_device_get_parent_guids		(FuDevice	*device);
 gboolean	 fu_device_has_parent_guid		(FuDevice	*device,
 							 const gchar	*guid);
+guint		 fu_device_get_order			(FuDevice	*device);
+void		 fu_device_set_order			(FuDevice	*device,
+							 guint		 order);
 
 G_END_DECLS
 

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -562,6 +562,20 @@ g_ptr_array_find (GPtrArray *haystack, gconstpointer needle, guint *index_)
 }
 #endif
 
+static gint
+fu_main_install_task_sort_cb (gconstpointer a, gconstpointer b)
+{
+	FuInstallTask *task_a = *((FuInstallTask **) a);
+	FuInstallTask *task_b = *((FuInstallTask **) b);
+	FuDevice *device_a = fu_install_task_get_device (task_a);
+	FuDevice *device_b = fu_install_task_get_device (task_b);
+	if (fu_device_get_order (device_a) < fu_device_get_order (device_b))
+		return -1;
+	if (fu_device_get_order (device_a) > fu_device_get_order (device_b))
+		return 1;
+	return 0;
+}
+
 static gboolean
 fu_main_install_with_helper (FuMainAuthHelper *helper_ref, GError **error)
 {
@@ -639,6 +653,9 @@ fu_main_install_with_helper (FuMainAuthHelper *helper_ref, GError **error)
 			g_ptr_array_add (helper->install_tasks, g_steal_pointer (&task));
 		}
 	}
+
+	/* order the install tasks by the device priority */
+	g_ptr_array_sort (helper->install_tasks, fu_main_install_task_sort_cb);
 
 	/* nothing suitable */
 	if (helper->install_tasks->len == 0) {

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -199,6 +199,11 @@ fu_engine_device_parent_func (void)
 	g_assert (fu_device_get_parent (device1) == device2);
 	g_assert_cmpstr (fu_device_get_vendor (device3), ==, "oem");
 	g_assert_cmpstr (fu_device_get_vendor (device1), ==, "oem");
+
+	/* verify order */
+	g_assert_cmpint (fu_device_get_order (device1), ==, 1);
+	g_assert_cmpint (fu_device_get_order (device2), ==, 0);
+	g_assert_cmpint (fu_device_get_order (device3), ==, 1);
 }
 
 static void


### PR DESCRIPTION
For comment -- I'm not particularly happy with the name of `child_flags`. Other ideas welcome.