### PR TITLE
trivial: Correct the install task ordering

### DIFF
--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -282,11 +282,11 @@ fu_device_add_child (FuDevice *device, FuDevice *child)
 
 	/* order devices so they are updated in the correct sequence */
 	if (fu_device_has_flag (child, FWUPD_DEVICE_FLAG_INSTALL_PARENT_FIRST)) {
-		if (priv->order <= fu_device_get_order (child))
-			priv->order = fu_device_get_order (child) + 1;
-	} else {
 		if (priv->order >= fu_device_get_order (child))
 			fu_device_set_order (child, priv->order + 1);
+	} else {
+		if (priv->order <= fu_device_get_order (child))
+			priv->order = fu_device_get_order (child) + 1;
 	}
 }
 

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -221,9 +221,9 @@ fu_engine_device_parent_func (void)
 	g_assert_cmpstr (fu_device_get_vendor (device1), ==, "oem");
 
 	/* verify order */
-	g_assert_cmpint (fu_device_get_order (device1), ==, 1);
-	g_assert_cmpint (fu_device_get_order (device2), ==, 0);
-	g_assert_cmpint (fu_device_get_order (device3), ==, 1);
+	g_assert_cmpint (fu_device_get_order (device1), ==, 0);
+	g_assert_cmpint (fu_device_get_order (device2), ==, 1);
+	g_assert_cmpint (fu_device_get_order (device3), ==, 0);
 }
 
 static void


### PR DESCRIPTION
With some instrumented testing I was finding that without
FWUPD_DEVICE_FLAG_INSTALL_PARENT_FIRST being set that the parent
was installing first.

The parent was getting set to order "0" and child order "1".  So when the array was sorted, parents were getting installed first.