### PR TITLE
Allow whitelisting plugins in fwupdtool

### DIFF
--- a/data/bash-completion/fwupdtool
+++ b/data/bash-completion/fwupdtool
@@ -15,6 +15,7 @@ _fwupdmgr_opts=(
 	'--allow-older'
 	'--force'
 	'--show-all-devices'
+	'--plugin-whitelist'
 )
 
 _show_modifiers()

--- a/data/bash-completion/fwupdtool.in
+++ b/data/bash-completion/fwupdtool.in
@@ -1,5 +1,6 @@
-_fwupdmgr_cmd_list=(
+_fwupdtool_cmd_list=(
 	'get-devices'
+	'get-plugins'
 	'get-topology'
 	'install'
 	'install-blob'
@@ -9,7 +10,7 @@ _fwupdmgr_cmd_list=(
 	'watch'
 )
 
-_fwupdmgr_opts=(
+_fwupdtool_opts=(
 	'--verbose'
 	'--allow-reinstall'
 	'--allow-older'
@@ -18,9 +19,16 @@ _fwupdmgr_opts=(
 	'--plugin-whitelist'
 )
 
+_show_plugins()
+{
+	local plugins
+	plugins="$(command @libexecdir@/fwupdtool get-plugins 2>/dev/null)"
+	COMPREPLY+=( $(compgen -W "${plugins}" -- "$cur") )
+}
+
 _show_modifiers()
 {
-	COMPREPLY+=( $(compgen -W '${_fwupdmgr_opts[@]}' -- "$cur") )
+	COMPREPLY+=( $(compgen -W '${_fwupdtool_opts[@]}' -- "$cur") )
 }
 
 _fwupdtool()
@@ -30,6 +38,13 @@ _fwupdtool()
 	cur=`_get_cword`
 	prev=${COMP_WORDS[COMP_CWORD-1]}
 	command=${COMP_WORDS[1]}
+
+	case $prev in
+	--plugin-whitelist)
+		_show_plugins
+		return 0
+		;;
+	esac
 
 	case $command in
 	install|install-blob)
@@ -52,7 +67,7 @@ _fwupdtool()
 	*)
 		#find first command
 		if [[ ${COMP_CWORD} = 1 ]]; then
-			COMPREPLY=( $(compgen -W '${_fwupdmgr_cmd_list[@]}' -- "$cur") )
+			COMPREPLY=( $(compgen -W '${_fwupdtool_cmd_list[@]}' -- "$cur") )
 		#modifiers for all commands
 		else
 			_show_modifiers

--- a/data/bash-completion/meson.build
+++ b/data/bash-completion/meson.build
@@ -3,7 +3,19 @@ if bashcomp.found()
                                          define_variable: [ 'prefix', prefix ],
   )
 
-  install_data(['fwupdmgr', 'fwupdtool'],
+  install_data(['fwupdmgr'],
     install_dir : tgt,
   )
+
+# replace @libexecdir@
+fwupdtool_path = join_paths(libexecdir, 'fwupd')
+con2 = configuration_data()
+con2.set('libexecdir', fwupdtool_path)
+configure_file(
+  input : 'fwupdtool.in',
+  output : 'fwupdtool',
+  configuration : con2,
+  install: true,
+  install_dir: tgt)
+
 endif

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1218,6 +1218,23 @@ fu_engine_install (FuEngine *self,
 				       version, flags, error);
 }
 
+/**
+ * fu_engine_get_plugins:
+ * @self: A #FuPluginList
+ *
+ * Gets all the plugins that have been added.
+ *
+ * Returns: (transfer none) (element-type FuPlugin): the plugins
+ *
+ * Since: 1.0.8
+ **/
+GPtrArray *
+fu_engine_get_plugins (FuEngine *self)
+{
+	g_return_val_if_fail (FU_IS_ENGINE (self), NULL);
+	return fu_plugin_list_get_all (self->plugin_list);
+}
+
 gboolean
 fu_engine_install_blob (FuEngine *self,
 			FuDevice *device,
@@ -2879,7 +2896,7 @@ fu_engine_is_plugin_name_blacklisted (FuEngine *self, const gchar *name)
 	return FALSE;
 }
 
-static gboolean
+gboolean
 fu_engine_load_plugins (FuEngine *self, GError **error)
 {
 	const gchar *fn;
@@ -2925,10 +2942,14 @@ fu_engine_load_plugins (FuEngine *self, GError **error)
 		fu_plugin_set_runtime_versions (plugin, self->runtime_versions);
 		fu_plugin_set_compile_versions (plugin, self->compile_versions);
 		g_debug ("adding plugin %s", filename);
-		if (!fu_plugin_open (plugin, filename, &error_local)) {
-			g_warning ("failed to open plugin %s: %s",
-				   filename, error_local->message);
-			continue;
+
+		/* if loaded from fu_engine_load() open the plugin */
+		if (self->usb_ctx != NULL) {
+			if (!fu_plugin_open (plugin, filename, &error_local)) {
+				g_warning ("failed to open plugin %s: %s",
+					   filename, error_local->message);
+				continue;
+			}
 		}
 
 		/* self disabled */

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -38,6 +38,8 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE (FuEngine, fu_engine, FU, ENGINE, GObject)
 
 FuEngine	*fu_engine_new				(FuAppFlags	 app_flags);
+void		 fu_engine_add_plugin_filter		(FuEngine	*self,
+							 const gchar	*plugin_glob);
 gboolean	 fu_engine_load				(FuEngine	*self,
 							 GError		**error);
 gboolean	 fu_engine_load_plugins			(FuEngine	*self,

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -40,6 +40,8 @@ G_DECLARE_FINAL_TYPE (FuEngine, fu_engine, FU, ENGINE, GObject)
 FuEngine	*fu_engine_new				(FuAppFlags	 app_flags);
 gboolean	 fu_engine_load				(FuEngine	*self,
 							 GError		**error);
+gboolean	 fu_engine_load_plugins			(FuEngine	*self,
+							 GError		**error);
 FwupdStatus	 fu_engine_get_status			(FuEngine	*self);
 void		 fu_engine_profile_dump			(FuEngine	*self);
 gboolean	 fu_engine_check_plugins_pending	(FuEngine	*self,
@@ -48,6 +50,7 @@ AsStore		*fu_engine_get_store_from_blob		(FuEngine	*self,
 							 GBytes		*blob_cab,
 							 GError		**error);
 guint64		 fu_engine_get_archive_size_max		(FuEngine	*self);
+GPtrArray	*fu_engine_get_plugins			(FuEngine	*self);
 GPtrArray	*fu_engine_get_devices			(FuEngine	*self,
 							 GError		**error);
 FuDevice	*fu_engine_get_device			(FuEngine	*self,

--- a/src/fu-plugin-list.c
+++ b/src/fu-plugin-list.c
@@ -124,11 +124,7 @@ fu_plugin_list_sort_cb (gconstpointer a, gconstpointer b)
 {
 	FuPlugin **pa = (FuPlugin **) a;
 	FuPlugin **pb = (FuPlugin **) b;
-	if (fu_plugin_get_order (*pa) < fu_plugin_get_order (*pb))
-		return -1;
-	if (fu_plugin_get_order (*pa) > fu_plugin_get_order (*pb))
-		return 1;
-	return 0;
+	return fu_plugin_order_compare (*pa, *pb);
 }
 
 /**

--- a/src/fu-plugin-private.h
+++ b/src/fu-plugin-private.h
@@ -106,6 +106,10 @@ gboolean	 fu_plugin_runner_clear_results		(FuPlugin	*plugin,
 gboolean	 fu_plugin_runner_get_results		(FuPlugin	*plugin,
 							 FuDevice	*device,
 							 GError		**error);
+gint		 fu_plugin_name_compare			(FuPlugin	*plugin1,
+							 FuPlugin	*plugin2);
+gint		 fu_plugin_order_compare		(FuPlugin	*plugin1,
+							 FuPlugin	*plugin2);
 
 /* utils */
 gchar		*fu_plugin_guess_name_from_fn           (const gchar	*filename);

--- a/src/fu-plugin.c
+++ b/src/fu-plugin.c
@@ -1538,6 +1538,44 @@ fu_plugin_get_config_value (FuPlugin *plugin, const gchar *key)
 	return g_key_file_get_string (keyfile, plugin_name, key, NULL);
 }
 
+/**
+ * fu_plugin_name_compare:
+ * @plugin1: first #FuPlugin to compare.
+ * @plugin2: second #FuPlugin to compare.
+ *
+ * Compares two plugins by their names.
+ *
+ * Returns: 1, 0 or -1 if @plugin1 is greater, equal, or less than @plugin2.
+ **/
+gint
+fu_plugin_name_compare (FuPlugin *plugin1, FuPlugin *plugin2)
+{
+	FuPluginPrivate *priv1 = fu_plugin_get_instance_private (plugin1);
+	FuPluginPrivate *priv2 = fu_plugin_get_instance_private (plugin2);
+	return g_strcmp0 (priv1->name, priv2->name);
+}
+
+/**
+ * fu_plugin_order_compare:
+ * @plugin1: first #FuPlugin to compare.
+ * @plugin2: second #FuPlugin to compare.
+ *
+ * Compares two plugins by their depsolved order.
+ *
+ * Returns: 1, 0 or -1 if @plugin1 is greater, equal, or less than @plugin2.
+ **/
+gint
+fu_plugin_order_compare (FuPlugin *plugin1, FuPlugin *plugin2)
+{
+	FuPluginPrivate *priv1 = fu_plugin_get_instance_private (plugin1);
+	FuPluginPrivate *priv2 = fu_plugin_get_instance_private (plugin2);
+	if (priv1->order < priv2->order)
+		return -1;
+	if (priv1->order > priv2->order)
+		return 1;
+	return 0;
+}
+
 static void
 fu_plugin_class_init (FuPluginClass *klass)
 {

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -653,6 +653,7 @@ main (int argc, char *argv[])
 	gboolean force = FALSE;
 	gboolean ret;
 	gboolean verbose = FALSE;
+	g_auto(GStrv) plugin_glob = NULL;
 	g_autoptr(FuUtilPrivate) priv = g_new0 (FuUtilPrivate, 1);
 	g_autoptr(GError) error = NULL;
 	g_autofree gchar *cmd_descriptions = NULL;
@@ -672,6 +673,9 @@ main (int argc, char *argv[])
 		{ "show-all-devices", '\0', 0, G_OPTION_ARG_NONE, &priv->show_all_devices,
 			/* TRANSLATORS: command line option */
 			_("Show devices that are not updatable"), NULL },
+		{ "plugin-whitelist", '\0', 0, G_OPTION_ARG_STRING_ARRAY, &plugin_glob,
+			/* TRANSLATORS: command line option */
+			_("Manually whitelist specific plugins"), NULL },
 		{ NULL}
 	};
 
@@ -814,6 +818,10 @@ main (int argc, char *argv[])
 	g_signal_connect (priv->engine, "percentage-changed",
 			  G_CALLBACK (fu_main_engine_percentage_changed_cb),
 			  priv);
+
+	/* any plugin whitelist specified */
+	for (guint i = 0; plugin_glob != NULL && plugin_glob[i] != NULL; i++)
+		fu_engine_add_plugin_filter (priv->engine, plugin_glob[i]);
 
 	/* run the specified command */
 	ret = fu_util_run (priv, argv[1], (gchar**) &argv[2], &error);

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -686,11 +686,9 @@ main (int argc, char *argv[])
 	textdomain (GETTEXT_PACKAGE);
 
 	/* ensure root user */
-	if (getuid () != 0 || geteuid () != 0) {
+	if (getuid () != 0 || geteuid () != 0)
 		/* TRANSLATORS: we're poking around as a power user */
-		g_print ("%s\n", _("This program can only be used when root"));
-		return EXIT_FAILURE;
-	}
+		g_printerr ("%s\n", _("This program may only work correctly as root"));
 
 	/* create helper object */
 	priv->loop = g_main_loop_new (NULL, FALSE);


### PR DESCRIPTION
When developing code it's really convenient to only run the new plugin. This
means you don't have to wait for the other hardware to initialize and there
are no side-effects from other plugins when installing firmware.

You can specify multiple plugins as globs, for instance:

    fwupdtool get-devices \
        --plugin-whitelist wacom \
        --plugin-whitelist "thunderbolt*"