### PR TITLE
trivial: Add a FuDevice flag to show the device is in bootloader mode

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -144,6 +144,8 @@ fwupd_device_flag_to_string (FwupdDeviceFlags device_flag)
 		return "use-runtime-version";
 	if (device_flag == FWUPD_DEVICE_FLAG_INSTALL_PARENT_FIRST)
 		return "install-parent-first";
+	if (device_flag == FWUPD_DEVICE_FLAG_IS_BOOTLOADER)
+		return "is-bootloader";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -192,6 +194,8 @@ fwupd_device_flag_from_string (const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_USE_RUNTIME_VERSION;
 	if (g_strcmp0 (device_flag, "install-parent-first") == 0)
 		return FWUPD_DEVICE_FLAG_INSTALL_PARENT_FIRST;
+	if (g_strcmp0 (device_flag, "is-bootloader") == 0)
+		return FWUPD_DEVICE_FLAG_IS_BOOTLOADER;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -78,6 +78,7 @@ typedef enum {
  * @FWUPD_DEVICE_FLAG_NOTIFIED:			User has been notified
  * @FWUPD_DEVICE_FLAG_USE_RUNTIME_VERSION:	Always use the runtime version rather than the bootloader
  * @FWUPD_DEVICE_FLAG_INSTALL_PARENT_FIRST:	Install composite firmware on the parent before the child
+ * @FWUPD_DEVICE_FLAG_IS_BOOTLOADER:		Is currently in bootloader mode
  *
  * The device flags.
  **/
@@ -95,6 +96,7 @@ typedef enum {
 #define FWUPD_DEVICE_FLAG_NOTIFIED		(1u << 10)	/* Since: 1.0.5 */
 #define FWUPD_DEVICE_FLAG_USE_RUNTIME_VERSION	(1u << 11)	/* Since: 1.0.6 */
 #define FWUPD_DEVICE_FLAG_INSTALL_PARENT_FIRST	(1u << 12)	/* Since: 1.0.8 */
+#define FWUPD_DEVICE_FLAG_IS_BOOTLOADER		(1u << 13)	/* Since: 1.0.8 */
 #define FWUPD_DEVICE_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 0.7.3 */
 typedef guint64 FwupdDeviceFlags;
 

--- a/plugins/ebitdo/fu-ebitdo-device.h
+++ b/plugins/ebitdo/fu-ebitdo-device.h
@@ -21,7 +21,6 @@ G_DECLARE_FINAL_TYPE (FuEbitdoDevice, fu_ebitdo_device, FU, EBITDO_DEVICE, FuUsb
 FuEbitdoDevice	*fu_ebitdo_device_new			(GUsbDevice	*usb_device);
 
 /* getters */
-gboolean	 fu_ebitdo_device_is_bootloader		(FuEbitdoDevice	*device);
 const guint32	*fu_ebitdo_device_get_serial		(FuEbitdoDevice	*device);
 
 G_END_DECLS

--- a/plugins/ebitdo/fu-plugin-ebitdo.c
+++ b/plugins/ebitdo/fu-plugin-ebitdo.c
@@ -43,7 +43,7 @@ fu_plugin_update (FuPlugin *plugin,
 	g_autoptr(GUsbDevice) usb_device2 = NULL;
 
 	/* get version */
-	if (!fu_ebitdo_device_is_bootloader (ebitdo_dev)) {
+	if (!fu_device_has_flag (dev, FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_NOT_SUPPORTED,

--- a/plugins/unifying/lu-device-bootloader.c
+++ b/plugins/unifying/lu-device-bootloader.c
@@ -398,6 +398,7 @@ lu_device_bootloader_init (LuDeviceBootloader *device)
 	/* FIXME: we need something better */
 	fu_device_add_icon (FU_DEVICE (device), "preferences-desktop-keyboard");
 	fu_device_set_summary (FU_DEVICE (device), "A miniaturised USB wireless receiver (bootloader)");
+	fu_device_add_flag (FU_DEVICE (device), FWUPD_DEVICE_FLAG_IS_BOOTLOADER);
 }
 
 static void


### PR DESCRIPTION
This is useful to present to the user using the command line, and means each
FuDevice-deriving object does not have to handle this.