### PR TITLE
Add support for building a flatpak bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /build
 /dist
 /.vscode
+/build-dir
+/.flatpak-builder
+/repo
+*.flatpak

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ env:
   - OS=debian-i386
   - OS=ubuntu-x86_64
   - OS=centos
+  - OS=flatpak
 
 install:
   - ./contrib/ci/generate_docker.py
 
 script:
-  - docker run -e CI=true -t -v `pwd`/dist:/build/dist fwupd-$OS
+  - docker run --privileged -e CI=true -t -v `pwd`/dist:/build/dist fwupd-$OS

--- a/contrib/ci/Dockerfile-flatpak.in
+++ b/contrib/ci/Dockerfile-flatpak.in
@@ -1,0 +1,11 @@
+FROM fedora:28
+%%%OS%%%
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+RUN echo fubar > /etc/machine-id
+%%%INSTALL_DEPENDENCIES_COMMAND%%%
+RUN mkdir /build
+WORKDIR /build
+COPY . .
+CMD ["./contrib/ci/flatpak.sh"]

--- a/contrib/ci/README.md
+++ b/contrib/ci/README.md
@@ -66,6 +66,14 @@ Arch Linux (x86_64)
 * Tests with the built in local test suite for all plugins.
 * All packages are installed
 
+Flatpak
+----------
+* A flatpak bundle with all but colorhug plugins enabled
+* Compiled under gcc with the org.gnome.Sdk/x86_64/3.28 runtime
+* Builds without the daemon, so only fwupdtool is available
+* No GPG, PKCS-7, GObjectIntrospection, systemd or ConsoleKit support
+* No tests
+
 Adding a new target
 ===================
 Dockerfiles are generated dynamically by the python script ```generate_dockerfile.py```.

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -1139,4 +1139,14 @@
       <package />
     </distro>
   </dependency>
+  <dependency type="build" id="flatpak-builder">
+    <distro id="flatpak">
+      <package />
+    </distro>
+  </dependency>
+  <dependency type="build" id="tree">
+    <distro id="flatpak">
+      <package />
+    </distro>
+  </dependency>
 </dependencies>

--- a/contrib/ci/flatpak.sh
+++ b/contrib/ci/flatpak.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+set -x
+
+# install the runtimes
+flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+flatpak install flathub runtime/org.gnome.Sdk/x86_64/3.28
+flatpak install flathub runtime/org.gnome.Platform/x86_64/3.28
+
+# build the bundle
+flatpak-builder --repo=repo --force-clean --disable-rofiles-fuse build-dir contrib/org.freedesktop.fwupd.json
+
+# show the files that were included
+tree build-dir
+
+# build a single file bundle
+flatpak build-bundle repo fwupd.flatpak org.freedesktop.fwupd
+
+# make available as a deliverable
+cp fwupd.flatpak dist
+
+# to run from the builddir:
+# sudo flatpak-builder --run build-dir org.freedesktop.fwupd.json /app/libexec/fwupd/fwupdtool get-devices
+
+# install the single file bundle
+# flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+# flatpak install fwupd.flatpak
+
+# to run a shell in the same environment that flatpak sees:
+# flatpak run --command=sh --devel org.freedesktop.fwupd
+
+# to run fwupdtool as root:
+# sudo flatpak run org.freedesktop.fwupd --verbose get-devices

--- a/contrib/ci/generate_docker.py
+++ b/contrib/ci/generate_docker.py
@@ -71,7 +71,7 @@ with open(out.name, 'w') as wfd:
                 replace = ''
             wfd.write(line.replace("%%%ARCH_PREFIX%%%", replace))
         elif line == "%%%INSTALL_DEPENDENCIES_COMMAND%%%\n":
-            if OS == "fedora":
+            if OS == "fedora" or OS == 'flatpak':
                 wfd.write("RUN dnf --enablerepo=updates-testing -y install \\\n")
             elif OS == "centos":
                 wfd.write("RUN yum -y install \\\n")

--- a/contrib/org.freedesktop.fwupd.json
+++ b/contrib/org.freedesktop.fwupd.json
@@ -1,0 +1,175 @@
+{
+    "app-id": "org.freedesktop.fwupd",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.28",
+    "branch": "master",
+    "sdk": "org.gnome.Sdk",
+    "command": "/app/libexec/fwupd/fwupdtool",
+    "tags": [],
+    "finish-args": [
+        "--device=all",
+        "--filesystem=/boot",
+        "--filesystem=/sys",
+        "--share=network",
+        "--system-talk-name=org.freedesktop.fwupd",
+        "--system-talk-name=org.freedesktop.UPower"
+    ],
+    "build-options" : {
+        "cflags": "-O2 -g",
+        "cxxflags": "-O2 -g"
+    },
+    "cleanup": [
+        "*.a",
+        "*.la",
+        "/include",
+        "/lib/girepository-1.0",
+        "/lib/pkgconfig",
+        "/share/bash-completion",
+        "/share/dbus-1/system-services",
+        "/share/gir-1.0",
+        "/share/gtk-doc",
+        "/share/info",
+        "/share/man",
+        "/share/pkgconfig" ],
+    "modules": [
+        {
+          /* not using shared-modules as we need gudev */
+          "name": "udev",
+          "rm-configure": true,
+          "config-opts": [
+            "--disable-hwdb",
+            "--disable-logging",
+            "--disable-introspection",
+            "--disable-keymap",
+            "--disable-mtd_probe"
+          ],
+          "cleanup": [
+            "/etc/udev",
+            "/libexec/*",
+            "/share/gtk-doc/html/libudev/",
+            "/sbin/udevadm"
+          ],
+          "sources": [
+            {
+                "type": "archive",
+                "url": "http://kernel.org/pub/linux/utils/kernel/hotplug/udev-175.tar.bz2",
+                "sha256": "4c7937fe5a1521316ea571188745b9a00a9fdf314228cffc53a7ba9e5968b7ab"
+            },
+            {
+                "type": "script",
+                "dest-filename": "autogen.sh",
+                "commands": [
+                    "autoreconf -vfi"
+                ]
+            }
+          ]
+        },
+        {
+            "name": "libusb",
+            "config-opts": [
+                "--disable-static"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://sourceforge.net/projects/libusb/files/libusb-1.0/libusb-1.0.21/libusb-1.0.21.tar.gz",
+                    "sha256": "1a5b08c05bc5e38c81c2d59c29954d5916646f4ff46f51381b3f624384e4ac01"
+                }
+            ]
+        },
+        {
+            "name": "gusb",
+            "buildsystem": "meson",
+            "config-opts": ["-Ddocs=false",
+                            "-Dvapi=false",
+                            "-Dtests=false"],
+            "cleanup": [
+                "/bin/gusbcmd"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://people.freedesktop.org/~hughsient/releases/libgusb-0.3.0.tar.xz",
+                    "sha256": "d8e7950f99b6ae4c3e9b8c65f3692b9635289e6cff8de40c4af41b2e9b348edc"
+                }
+            ]
+        },
+        {
+            "name": "efivar",
+            "buildsystem": "simple",
+            "build-commands": ["make prefix=/app libdir=/app/lib", "make install prefix=/app libdir=/app/lib"],
+            "cleanup": [
+                "/bin/efivar"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/rhboot/efivar/releases/download/35/efivar-35.tar.bz2",
+                    "sha256": "1e033dc5d099a44fd473b0887dbcc4b105613efab0fb3c5df9f111ea5d147394"
+                }
+            ]
+        },
+        {
+            "name": "fwupdate",
+            "buildsystem": "simple",
+            "build-commands": ["make -C linux prefix=/app libdir=/app/lib", "EFIDIR=/boot/efi make -C linux install prefix=/app libdir=/app/lib"],
+            "cleanup": [
+                "/bin/fwupdate",
+                "/lib/systemd/system/fwupdate-cleanup.service",
+                "/libexec/fwupdate/cleanup"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/rhboot/fwupdate/releases/download/11/fwupdate-11.tar.bz2",
+                    "sha256": "d350eae66215c90fdc70f46ea734dedbfe6006ec21b7e764114b7d9e283e4abe"
+                }
+            ]
+        },
+        {
+            "name": "libsmbios_c",
+            "config-opts": ["--disable-doxygen",
+                            "--disable-graphviz",
+                            "--disable-python"],
+            "cleanup": [
+                "/sbin/smbios*",
+                "/share/locale/*/LC_MESSAGES/libsmbios.mo"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/dell/libsmbios.git",
+                    "branch": "master" /* FIXME: needed for the flatpak fixes... */
+                }
+            ]
+        },
+        {
+            "name": "fwupd",
+            "buildsystem": "meson",
+            "config-opts": ["-Dconsolekit=false",
+                            "-Ddaemon=false",
+                            "-Dgpg=false",
+                            "-Dgtkdoc=false",
+                            "-Dintrospection=false",
+                            "-Dman=false",
+                            "-Dpkcs7=false",
+                            "-Dplugin_colorhug=false",
+                            "-Dplugin_uefi_labels=false",
+                            "-Dsystemd=false",
+                            "-Dtests=false",
+                            "--sysconfdir=/app/etc",
+                            "--localstatedir=/var/data"],
+            "cleanup": [
+                "/etc/dbus-1/system.d/org.freedesktop.fwupd.conf",
+                "/share/fwupd/remotes.d/vendor"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/hughsie/fwupd.git",
+                    "branch": "master"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This allows me to make a flatpak, and either export it to a store like "flathub" (although, the store is more geared-up for GUI applications rather than tools that need to be run as root...) or more usefully to a single-file flatpak bundle that means I can install a .cab file on older version of RHEL.

I don't think producing a flatpak on every commit (i.e. wiring it up to travis) makes sense. On one hand it might be useful to see if fwupd still builds against all the deps, but on the other it's hugely wasteful as we'd have no flatpak cache and so we'd download the big runtime and build every dep on every new PR. I'm also not sure how you'd tell flatpak builder to use a git URI of `file://../..`.

I used the tarball releases of all the deps except smbios_c and fwupd itself as flathub prefers (and I think long term, this is where the fwupd manifest will be maintained) reproducable builds over using the lastest bleeding edge development releases of everything. Maybe two manifests make sense; one that targets the latest tarballs for flathub and one that targets the latest development versions of everything to check everything still builds against each other.

Anyway, comments welcome.