### PR TITLE
More Microsoft compatibility fixes around bios major/minor version

### DIFF
--- a/src/fu-hwids.c
+++ b/src/fu-hwids.c
@@ -241,7 +241,7 @@ fu_hwids_convert_string_table_cb (FuSmbios *smbios,
 }
 
 static gchar *
-fu_hwids_convert_base10_integer_cb (FuSmbios *smbios,
+fu_hwids_convert_padded_integer_cb (FuSmbios *smbios,
 				    guint8 type, guint8 offset,
 				    GError **error)
 {
@@ -259,13 +259,13 @@ fu_hwids_convert_base10_integer_cb (FuSmbios *smbios,
 				     "offset bigger than data");
 		return NULL;
 	}
-	return g_strdup_printf ("%02u", data_raw[offset]);
+	return g_strdup_printf ("%02x", data_raw[offset]);
 }
 
 static gchar *
-fu_hwids_convert_base16_integer_cb (FuSmbios *smbios,
-				    guint8 type, guint8 offset,
-				    GError **error)
+fu_hwids_convert_integer_cb (FuSmbios *smbios,
+			     guint8 type, guint8 offset,
+			     GError **error)
 {
 	GBytes *data;
 	const guint8 *data_raw;
@@ -306,7 +306,7 @@ fu_hwids_setup (FuHwids *self, FuSmbios *smbios, GError **error)
 		{ FU_HWIDS_KEY_MANUFACTURER,		FU_SMBIOS_STRUCTURE_TYPE_SYSTEM, 0x04,
 							fu_hwids_convert_string_table_cb },
 		{ FU_HWIDS_KEY_ENCLOSURE_KIND,		FU_SMBIOS_STRUCTURE_TYPE_CHASSIS, 0x05,
-							fu_hwids_convert_base16_integer_cb },
+							fu_hwids_convert_integer_cb },
 		{ FU_HWIDS_KEY_FAMILY,			FU_SMBIOS_STRUCTURE_TYPE_SYSTEM, 0x1a,
 							fu_hwids_convert_string_table_cb },
 		{ FU_HWIDS_KEY_PRODUCT_NAME,		FU_SMBIOS_STRUCTURE_TYPE_SYSTEM, 0x05,
@@ -318,9 +318,9 @@ fu_hwids_setup (FuHwids *self, FuSmbios *smbios, GError **error)
 		{ FU_HWIDS_KEY_BIOS_VERSION,		FU_SMBIOS_STRUCTURE_TYPE_BIOS, 0x05,
 							fu_hwids_convert_string_table_cb },
 		{ FU_HWIDS_KEY_BIOS_MAJOR_RELEASE,	FU_SMBIOS_STRUCTURE_TYPE_BIOS, 0x14,
-							fu_hwids_convert_base10_integer_cb },
+							fu_hwids_convert_padded_integer_cb },
 		{ FU_HWIDS_KEY_BIOS_MINOR_RELEASE,	FU_SMBIOS_STRUCTURE_TYPE_BIOS, 0x15,
-							fu_hwids_convert_base10_integer_cb },
+							fu_hwids_convert_padded_integer_cb },
 		{ FU_HWIDS_KEY_BASEBOARD_MANUFACTURER,	FU_SMBIOS_STRUCTURE_TYPE_BASEBOARD, 0x04,
 							fu_hwids_convert_string_table_cb },
 		{ FU_HWIDS_KEY_BASEBOARD_PRODUCT,	FU_SMBIOS_STRUCTURE_TYPE_BASEBOARD, 0x05,
@@ -349,7 +349,7 @@ fu_hwids_setup (FuHwids *self, FuSmbios *smbios, GError **error)
 		/* weirdly, remove leading zeros */
 		contents_hdr = contents;
 		while (contents_hdr[0] == '0' &&
-		       map[i].func != fu_hwids_convert_base10_integer_cb)
+		       map[i].func != fu_hwids_convert_padded_integer_cb)
 			contents_hdr++;
 		g_hash_table_insert (self->hash_dmi_hw,
 				     g_strdup (map[i].key),

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -1052,9 +1052,9 @@ fu_hwids_func (void)
 		{ "HardwareID-5",	"8dc9b7c5-f5d5-5850-9ab3-bd6f0549d814" },
 		{ "HardwareID-4",	"660ccba8-1b78-5a33-80e6-9fb8354ee873" },
 		{ "HardwareID-3",	"3faec92a-3ae3-5744-be88-495e90a7d541" },
-		{ "HardwareID-2",	"187b6b26-efdf-56f8-9cdf-e8ac07eeeeff" },
-		{ "HardwareID-1",	"93bb295e-8fd6-5349-9dd2-eb0d9d6576cb" },
-		{ "HardwareID-0",	"852e40d3-0b89-581a-b4a0-786b00666625" },
+		{ "HardwareID-2",	"f5ff077f-3eeb-5bae-be1c-e98ffe8ce5f8" },
+		{ "HardwareID-1",	"b7cceb67-774c-537e-bf8b-22c6107e9a74" },
+		{ "HardwareID-0",	"147efce9-f201-5fc8-ab0c-c859751c3440" },
 		{ NULL, NULL }
 	};
 
@@ -1081,7 +1081,7 @@ fu_hwids_func (void)
 	g_assert_cmpstr (fu_hwids_get_value (hwids, FU_HWIDS_KEY_BIOS_VERSION), ==,
 			 "GJET75WW (2.25 )");
 	g_assert_cmpstr (fu_hwids_get_value (hwids, FU_HWIDS_KEY_BIOS_MAJOR_RELEASE), ==, "02");
-	g_assert_cmpstr (fu_hwids_get_value (hwids, FU_HWIDS_KEY_BIOS_MINOR_RELEASE), ==, "25");
+	g_assert_cmpstr (fu_hwids_get_value (hwids, FU_HWIDS_KEY_BIOS_MINOR_RELEASE), ==, "19");
 	g_assert_cmpstr (fu_hwids_get_value (hwids, FU_HWIDS_KEY_PRODUCT_SKU), ==,
 			 "LENOVO_MT_20AR_BU_Think_FM_ThinkPad T440s");
 	for (guint i = 0; guids[i].key != NULL; i++) {


### PR DESCRIPTION
As it turns out, the major and minor BIOS version should also be
represented in hex format in the hash, but in contrast to the
enclosure type, always on 2 digits, padded if necessary.  There is no
decimal value in any of the hashes, it seems.

The previous data, I tested with didn't include major/minor version
numbers bigger than 9, so the issue didn't materialize.