### PR TITLE
Do not use the system metainfo location

### DIFF
--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -204,6 +204,7 @@ mkdir -p --mode=0700 $RPM_BUILD_ROOT%{_localstatedir}/lib/fwupd/gnupg
 %{_sysconfdir}/pki/fwupd-metadata
 %{_sysconfdir}/dbus-1/system.d/org.freedesktop.fwupd.conf
 %{_datadir}/bash-completion/completions/fwupdmgr
+%{_datadir}/fwupd/metainfo/org.freedesktop.fwupd*.metainfo.xml
 %{_datadir}/fwupd/remotes.d/fwupd/metadata.xml
 %{_datadir}/fwupd/remotes.d/vendor/firmware/README.md
 %{_datadir}/dbus-1/interfaces/org.freedesktop.fwupd.xml
@@ -212,7 +213,7 @@ mkdir -p --mode=0700 $RPM_BUILD_ROOT%{_localstatedir}/lib/fwupd/gnupg
 %{_datadir}/dbus-1/system-services/org.freedesktop.fwupd.service
 %{_datadir}/man/man1/dfu-tool.1.gz
 %{_datadir}/man/man1/fwupdmgr.1.gz
-%{_datadir}/metainfo/org.freedesktop.fwupd*.metainfo.xml
+%{_datadir}/metainfo/org.freedesktop.fwupd.metainfo.xml
 %{_datadir}/fwupd/firmware-packager
 %{_unitdir}/fwupd-offline-update.service
 %{_unitdir}/fwupd.service

--- a/data/remotes.d/meson.build
+++ b/data/remotes.d/meson.build
@@ -12,7 +12,7 @@ if get_option('lvfs')
     po_dir: join_paths(meson.source_root(), 'po'),
     data_dirs: join_paths(meson.source_root(), 'po'),
     install: true,
-    install_dir: join_paths(get_option('datadir'), 'metainfo')
+    install_dir: join_paths(get_option('datadir'), 'fwupd', 'metainfo')
   )
   i18n.merge_file(
     input: 'lvfs-testing.metainfo.xml',
@@ -21,7 +21,7 @@ if get_option('lvfs')
     po_dir: join_paths(meson.source_root(), 'po'),
     data_dirs: join_paths(meson.source_root(), 'po'),
     install: true,
-    install_dir: join_paths(get_option('datadir'), 'metainfo')
+    install_dir: join_paths(get_option('datadir'), 'fwupd', 'metainfo')
   )
 endif
 

--- a/src/fu-config.c
+++ b/src/fu-config.c
@@ -401,6 +401,7 @@ fu_config_load (FuConfig *self, GError **error)
 	GFileMonitor *monitor;
 	guint64 archive_size_max;
 	g_autofree gchar *config_file = NULL;
+	g_autofree gchar *metainfo_path = NULL;
 	g_auto(GStrv) devices = NULL;
 	g_auto(GStrv) plugins = NULL;
 	g_autoptr(GFile) file = NULL;
@@ -468,8 +469,14 @@ fu_config_load (FuConfig *self, GError **error)
 	if (self->os_release == NULL)
 		return FALSE;
 	as_store_add_filter (self->store_remotes, AS_APP_KIND_SOURCE);
-	if (!as_store_load (self->store_remotes, AS_STORE_LOAD_FLAG_APPDATA, NULL, error))
-		return FALSE;
+	metainfo_path = g_build_filename (FWUPDDATADIR, "metainfo", NULL);
+	if (g_file_test (metainfo_path, G_FILE_TEST_EXISTS)) {
+		if (!as_store_load_path (self->store_remotes,
+					 metainfo_path,
+					 NULL, /* cancellable */
+					 error))
+			return FALSE;
+	}
 
 	/* load remotes */
 	if (!fu_config_load_remotes (self, error))


### PR DESCRIPTION
This means we can avoid loading a ton of non-fwupd files, and reduces our
running RSS from 5.4Mb to 2.8Mb. Old versions of appstream-glib caches a lot of
the localization string data which we just don't care about for firmware files.