### PR TITLE
Add snap build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 /.flatpak-builder
 /repo
 *.flatpak
+*.snap
+/fwupdtool_source.tar.bz2
+/parts
+/prime
+/stage

--- a/contrib/ci/Dockerfile-snap.in
+++ b/contrib/ci/Dockerfile-snap.in
@@ -1,0 +1,5 @@
+FROM snapcore/snapcraft
+RUN mkdir /build
+WORKDIR /build
+COPY . .
+CMD ["./contrib/ci/snap.sh"]

--- a/contrib/ci/snap.sh
+++ b/contrib/ci/snap.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd /build
+snapcraft

--- a/contrib/snap/fwupdtool.wrapper
+++ b/contrib/snap/fwupdtool.wrapper
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+[ ! -d "$SNAP_USER_DATA/etc" ] && cp -R "$SNAP/etc" "$SNAP_USER_DATA"
+[ ! -d "$SNAP_USER_DATA/var" ] && cp -R "$SNAP/var" "$SNAP_USER_DATA"
+export PATH="$SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH"
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$SNAP/lib:$SNAP/usr/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu"
+export LD_LIBRARY_PATH=$SNAP_LIBRARY_PATH:$LD_LIBRARY_PATH
+exec "$SNAP/usr/lib/fwupd/fwupdtool" "$@"

--- a/contrib/snap/libefivar-fixpkgconfig/Makefile
+++ b/contrib/snap/libefivar-fixpkgconfig/Makefile
@@ -1,0 +1,12 @@
+export TRIPLET=$(shell gcc -dumpmachine)
+
+build:
+	true
+
+install:
+	sed -i 's!libdir=\(.*\)!libdir=${SNAPCRAFT_STAGE}\1!' ${SNAPCRAFT_STAGE}/usr/lib/${TRIPLET}/pkgconfig/efiboot.pc
+	sed -i 's!includedir=\(.*\)!includedir=${SNAPCRAFT_STAGE}\1!' ${SNAPCRAFT_STAGE}/usr/lib/${TRIPLET}/pkgconfig/efiboot.pc
+	sed -i 's!Cflags:\(.*\)!Cflags:\1 -L$$\{libdir\}!' ${SNAPCRAFT_STAGE}/usr/lib/${TRIPLET}/pkgconfig/efiboot.pc
+	sed -i 's!libdir=\(.*\)!libdir=${SNAPCRAFT_STAGE}\1!' ${SNAPCRAFT_STAGE}/usr/lib/${TRIPLET}/pkgconfig/efivar.pc
+	sed -i 's!includedir=\(.*\)!includedir=${SNAPCRAFT_STAGE}\1!' ${SNAPCRAFT_STAGE}/usr/lib/${TRIPLET}/pkgconfig/efivar.pc
+	sed -i 's!Cflags:\(.*\)!Cflags:\1 -L$$\{libdir\}!' ${SNAPCRAFT_STAGE}/usr/lib/${TRIPLET}/pkgconfig/efivar.pc

--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -1,0 +1,236 @@
+name: fwupdtool
+version-script: cat $SNAPCRAFT_STAGE/version
+version: 'daily'
+summary: A standalone version of fwupd to install newer firmware updates
+description: |
+  This is a tool that can be used to install firmware updates on devices
+  not yet supported by the version of fwupd distributed with the OS.
+
+grade: devel
+confinement: classic
+
+architectures:
+  - amd64
+
+apps:
+  fwupdtool:
+    command: fwupdtool.wrapper
+    completer:
+      usr/share/bash-completion/completions/fwupdtool
+
+parts:
+  libefivar-dev:
+    plugin: make
+    source: https://github.com/rhboot/efivar.git
+    source-type: git
+    build-packages:
+      - libpopt-dev
+    organize:
+      usr/lib64: usr/lib/x86_64-linux-gnu
+      usr/lib: usr/lib/i386-linux-gnu
+    prime:
+     - -usr/include
+     - -usr/bin
+     - -usr/share/man
+     - -usr/lib/*/pkgconfig
+  #adjust the paths from libefivar
+  libefivar-fixpkgconfig:
+    plugin: make
+    source: contrib/snap/libefivar-fixpkgconfig
+    make-parameters:
+      - SNAPCRAFT_STAGE=$SNAPCRAFT_STAGE
+    after: [libefivar-dev]
+  libsmbios:
+    plugin: autotools
+    source: https://github.com/dell/libsmbios
+    source-type: git
+    build-packages:
+      - python3
+      - libxml2-dev
+      - pkg-config
+      - autoconf
+      - automake
+      - libtool
+      - autopoint
+    prime:
+      - -include/
+      - -lib/pkgconfig
+      - -lib/python3.5
+      - -sbin/
+      - -share/
+      - -etc/
+      - -lib/*.a
+  libfwup-dev:
+    plugin: make
+    source: https://github.com/rhboot/fwupdate.git
+    source-type: git
+    make-parameters:
+      - EFIDIR=ubuntu
+      - GNUEFIDIR=/usr/lib
+      - LIBDIR=$SNAPCRAFT_STAGE/usr/lib/x86_64-linux-gnu
+      - libdir=/usr/lib/x86_64-linux-gnu
+      - PKG_CONFIG_PATH=$SNAPCRAFT_STAGE/usr/lib/x86_64-linux-gnu/pkgconfig
+      - --eval=export PKG_CONFIG_PATH
+    build-packages:
+      - elfutils
+      - gnu-efi
+      - libasm1
+      - libdw1
+    prime:
+      - -usr/lib/debug
+      - -usr/lib/systemd
+      - -usr/src
+      - -usr/share
+      - -usr/lib/*/pkgconfig
+      - -usr/include
+      - -usr/bin
+    after: [libsmbios, libefivar-fixpkgconfig]
+  meson:
+    plugin: python
+    source: https://github.com/mesonbuild/meson.git
+    source-tag: 0.46.1
+    build-packages:
+      - ninja-build
+    prime:
+      - -bin
+      - -etc
+      - -lib
+      - -share
+      - -usr
+  appstream-glib-dev:
+    plugin: meson
+    meson-parameters: [--prefix=/usr, -Dgtk-doc=false, -Dintrospection=false, -Dman=false, -Drpm=false]
+    source: https://github.com/hughsie/appstream-glib
+    source-type: git
+    build-packages:
+      - python3-pip
+      - gperf
+      - intltool
+      - libarchive-dev
+      - libgcab-dev
+      - libgdk-pixbuf2.0-dev
+      - libgirepository1.0-dev
+      - libglib2.0-dev
+      - libgtk-3-dev
+      - libjson-glib-dev
+      - libsoup2.4-dev
+      - libsqlite3-dev
+      - libyaml-dev
+      - libstemmer-dev
+      - uuid-dev
+      - xmlto
+    stage-packages:
+      - libarchive13
+      - libgcab-1.0-0
+      - libsoup2.4-1
+      - libstemmer0d
+      - libgdk-pixbuf2.0-0
+    prime:
+      - -usr/bin
+      - -usr/include
+      - -usr/share/doc
+      - -usr/lib/*/asb-plugins-5
+      - -usr/share/bash-completion
+      - -usr/share/aclocal
+      - -usr/lib/*/pkgconfig
+      - -usr/share/installed-tests
+      - -usr/lib/systemd
+      - -usr/lib/glib-networking
+      - -usr/lib/dconf
+      - -usr/share/X11
+      - -usr/share/GConf
+      - -usr/share/dbus-1
+      - -usr/share/glib-2.0/schemas
+      - -usr/share/lintian
+      - -usr/share/man
+    after: [meson]
+  fwupd:
+    plugin: meson
+    meson-parameters: [--prefix=/usr,
+                       --libexecdir=/usr/lib,
+                       -Dtests=false,
+                       -Ddaemon=false,
+                       -Dgtkdoc=false,
+                       -Dplugin_colorhug=false,
+                       -Dplugin_uefi_labels=false,
+                       -Dintrospection=false,
+                       -Dsystemd=false,
+                       -Dman=false,
+                       -Dconsolekit=false,
+                       -Dpkcs7=false,
+                       -Dgpg=false]
+    source: .
+    source-type: git
+    override-build: |
+      snapcraftctl build
+      echo $(git describe HEAD) > $SNAPCRAFT_STAGE/version
+    build-packages:
+      - bash-completion
+      - gcab
+      - gettext
+      - gir1.2-pango-1.0
+      - libarchive-dev
+      - libelf-dev
+      - libgcab-dev
+      - libglib2.0-dev
+      - libgpgme11-dev
+      - libgudev-1.0-dev
+      - libgusb-dev
+      - libjson-glib-dev
+      - libsoup2.4-dev
+      - libsqlite3-dev
+      - locales
+      - pkg-config
+      - valac
+    stage-packages:
+      - libassuan0
+      - liblcms2-2
+      - libelf1
+      - libgpgme11
+      - libjson-glib-1.0-0
+      - libgusb2
+      - libgudev-1.0-0
+    prime:
+      - -usr/bin
+      - -usr/sbin
+      - -usr/lib/gnupg
+      - -usr/share/mime
+      - -usr/share/man
+      - -usr/share/GConf
+      - -etc/X11
+      - -etc/ldap
+      - -etc/logcheck
+      - -usr/lib/dconf
+      - -usr/lib/gcc
+      - -usr/lib/glib-networking
+      - -usr/lib/gnupg2
+      - -usr/lib/sasl2
+      - -usr/lib/systemd
+      - -usr/lib/*/audit
+      - -usr/share/glib-2.0/schemas
+      - -usr/share/X11
+      - -usr/include
+      - -etc/dbus-1
+      - -lib/systemd
+      - -lib/udev
+      - -usr/lib/fwupd/fwupd
+      - -usr/share/dbus-1
+      - -usr/share/gnupg
+      - -usr/share/lintian
+      - -usr/share/pkgconfig
+      - -usr/share/installed-tests
+      - -usr/share/polkit-1
+      - -usr/share/vala
+      - -usr/share/doc
+      - -usr/share/gnupg2
+      - -usr/share/info
+      - -usr/share/gir-1.0
+      - -usr/share/upstart
+      - -usr/lib/*/glib-2.0
+      - -usr/lib/*/pkgconfig
+    after: [appstream-glib-dev, libfwup-dev]
+  fwupdtool-wrapper:
+    plugin: dump
+    source: contrib/snap
+    stage:
+    - fwupdtool.wrapper

--- a/snap
+++ b/snap
@@ -1,0 +1,1 @@
+contrib/snap/


### PR DESCRIPTION
There are 4 build systems that can be used for generating snaps:
* Travis CI (in a docker container)
* build.snapcraft.io
* Launchpad
* LXC

So after reading and experimenting with the pros/cons of the various different approaches I think the best thing to do is to keep snapcraft.yaml in tree (contrib/snap/) and them symlink the snap directory to top level (to let it build with build.snapcraft.io).

Here's my reasoning:
1) You don't need to cache credentials into Travis that will expire in 1 year.
2)  It will build automatically on pushes to master and publish them to the "edge" channel in the snap store.  That means anyone running a distro with snapd can easily test master with fwupdtool.
3) Using LXC locally means just that - need to generate snaps on demand.

I've done some tests with automatic publishing and once it's been reviewed the first time by a human at the snap store it should be hands off for the future.
The test version is published here: https://dashboard.snapcraft.io/snaps/fwupdtool/
