### PR TITLE
Add support for building snaps

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -155,6 +155,8 @@ if get_option('daemon')
     udev = dependency('udev')
     udevdir = udev.get_pkgconfig_variable('udevdir')
   endif
+else
+  conf.set('SNAP_SUPPORT', '1')
 endif
 if get_option('pkcs7')
   gnutls = dependency('gnutls', version : '>= 3.4.4.1')

--- a/src/fu-common.h
+++ b/src/fu-common.h
@@ -61,4 +61,5 @@ guint16		 fu_common_read_uint16		(const guint8	*buf,
 guint32		 fu_common_read_uint32		(const guint8	*buf,
 						 FuEndianType	 endian);
 
+gchar		*fu_common_get_localstatedir 	(void);
 #endif /* __FU_COMMON_H__ */

--- a/src/fu-history.c
+++ b/src/fu-history.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 
 #include "fu-device-private.h"
+#include "fu-common.h"
 #include "fu-history.h"
 
 static void fu_history_finalize			 (GObject *object);
@@ -227,6 +228,7 @@ fu_history_load (FuHistory *self, GError **error)
 {
 	gint rc;
 	guint schema_ver;
+	g_autofree gchar *localstatedir = NULL;
 	g_autofree gchar *dirname = NULL;
 	g_autofree gchar *filename = NULL;
 	g_autoptr(GFile) file = NULL;
@@ -239,7 +241,8 @@ fu_history_load (FuHistory *self, GError **error)
 	g_return_val_if_fail (self->db == NULL, FALSE);
 
 	/* create directory */
-	dirname = g_build_filename (LOCALSTATEDIR, "lib", "fwupd", NULL);
+	localstatedir = fu_common_get_localstatedir ();
+	dirname = g_build_filename (localstatedir, "lib", "fwupd", NULL);
 	file = g_file_new_for_path (dirname);
 	if (!g_file_query_exists (file, NULL)) {
 		if (!g_file_make_directory_with_parents (file, NULL, error))

--- a/src/fu-keyring-gpg.c
+++ b/src/fu-keyring-gpg.c
@@ -11,6 +11,7 @@
 
 #include "fwupd-error.h"
 
+#include "fu-common.h"
 #include "fu-keyring-gpg.h"
 
 struct _FuKeyringGpg
@@ -82,6 +83,7 @@ fu_keyring_gpg_setup (FuKeyring *keyring, GError **error)
 {
 	FuKeyringGpg *self = FU_KEYRING_GPG (keyring);
 	gpgme_error_t rc;
+	g_autofree gchar *localstatedir = NULL;
 	g_autofree gchar *gpg_home = NULL;
 
 	if (self->ctx != NULL)
@@ -121,7 +123,8 @@ fu_keyring_gpg_setup (FuKeyring *keyring, GError **error)
 	}
 
 	/* set a custom home directory */
-	gpg_home = g_build_filename (LOCALSTATEDIR,
+	localstatedir = fu_common_get_localstatedir ();
+	gpg_home = g_build_filename (localstatedir,
 				     "lib",
 				     PACKAGE_NAME,
 				     "gnupg",

--- a/src/fu-plugin.c
+++ b/src/fu-plugin.c
@@ -1125,6 +1125,7 @@ fu_plugin_runner_schedule_update (FuPlugin *plugin,
 	gchar tmpname[] = {"XXXXXX.cap"};
 	g_autofree gchar *dirname = NULL;
 	g_autofree gchar *filename = NULL;
+	g_autofree gchar *localstatedir = NULL;
 	g_autoptr(FuDevice) res_tmp = NULL;
 	g_autoptr(FuHistory) history = NULL;
 	g_autoptr(FwupdRelease) release_tmp = fwupd_release_new ();
@@ -1143,7 +1144,8 @@ fu_plugin_runner_schedule_update (FuPlugin *plugin,
 	}
 
 	/* create directory */
-	dirname = g_build_filename (LOCALSTATEDIR, "lib", "fwupd", NULL);
+	localstatedir = fu_common_get_localstatedir ();
+	dirname = g_build_filename (localstatedir, "lib", "fwupd", NULL);
 	file = g_file_new_for_path (dirname);
 	if (!g_file_query_exists (file, NULL)) {
 		if (!g_file_make_directory_with_parents (file, NULL, error))
@@ -1511,10 +1513,17 @@ fu_plugin_get_config_value (FuPlugin *plugin, const gchar *key)
 	g_autofree gchar *conf_path = NULL;
 	g_autoptr(GKeyFile) keyfile = NULL;
 	const gchar *plugin_name;
+	const gchar *runtime_prefix;
 
 	plugin_name = fu_plugin_get_name (plugin);
 	conf_file = g_strdup_printf ("%s.conf", plugin_name);
-	conf_path = g_build_filename (FWUPDCONFIGDIR, conf_file,  NULL);
+#ifdef SNAP_SUPPORT
+	runtime_prefix = g_getenv ("SNAP_USER_DATA");
+	if (runtime_prefix != NULL)
+		conf_path = g_build_filename (runtime_prefix, FWUPDCONFIGDIR, conf_file, NULL);
+#endif
+	if (conf_path == NULL)
+		conf_path = g_build_filename (FWUPDCONFIGDIR, conf_file,  NULL);
 	if (!g_file_test (conf_path, G_FILE_TEST_IS_REGULAR))
 		return NULL;
 	keyfile = g_key_file_new ();


### PR DESCRIPTION
When this prefix is set fu-config, fu-engine and fu-quirks will
look for all configured content at subdirectories of this one.

This should allow usage with snaps and flatpaks by wrappers setting
this prefix at application launch time for fwupdtool.


I haven't tested this specifically in a snap or flatpak yet, but instead purged fwupd from the system and just tested with doing a deb build, switching to `build/obj-x86_64-linux-gnu` and then running fwupdtool like this:
```
sudo FWUPD_RUNTIME_PREFIX=~/src/fwupd/build/debian/tmp ./src/fwupdtool get-devices -v
```
