### PR TITLE
Clean up plugins as the last step of engine cleanup (Closes: #550)

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3435,7 +3435,6 @@ fu_engine_finalize (GObject *obj)
 	g_object_unref (self->quirks);
 	g_object_unref (self->hwids);
 	g_object_unref (self->history);
-	g_object_unref (self->plugin_list);
 	g_object_unref (self->profile);
 	g_object_unref (self->store);
 	g_object_unref (self->device_list);
@@ -3443,6 +3442,7 @@ fu_engine_finalize (GObject *obj)
 	g_ptr_array_unref (self->plugin_filter);
 	g_hash_table_unref (self->runtime_versions);
 	g_hash_table_unref (self->compile_versions);
+	g_object_unref (self->plugin_list);
 
 	G_OBJECT_CLASS (fu_engine_parent_class)->finalize (obj);
 }

--- a/src/fu-plugin.c
+++ b/src/fu-plugin.c
@@ -1647,15 +1647,17 @@ fu_plugin_finalize (GObject *object)
 		g_hash_table_unref (priv->runtime_versions);
 	if (priv->compile_versions != NULL)
 		g_hash_table_unref (priv->compile_versions);
-#ifndef RUNNING_ON_VALGRIND
-	if (priv->module != NULL)
-		g_module_close (priv->module);
-#endif
 	g_hash_table_unref (priv->devices);
 	g_hash_table_unref (priv->devices_delay);
 	g_hash_table_unref (priv->report_metadata);
 	g_free (priv->name);
 	g_free (priv->data);
+	/* Must happen as the last step to avoid prematurely
+	 * freeing memory held by the plugin */
+#ifndef RUNNING_ON_VALGRIND
+	if (priv->module != NULL)
+		g_module_close (priv->module);
+#endif
 
 	G_OBJECT_CLASS (fu_plugin_parent_class)->finalize (object);
 }


### PR DESCRIPTION
Fixes a segfault that occurs during cleanup of USB plugins.

When g_module_close was called memory allocated by the plugin would
get freed leading to the finalize method for object class pointing
to garbage.