### PR TITLE
Add clang formating

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,32 @@
+﻿---
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: 'false'
+AlignConsecutiveDeclarations: 'false'
+AlignOperands: 'true'
+AlignTrailingComments: 'true'
+AllowAllParametersOfDeclarationOnNextLine: 'true'
+AllowShortBlocksOnASingleLine: 'false'
+AllowShortCaseLabelsOnASingleLine: 'false'
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: 'false'
+AlwaysBreakAfterReturnType: All
+BinPackArguments: 'true'
+BreakBeforeBraces: Linux
+DerivePointerAlignment: 'false'
+IndentCaseLabels: 'false'
+IndentWidth: '8'
+IncludeBlocks: 'Regroup'
+KeepEmptyLinesAtTheStartOfBlocks: 'false'
+Language: Cpp
+MaxEmptyLinesToKeep: '1'
+PointerAlignment: Right
+SortIncludes: 'true'
+SpaceAfterCStyleCast: 'true'
+SpaceBeforeAssignmentOperators : 'true'
+SpaceBeforeParens: Always
+SpaceInEmptyParentheses: 'false'
+SpacesInSquareBrackets: 'false'
+TabWidth: '8'
+UseTab: Always
+
+...

--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
-﻿---
+---
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: 'false'
-AlignConsecutiveDeclarations: 'false'
+AlignConsecutiveDeclarations: 'true'
 AlignOperands: 'true'
 AlignTrailingComments: 'true'
 AllowAllParametersOfDeclarationOnNextLine: 'false'

--- a/.clang-format
+++ b/.clang-format
@@ -4,12 +4,13 @@ AlignConsecutiveAssignments: 'false'
 AlignConsecutiveDeclarations: 'false'
 AlignOperands: 'true'
 AlignTrailingComments: 'true'
-AllowAllParametersOfDeclarationOnNextLine: 'true'
+AllowAllParametersOfDeclarationOnNextLine: 'false'
 AllowShortBlocksOnASingleLine: 'false'
 AllowShortCaseLabelsOnASingleLine: 'false'
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: 'false'
 AlwaysBreakAfterReturnType: All
+BinPackParameters: 'false'
 BinPackArguments: 'true'
 BreakBeforeBraces: Linux
 DerivePointerAlignment: 'false'

--- a/.clang-format
+++ b/.clang-format
@@ -34,4 +34,10 @@ PenaltyBreakAssignment: '3'
 PenaltyBreakString: '10'
 PenaltyExcessCharacter: '1'
 PenaltyBreakBeforeFirstCallParameter: '15'
+
+IncludeCategories:
+  - Regex:           'config.h'
+    Priority:        0
+  - Regex:           '.*'
+    Priority:        1
 ...

--- a/.clang-format
+++ b/.clang-format
@@ -30,4 +30,8 @@ SpacesInSquareBrackets: 'false'
 TabWidth: '8'
 UseTab: Always
 
+PenaltyBreakAssignment: '3'
+PenaltyBreakString: '10'
+PenaltyExcessCharacter: '1'
+PenaltyBreakBeforeFirstCallParameter: '15'
 ...

--- a/contrib/reformat-code.py
+++ b/contrib/reformat-code.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2017 Dell Inc.
+#
+# SPDX-License-Identifier: LGPL-2.1+
+#
+
+import argparse
+import os
+import sys
+import subprocess
+
+CLANG_FORMATTERS = ['clang-format-6.0', 'clang-format-5.0', 'clang-format-4.0']
+FIXUPS = {'g_autoptr (' : 'g_autoptr(',
+          'sizeof ('    : 'sizeof(',
+          'g_auto ('    : 'g_auto('
+         }
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Reformat code to match style")
+    parser.add_argument("files", nargs='*', help="files to reformat")
+    args = parser.parse_args()
+    if (len(args.files) == 0):
+        parser.print_help()
+        sys.exit (0)
+    return args
+
+def select_clang_version ():
+        for formatter in CLANG_FORMATTERS:
+                try:
+                        ret = subprocess.check_call ([formatter, '--version'])
+                        if (ret == 0):
+                                return formatter
+                except FileNotFoundError:
+                        continue
+        return None
+
+def reformat_file (formatter, f):
+        print ("Reformatting %s using %s" % (f, formatter))
+        ret = subprocess.check_call ([formatter, '-i', '-style=file', f])
+        lines = None
+        with open (f, 'r') as rfd:
+                lines = rfd.readlines()
+        with open (f, 'w') as wfd:
+                for line in lines:
+                        for fixup in FIXUPS:
+                                if fixup in line:
+                                        line = line.replace(fixup, FIXUPS[fixup])
+                        wfd.write (line)
+
+## Entry Point ##
+if __name__ == '__main__':
+        args = parse_args()
+        formatter = select_clang_version ()
+        if not formatter:
+                print ("No clang formatter installed")
+                sys.exit (1)
+        for f in args.files:
+                if not os.path.exists(f):
+                        print ("%s does not exist" % f)
+                        sys.exit(1)
+                if not (f.endswith (".c") or f.endswith ('.h')):
+                        print ("Skipping %s" % f)
+                        continue
+                reformat_file (formatter, f)
+        sys.exit (0)

--- a/plugins/dell/fu-dell-smi.c
+++ b/plugins/dell/fu-dell-smi.c
@@ -7,8 +7,8 @@
 
 #include "config.h"
 
-#include <appstream-glib.h>
 #include "fu-dell-smi.h"
+#include <appstream-glib.h>
 
 /* These are for dock query capabilities */
 struct dock_count_in {
@@ -26,8 +26,8 @@ struct dock_count_out {
 };
 
 /* This is used for host flash GUIDs */
-typedef union _ADDR_UNION{
-	uint8_t *buf;
+typedef union _ADDR_UNION {
+	uint8_t    *buf;
 	efi_guid_t *guid;
 } ADDR_UNION;
 #pragma pack()
@@ -36,7 +36,7 @@ static void
 _dell_smi_obj_free (FuDellSmiObj *obj)
 {
 	dell_smi_obj_free (obj->smi);
-	g_free(obj);
+	g_free (obj);
 }
 
 #pragma clang diagnostic push
@@ -51,7 +51,7 @@ fu_dell_clear_smi (FuDellSmiObj *obj)
 	if (obj->fake_smbios)
 		return TRUE;
 
-	for (gint i=0; i < 4; i++) {
+	for (gint i = 0; i < 4; i++) {
 		obj->input[i] = 0;
 		obj->output[i] = 0;
 	}
@@ -90,13 +90,8 @@ fu_dell_execute_simple_smi (FuDellSmiObj *obj, guint16 class, guint16 select)
 	if (obj->fake_smbios)
 		return TRUE;
 
-	if (dell_simple_ci_smi (class,
-				select,
-				obj->input,
-				obj->output)) {
-		g_debug ("failed to run query %u/%u",
-			 class,
-			 select);
+	if (dell_simple_ci_smi (class, select, obj->input, obj->output)) {
+		g_debug ("failed to run query %u/%u", class, select);
 		return FALSE;
 	}
 	return TRUE;
@@ -105,25 +100,24 @@ fu_dell_execute_simple_smi (FuDellSmiObj *obj, guint16 class, guint16 select)
 gboolean
 fu_dell_detect_dock (FuDellSmiObj *smi_obj, guint32 *location)
 {
-	struct dock_count_in *count_args;
+	struct dock_count_in  *count_args;
 	struct dock_count_out *count_out;
 
 	/* look up dock count */
 	count_args = (struct dock_count_in *) smi_obj->input;
-	count_out  = (struct dock_count_out *) smi_obj->output;
+	count_out = (struct dock_count_out *) smi_obj->output;
 	if (!fu_dell_clear_smi (smi_obj)) {
 		g_debug ("failed to clear SMI buffers");
 		return FALSE;
 	}
 	count_args->argument = DACI_DOCK_ARG_COUNT;
 
-	if (!fu_dell_execute_simple_smi (smi_obj,
-					 DACI_DOCK_CLASS,
-					 DACI_DOCK_SELECT))
+	if (!fu_dell_execute_simple_smi (smi_obj, DACI_DOCK_CLASS, DACI_DOCK_SELECT))
 		return FALSE;
 	if (count_out->ret != 0) {
 		g_debug ("Failed to query system for dock count: "
-			 "(%" G_GUINT32_FORMAT ")", count_out->ret);
+			 "(%" G_GUINT32_FORMAT ")",
+			 count_out->ret);
 		return FALSE;
 	}
 	if (count_out->count < 1) {
@@ -138,9 +132,9 @@ fu_dell_detect_dock (FuDellSmiObj *smi_obj, guint32 *location)
 gboolean
 fu_dell_query_dock (FuDellSmiObj *smi_obj, DOCK_UNION *buf)
 {
-	gint result;
+	gint    result;
 	guint32 location;
-	guint buf_size;
+	guint   buf_size;
 
 	if (!fu_dell_detect_dock (smi_obj, &location))
 		return FALSE;
@@ -155,10 +149,9 @@ fu_dell_query_dock (FuDellSmiObj *smi_obj, DOCK_UNION *buf)
 		dell_smi_obj_set_select (smi_obj->smi, DACI_DOCK_SELECT);
 		dell_smi_obj_set_arg (smi_obj->smi, cbARG1, DACI_DOCK_ARG_INFO);
 		dell_smi_obj_set_arg (smi_obj->smi, cbARG2, location);
-		buf_size = sizeof (DOCK_INFO_RECORD);
+		buf_size = sizeof(DOCK_INFO_RECORD);
 		buf->buf = dell_smi_obj_make_buffer_frombios_auto (smi_obj->smi,
-								  cbARG3,
-								  buf_size);
+								   cbARG3, buf_size);
 		if (!buf->buf) {
 			g_debug ("Failed to initialize buffer");
 			return FALSE;
@@ -169,21 +162,21 @@ fu_dell_query_dock (FuDellSmiObj *smi_obj, DOCK_UNION *buf)
 	result = fu_dell_get_res (smi_obj, cbARG1);
 	if (result != SMI_SUCCESS) {
 		if (result == SMI_INVALID_BUFFER) {
-			g_debug ("Invalid buffer size, needed %" G_GUINT32_FORMAT,
+			g_debug ("Invalid buffer size, needed "
+				 "%" G_GUINT32_FORMAT,
 				 fu_dell_get_res (smi_obj, cbARG2));
 		} else {
-			g_debug ("SMI execution returned error: %d",
-				 result);
+			g_debug ("SMI execution returned error: %d", result);
 		}
 		return FALSE;
 	}
 	return TRUE;
 }
 
-const gchar*
+const gchar *
 fu_dell_get_dock_type (guint8 type)
 {
-	g_autoptr (FuDellSmiObj) smi_obj = NULL;
+	g_autoptr(FuDellSmiObj) smi_obj = NULL;
 	DOCK_UNION buf;
 
 	/* not yet initialized, look it up */
@@ -201,16 +194,14 @@ fu_dell_get_dock_type (guint8 type)
 	case DOCK_TYPE_WD15:
 		return "WD15";
 	default:
-		g_debug ("Dock type %d unknown",
-			 type);
+		g_debug ("Dock type %d unknown", type);
 	}
 
 	return NULL;
 }
 
 gboolean
-fu_dell_toggle_dock_mode (FuDellSmiObj *smi_obj, guint32 new_mode,
-			  guint32 dock_location, GError **error)
+fu_dell_toggle_dock_mode (FuDellSmiObj *smi_obj, guint32 new_mode, guint32 dock_location, GError **error)
 {
 	/* Put into mode to accept AR/MST */
 	fu_dell_clear_smi (smi_obj);
@@ -218,16 +209,11 @@ fu_dell_toggle_dock_mode (FuDellSmiObj *smi_obj, guint32 new_mode,
 	smi_obj->input[1] = dock_location;
 	smi_obj->input[2] = new_mode;
 
-	if (!fu_dell_execute_simple_smi (smi_obj,
-					 DACI_DOCK_CLASS,
-					 DACI_DOCK_SELECT))
+	if (!fu_dell_execute_simple_smi (smi_obj, DACI_DOCK_CLASS, DACI_DOCK_SELECT))
 		return FALSE;
 	if (smi_obj->output[1] != 0) {
-		g_set_error (error,
-			     G_IO_ERROR,
-			     G_IO_ERROR_INVALID_DATA,
-			     "Failed to set dock flash mode: %u",
-			     smi_obj->output[1]);
+		g_set_error (error, G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+			     "Failed to set dock flash mode: %u", smi_obj->output[1]);
 		return FALSE;
 	}
 	return TRUE;
@@ -236,7 +222,7 @@ fu_dell_toggle_dock_mode (FuDellSmiObj *smi_obj, guint32 new_mode,
 gboolean
 fu_dell_toggle_host_mode (FuDellSmiObj *smi_obj, const efi_guid_t guid, int mode)
 {
-	gint ret;
+	gint       ret;
 	ADDR_UNION buf;
 
 	dell_smi_obj_set_class (smi_obj->smi, DACI_FLASH_INTERFACE_CLASS);
@@ -244,21 +230,20 @@ fu_dell_toggle_host_mode (FuDellSmiObj *smi_obj, const efi_guid_t guid, int mode
 	dell_smi_obj_set_arg (smi_obj->smi, cbARG1, DACI_FLASH_ARG_FLASH_MODE);
 	dell_smi_obj_set_arg (smi_obj->smi, cbARG4, mode);
 	/* needs to be padded with an empty GUID */
-	buf.buf = dell_smi_obj_make_buffer_frombios_withoutheader(smi_obj->smi,
-								  cbARG2,
-								  sizeof(efi_guid_t) * 2);
+	buf.buf = dell_smi_obj_make_buffer_frombios_withoutheader (
+	    smi_obj->smi, cbARG2, sizeof(efi_guid_t) * 2);
 	if (!buf.buf) {
 		g_debug ("Failed to initialize SMI buffer");
 		return FALSE;
 	}
 	*buf.guid = guid;
-	ret = dell_smi_obj_execute(smi_obj->smi);
-	if (ret != SMI_SUCCESS){
+	ret = dell_smi_obj_execute (smi_obj->smi);
+	if (ret != SMI_SUCCESS) {
 		g_debug ("failed to execute SMI: %d", ret);
 		return FALSE;
 	}
 
-	ret = dell_smi_obj_get_res(smi_obj->smi, cbRES1);
+	ret = dell_smi_obj_get_res (smi_obj->smi, cbRES1);
 	if (ret != SMI_SUCCESS) {
 		g_debug ("SMI execution returned error: %d", ret);
 		return FALSE;

--- a/plugins/dell/fu-dell-smi.h
+++ b/plugins/dell/fu-dell-smi.h
@@ -100,6 +100,7 @@ fu_dell_toggle_dock_mode (FuDellSmiObj *smi_obj, guint32 new_mode,
 gboolean
 fu_dell_toggle_host_mode (FuDellSmiObj *smi_obj, const efi_guid_t guid, int mode);
 
+/* clang-format off */
 /* SMI return values used */
 #define SMI_SUCCESS			0
 #define SMI_INVALID_BUFFER		-6
@@ -127,5 +128,6 @@ fu_dell_toggle_host_mode (FuDellSmiObj *smi_obj, const efi_guid_t guid, int mode
 /* VID/PID of ethernet controller on dock */
 #define DOCK_NIC_VID		0x0bda
 #define DOCK_NIC_PID		0x8153
+/* clang-format on */
 
 #endif /* __FU_DELL_COMMON_H */

--- a/plugins/dell/fu-dell-smi.h
+++ b/plugins/dell/fu-dell-smi.h
@@ -9,16 +9,16 @@
 #define __FU_DELL_COMMON_H
 
 #include "fu-device.h"
-#include <smbios_c/smi.h>
-#include <smbios_c/obj/smi.h>
 #include <efivar.h>
+#include <smbios_c/obj/smi.h>
+#include <smbios_c/smi.h>
 
 typedef struct {
-	struct dell_smi_obj	*smi;
-	guint32			input[4];
-	guint32			output[4];
-	gboolean		fake_smbios;
-	guint8			*fake_buffer;
+	struct dell_smi_obj *smi;
+	guint32		     input[4];
+	guint32		     output[4];
+	gboolean	     fake_smbios;
+	guint8 	     *fake_buffer;
 } FuDellSmiObj;
 
 /* Dock Info version 1 */
@@ -26,46 +26,44 @@ typedef struct {
 #define MAX_COMPONENTS 5
 
 typedef struct _COMPONENTS {
-	gchar		description[80];
-	guint32		fw_version; 		/* BCD format: 0x00XXYYZZ */
+	gchar   description[80];
+	guint32 fw_version; /* BCD format: 0x00XXYYZZ */
 } COMPONENTS;
 
 typedef struct _DOCK_INFO {
-	gchar		dock_description[80];
-	guint32		flash_pkg_version;	/* BCD format: 0x00XXYYZZ */
-	guint32		cable_type;		/* bit0-7 cable type, bit7-31 set to 0 */
-	guint8		location;		/* Location of the dock */
-	guint8		reserved;
-	guint8		component_count;
-	COMPONENTS	components[MAX_COMPONENTS];	/* number of component_count */
+	gchar      dock_description[80];
+	guint32    flash_pkg_version; /* BCD format: 0x00XXYYZZ */
+	guint32    cable_type;	/* bit0-7 cable type, bit7-31 set to 0 */
+	guint8     location;	  /* Location of the dock */
+	guint8     reserved;
+	guint8     component_count;
+	COMPONENTS components[MAX_COMPONENTS]; /* number of component_count */
 } DOCK_INFO;
 
 typedef struct _DOCK_INFO_HEADER {
-	guint8		dir_version;  		/* version 1, 2 … */
-	guint8		dock_type;
-	guint16		reserved;
+	guint8  dir_version; /* version 1, 2 … */
+	guint8  dock_type;
+	guint16 reserved;
 } DOCK_INFO_HEADER;
 
 typedef struct _DOCK_INFO_RECORD {
-	DOCK_INFO_HEADER	dock_info_header; /* dock version specific definition */
-	DOCK_INFO		dock_info;
+	DOCK_INFO_HEADER dock_info_header; /* dock version specific definition */
+	DOCK_INFO	dock_info;
 } DOCK_INFO_RECORD;
 
-typedef union _DOCK_UNION{
-	guint8 *buf;
+typedef union _DOCK_UNION {
+	guint8 	  *buf;
 	DOCK_INFO_RECORD *record;
 } DOCK_UNION;
 #pragma pack()
 
-typedef enum _DOCK_TYPE
-{
+typedef enum _DOCK_TYPE {
 	DOCK_TYPE_NONE,
 	DOCK_TYPE_TB16,
 	DOCK_TYPE_WD15
 } DOCK_TYPE;
 
-typedef enum _CABLE_TYPE
-{
+typedef enum _CABLE_TYPE {
 	CABLE_TYPE_NONE,
 	CABLE_TYPE_LEGACY,
 	CABLE_TYPE_UNIV,
@@ -90,12 +88,14 @@ fu_dell_detect_dock (FuDellSmiObj *obj, guint32 *location);
 gboolean
 fu_dell_query_dock (FuDellSmiObj *smi_obj, DOCK_UNION *buf);
 
-const gchar*
+const gchar *
 fu_dell_get_dock_type (guint8 type);
 
 gboolean
-fu_dell_toggle_dock_mode (FuDellSmiObj *smi_obj, guint32 new_mode,
-			  guint32 dock_location, GError **error);
+fu_dell_toggle_dock_mode (FuDellSmiObj *smi_obj,
+			  guint32       new_mode,
+			  guint32       dock_location,
+			  GError **     error);
 
 gboolean
 fu_dell_toggle_host_mode (FuDellSmiObj *smi_obj, const efi_guid_t guid, int mode);

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -19,6 +19,7 @@
 #include "fu-plugin-vfuncs.h"
 #include "fu-device-metadata.h"
 
+/* clang-format off */
 /* These are used to indicate the status of a previous DELL flash */
 #define DELL_SUCCESS			0x0000
 #define DELL_CONSISTENCY_FAIL		0x0001
@@ -38,6 +39,7 @@
 
 /* Delay for settling */
 #define DELL_FLASH_MODE_DELAY		2
+/* clang-format on */
 
 typedef struct _DOCK_DESCRIPTION
 {
@@ -46,6 +48,7 @@ typedef struct _DOCK_DESCRIPTION
 	const gchar *		desc;
 } DOCK_DESCRIPTION;
 
+/* clang-format off */
 /* These are for matching the components */
 #define WD15_EC_STR		"2 0 2 2 0"
 #define TB16_EC_STR		"2 0 2 1 0"
@@ -76,6 +79,7 @@ typedef struct _DOCK_DESCRIPTION
 
 /* supported host related GUIDs */
 #define MST_GPIO_GUID		EFI_GUID (0xF24F9bE4, 0x2a13, 0x4344, 0xBC05, 0x01, 0xCE, 0xF7, 0xDA, 0xEF, 0x92)
+/* clang-format on */
 
 /**
  * Devices that should allow modeswitching

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -8,16 +8,15 @@
 
 #include "config.h"
 
+#include "fu-device-metadata.h"
+#include "fu-plugin-dell.h"
+#include "fu-plugin-vfuncs.h"
 #include <appstream-glib.h>
+#include <fcntl.h>
 #include <glib/gstdio.h>
 #include <smbios_c/system_info.h>
 #include <string.h>
 #include <unistd.h>
-#include <fcntl.h>
-
-#include "fu-plugin-dell.h"
-#include "fu-plugin-vfuncs.h"
-#include "fu-device-metadata.h"
 
 /* clang-format off */
 /* These are used to indicate the status of a previous DELL flash */
@@ -41,11 +40,10 @@
 #define DELL_FLASH_MODE_DELAY		2
 /* clang-format on */
 
-typedef struct _DOCK_DESCRIPTION
-{
-	const gchar *		guid;
-	const gchar *		query;
-	const gchar *		desc;
+typedef struct _DOCK_DESCRIPTION {
+	const gchar *guid;
+	const gchar *query;
+	const gchar *desc;
 } DOCK_DESCRIPTION;
 
 /* clang-format off */
@@ -84,66 +82,65 @@ typedef struct _DOCK_DESCRIPTION
 /**
  * Devices that should allow modeswitching
  */
-static guint16 tpm_switch_whitelist[] = {0x06F2, 0x06F3, 0x06DD, 0x06DE, 0x06DF,
-					 0x06DB, 0x06DC, 0x06BB, 0x06C6, 0x06BA,
-					 0x06B9, 0x05CA, 0x06C7, 0x06B7, 0x06E0,
-					 0x06E5, 0x06D9, 0x06DA, 0x06E4, 0x0704,
-					 0x0720, 0x0730, 0x0758, 0x0759, 0x075B,
-					 0x07A0, 0x079F, 0x07A4, 0x07A5, 0x07A6,
-					 0x07A7, 0x07A8, 0x07A9, 0x07AA, 0x07AB,
-					 0x07B0, 0x07B1, 0x07B2, 0x07B4, 0x07B7,
-					 0x07B8, 0x07B9, 0x07BE, 0x07BF, 0x077A,
-					 0x07CF};
+static guint16 tpm_switch_whitelist[] = {
+    0x06F2, 0x06F3, 0x06DD, 0x06DE, 0x06DF, 0x06DB, 0x06DC, 0x06BB,
+    0x06C6, 0x06BA, 0x06B9, 0x05CA, 0x06C7, 0x06B7, 0x06E0, 0x06E5,
+    0x06D9, 0x06DA, 0x06E4, 0x0704, 0x0720, 0x0730, 0x0758, 0x0759,
+    0x075B, 0x07A0, 0x079F, 0x07A4, 0x07A5, 0x07A6, 0x07A7, 0x07A8,
+    0x07A9, 0x07AA, 0x07AB, 0x07B0, 0x07B1, 0x07B2, 0x07B4, 0x07B7,
+    0x07B8, 0x07B9, 0x07BE, 0x07BF, 0x077A, 0x07CF};
 /**
-  * Dell device types to run
-  */
-static guint8 enclosure_whitelist [] = { 0x03, /* desktop */
-					 0x04, /* low profile desktop */
-					 0x06, /* mini tower */
-					 0x07, /* tower */
-					 0x08, /* portable */
-					 0x09, /* laptop */
-					 0x0A, /* notebook */
-					 0x0D, /* AIO */
-					 0x1E, /* tablet */
-					 0x1F, /* convertible */
-					 0x21, /* IoT gateway */
-					 0x22, /* embedded PC */};
+ * Dell device types to run
+ */
+static guint8 enclosure_whitelist[] = {0x03, /* desktop */
+				       0x04, /* low profile desktop */
+				       0x06, /* mini tower */
+				       0x07, /* tower */
+				       0x08, /* portable */
+				       0x09, /* laptop */
+				       0x0A, /* notebook */
+				       0x0D, /* AIO */
+				       0x1E, /* tablet */
+				       0x1F, /* convertible */
+				       0x21, /* IoT gateway */
+				       0x22,
+				       /* embedded PC */};
 
 /**
-  * System blacklist on older libsmbios
-  */
-static guint16 system_blacklist [] =	{ 0x071E, /* latitude 5414 */
-					  0x07A8, /* latitude 5580 */
-					  0x077A, /* xps 9365 */ };
+ * System blacklist on older libsmbios
+ */
+static guint16 system_blacklist[] = {0x071E, /* latitude 5414 */
+				     0x07A8, /* latitude 5580 */
+				     0x077A,
+				     /* xps 9365 */};
 
 /**
-  * Systems containing host MST device
-  */
-static guint16 systems_host_mst [] =	{ 0x062d, /* Latitude E7250 */
-					  0x062e, /* Latitude E7450 */
-					  0x062a, /* Latitude E5250 */
-					  0x062b, /* Latitude E5450 */
-					  0x062c, /* Latitude E5550 */
-					  0x06db, /* Latitude E7270 */
-					  0x06dc, /* Latitude E7470 */
-					  0x06dd, /* Latitude E5270 */
-					  0x06de, /* Latitude E5470 */
-					  0x06df, /* Latitude E5570 */
-					  0x06e0, /* Precision 3510 */
-					  0x071d, /* Latitude Rugged 7214 */
-					  0x071e, /* Latitude Rugged 5414 */
-					  0x071c, /* Latitude Rugged 7414 */};
+ * Systems containing host MST device
+ */
+static guint16 systems_host_mst[] = {0x062d, /* Latitude E7250 */
+				     0x062e, /* Latitude E7450 */
+				     0x062a, /* Latitude E5250 */
+				     0x062b, /* Latitude E5450 */
+				     0x062c, /* Latitude E5550 */
+				     0x06db, /* Latitude E7270 */
+				     0x06dc, /* Latitude E7470 */
+				     0x06dd, /* Latitude E5270 */
+				     0x06de, /* Latitude E5470 */
+				     0x06df, /* Latitude E5570 */
+				     0x06e0, /* Precision 3510 */
+				     0x071d, /* Latitude Rugged 7214 */
+				     0x071e, /* Latitude Rugged 5414 */
+				     0x071c,
+				     /* Latitude Rugged 7414 */};
 
 static guint16
 fu_dell_get_system_id (FuPlugin *plugin)
 {
 	const gchar *system_id_str = NULL;
-	guint16 system_id = 0;
-	gchar *endptr = NULL;
+	guint16      system_id = 0;
+	gchar       *endptr = NULL;
 
-	system_id_str = fu_plugin_get_dmi_value (plugin,
-		FU_HWIDS_KEY_PRODUCT_SKU);
+	system_id_str = fu_plugin_get_dmi_value (plugin, FU_HWIDS_KEY_PRODUCT_SKU);
 	if (system_id_str != NULL)
 		system_id = g_ascii_strtoull (system_id_str, &endptr, 16);
 	if (system_id == 0 || endptr == system_id_str)
@@ -170,11 +167,11 @@ static gboolean
 fu_dell_supported (FuPlugin *plugin)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
-	GBytes *de_table = NULL;
-	GBytes *enclosure = NULL;
-	guint16 system_id = 0;
+	GBytes       *de_table = NULL;
+	GBytes       *enclosure = NULL;
+	guint16       system_id = 0;
 	const guint8 *value;
-	gsize len;
+	gsize	 len;
 
 	/* make sure that Dell SMBIOS methods are available */
 	de_table = fu_plugin_get_smbios_data (plugin, 0xDE);
@@ -187,8 +184,7 @@ fu_dell_supported (FuPlugin *plugin)
 		return FALSE;
 
 	/* skip blacklisted hw on libsmbios 2.3 or less */
-	if (data->libsmbios_major <= 2 &&
-	    data->libsmbios_minor <= 3) {
+	if (data->libsmbios_major <= 2 && data->libsmbios_minor <= 3) {
 		system_id = fu_dell_get_system_id (plugin);
 		if (system_id == 0)
 			return FALSE;
@@ -199,8 +195,7 @@ fu_dell_supported (FuPlugin *plugin)
 	}
 
 	/* only run on intended Dell hw types */
-	enclosure = fu_plugin_get_smbios_data (plugin,
-					       FU_SMBIOS_STRUCTURE_TYPE_CHASSIS);
+	enclosure = fu_plugin_get_smbios_data (plugin, FU_SMBIOS_STRUCTURE_TYPE_CHASSIS);
 	if (enclosure == NULL)
 		return FALSE;
 	value = g_bytes_get_data (enclosure, &len);
@@ -215,24 +210,23 @@ fu_dell_supported (FuPlugin *plugin)
 }
 
 static gboolean
-fu_plugin_dell_match_dock_component (const gchar *query_str,
+fu_plugin_dell_match_dock_component (const gchar  *query_str,
 				     const gchar **guid_out,
 				     const gchar **name_out)
 {
 	const DOCK_DESCRIPTION list[] = {
-		{WD15_EC_GUID, WD15_EC_STR, EC_DESC},
-		{TB16_EC_GUID, TB16_EC_STR, EC_DESC},
-		{WD15_PC1_GUID, WD15_PC1_STR, PC1_DESC},
-		{TB16_PC1_GUID, TB16_PC1_STR, PC1_DESC},
-		{TB16_PC2_GUID, TB16_PC2_STR, PC2_DESC},
-		{TBT_CBL_GUID, TBT_CBL_STR, TBT_CBL_DESC},
-		{UNIV_CBL_GUID, UNIV_CBL_STR, UNIV_CBL_DESC},
-		{LEGACY_CBL_GUID, LEGACY_CBL_STR, LEGACY_CBL_DESC},
+	    {WD15_EC_GUID, WD15_EC_STR, EC_DESC},
+	    {TB16_EC_GUID, TB16_EC_STR, EC_DESC},
+	    {WD15_PC1_GUID, WD15_PC1_STR, PC1_DESC},
+	    {TB16_PC1_GUID, TB16_PC1_STR, PC1_DESC},
+	    {TB16_PC2_GUID, TB16_PC2_STR, PC2_DESC},
+	    {TBT_CBL_GUID, TBT_CBL_STR, TBT_CBL_DESC},
+	    {UNIV_CBL_GUID, UNIV_CBL_STR, UNIV_CBL_DESC},
+	    {LEGACY_CBL_GUID, LEGACY_CBL_STR, LEGACY_CBL_DESC},
 	};
 
 	for (guint i = 0; i < G_N_ELEMENTS (list); i++) {
-		if (g_strcmp0 (query_str,
-			       list[i].query) == 0) {
+		if (g_strcmp0 (query_str, list[i].query) == 0) {
 			*guid_out = list[i].guid;
 			*name_out = list[i].desc;
 			return TRUE;
@@ -243,8 +237,11 @@ fu_plugin_dell_match_dock_component (const gchar *query_str,
 
 void
 fu_plugin_dell_inject_fake_data (FuPlugin *plugin,
-				 guint32 *output, guint16 vid, guint16 pid,
-				 guint8 *buf, gboolean can_switch_modes)
+				 guint32  *output,
+				 guint16   vid,
+				 guint16   pid,
+				 guint8   *buf,
+				 gboolean  can_switch_modes)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
 
@@ -271,8 +268,7 @@ fu_plugin_dell_get_version_format (FuPlugin *plugin)
 
 	/* any quirks match */
 	group = g_strdup_printf ("SmbiosManufacturer=%s", content);
-	quirk = fu_plugin_lookup_quirk_by_id (plugin, group,
-					      FU_QUIRKS_UEFI_VERSION_FORMAT);
+	quirk = fu_plugin_lookup_quirk_by_id (plugin, group, FU_QUIRKS_UEFI_VERSION_FORMAT);
 	if (g_strcmp0 (quirk, "quad") == 0)
 		return AS_VERSION_PARSE_FLAG_NONE;
 
@@ -281,11 +277,10 @@ fu_plugin_dell_get_version_format (FuPlugin *plugin)
 }
 
 static gchar *
-fu_plugin_get_dock_key (FuPlugin *plugin,
-			GUsbDevice *device, const gchar *guid)
+fu_plugin_get_dock_key (FuPlugin *plugin, GUsbDevice *device, const gchar *guid)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
-	const gchar* platform_id;
+	const gchar  *platform_id;
 
 	if (data->smi_obj->fake_smbios)
 		platform_id = "fake";
@@ -303,9 +298,12 @@ fu_plugin_dell_capsule_supported (FuPlugin *plugin)
 }
 
 static gboolean
-fu_plugin_dock_node (FuPlugin *plugin, GUsbDevice *device,
-		     guint8 type, const gchar *component_guid,
-		     const gchar *component_desc, const gchar *version)
+fu_plugin_dock_node (FuPlugin *   plugin,
+		     GUsbDevice  *device,
+		     guint8       type,
+		     const gchar *component_guid,
+		     const gchar *component_desc,
+		     const gchar *version)
 {
 	const gchar *dock_type;
 	g_autofree gchar *dock_id = NULL;
@@ -328,8 +326,7 @@ fu_plugin_dock_node (FuPlugin *plugin, GUsbDevice *device,
 	dev = fu_device_new ();
 	dock_id = g_strdup_printf ("DELL-%s" G_GUINT64_FORMAT, component_guid);
 	if (component_desc != NULL) {
-		dock_name = g_strdup_printf ("Dell %s %s", dock_type,
-					     component_desc);
+		dock_name = g_strdup_printf ("Dell %s %s", dock_type, component_desc);
 		fu_device_add_parent_guid (dev, DOCK_FLASH_GUID);
 	} else {
 		dock_name = g_strdup_printf ("Dell %s", dock_type);
@@ -360,22 +357,19 @@ fu_plugin_dock_node (FuPlugin *plugin, GUsbDevice *device,
 	return TRUE;
 }
 
-
 void
-fu_plugin_dell_device_added_cb (GUsbContext *ctx,
-				GUsbDevice *device,
-				FuPlugin *plugin)
+fu_plugin_dell_device_added_cb (GUsbContext *ctx, GUsbDevice *device, FuPlugin *plugin)
 {
-	FuPluginData *data = fu_plugin_get_data (plugin);
+	FuPluginData      *data = fu_plugin_get_data (plugin);
 	AsVersionParseFlag parse_flags;
-	guint16 pid;
-	guint16 vid;
-	const gchar *query_str;
-	const gchar *component_guid = NULL;
-	const gchar *component_name = NULL;
-	DOCK_UNION buf;
-	DOCK_INFO *dock_info;
-	gboolean old_ec = FALSE;
+	guint16		   pid;
+	guint16		   vid;
+	const gchar       *query_str;
+	const gchar       *component_guid = NULL;
+	const gchar       *component_name = NULL;
+	DOCK_UNION	 buf;
+	DOCK_INFO 	*dock_info;
+	gboolean	   old_ec = FALSE;
 	g_autofree gchar *flash_ver_str = NULL;
 
 	/* don't look up immediately if a dock is connected as that would
@@ -424,17 +418,15 @@ fu_plugin_dell_device_added_cb (GUsbContext *ctx,
 		g_debug ("Dock component %u: %s (version 0x%x)", i,
 			 dock_info->components[i].description,
 			 dock_info->components[i].fw_version);
-		query_str = g_strrstr (dock_info->components[i].description,
-				       "Query ");
+		query_str =
+		    g_strrstr (dock_info->components[i].description, "Query ");
 		if (query_str == NULL) {
 			g_debug ("Invalid dock component request");
 			return;
 		}
-		if (!fu_plugin_dell_match_dock_component (query_str + 6,
-							  &component_guid,
-							  &component_name)) {
-			g_debug ("Unable to match dock component %s",
-				query_str);
+		if (!fu_plugin_dell_match_dock_component (
+			query_str + 6, &component_guid, &component_name)) {
+			g_debug ("Unable to match dock component %s", query_str);
 			return;
 		}
 
@@ -451,14 +443,11 @@ fu_plugin_dell_device_added_cb (GUsbContext *ctx,
 			continue;
 		}
 
-		fw_str = as_utils_version_from_uint32 (dock_info->components[i].fw_version,
-						       parse_flags);
-		if (!fu_plugin_dock_node (plugin,
-						 device,
-						 buf.record->dock_info_header.dock_type,
-						 component_guid,
-						 component_name,
-						 fw_str)) {
+		fw_str = as_utils_version_from_uint32 (
+		    dock_info->components[i].fw_version, parse_flags);
+		if (!fu_plugin_dock_node (plugin, device,
+					  buf.record->dock_info_header.dock_type,
+					  component_guid, component_name, fw_str)) {
 			g_debug ("Failed to create %s", component_name);
 			return;
 		}
@@ -466,36 +455,29 @@ fu_plugin_dell_device_added_cb (GUsbContext *ctx,
 
 	/* if an old EC or invalid EC version found, create updatable parent */
 	if (old_ec)
-		flash_ver_str = as_utils_version_from_uint32 (dock_info->flash_pkg_version,
-							      parse_flags);
-	if (!fu_plugin_dock_node (plugin,
-				  device,
-				  buf.record->dock_info_header.dock_type,
-				  DOCK_FLASH_GUID,
-				  NULL,
-				  flash_ver_str)) {
+		flash_ver_str = as_utils_version_from_uint32 (
+		    dock_info->flash_pkg_version, parse_flags);
+	if (!fu_plugin_dock_node (plugin, device, buf.record->dock_info_header.dock_type,
+				  DOCK_FLASH_GUID, NULL, flash_ver_str)) {
 		g_debug ("Failed to create top dock node");
 		return;
 	}
 
-#if defined (HAVE_SYNAPTICS)
+#if defined(HAVE_SYNAPTICS)
 	fu_plugin_request_recoldplug (plugin);
 #endif
 }
 
 void
-fu_plugin_dell_device_removed_cb (GUsbContext *ctx,
-				  GUsbDevice *device,
-				  FuPlugin *plugin)
+fu_plugin_dell_device_removed_cb (GUsbContext *ctx, GUsbDevice *device, FuPlugin *plugin)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
-	const gchar *guids[] = { WD15_EC_GUID, TB16_EC_GUID, TB16_PC2_GUID,
-				 TB16_PC1_GUID, WD15_PC1_GUID,
-				 LEGACY_CBL_GUID, UNIV_CBL_GUID,
-				 TBT_CBL_GUID, DOCK_FLASH_GUID};
-	guint16 pid;
-	guint16 vid;
-	FuDevice *dev = NULL;
+	const gchar  *guids[] = {WD15_EC_GUID,  TB16_EC_GUID,  TB16_PC2_GUID,
+				 TB16_PC1_GUID, WD15_PC1_GUID, LEGACY_CBL_GUID,
+				 UNIV_CBL_GUID, TBT_CBL_GUID,  DOCK_FLASH_GUID};
+	guint16       pid;
+	guint16       vid;
+	FuDevice     *dev = NULL;
 
 	if (!data->smi_obj->fake_smbios) {
 		vid = g_usb_device_get_vid (device);
@@ -512,16 +494,14 @@ fu_plugin_dell_device_removed_cb (GUsbContext *ctx,
 	/* remove any components already in database? */
 	for (guint i = 0; i < G_N_ELEMENTS (guids); i++) {
 		g_autofree gchar *dock_key = NULL;
-		dock_key = fu_plugin_get_dock_key (plugin, device,
-							  guids[i]);
+		dock_key = fu_plugin_get_dock_key (plugin, device, guids[i]);
 		dev = fu_plugin_cache_lookup (plugin, dock_key);
 		if (dev != NULL) {
-			fu_plugin_device_remove (plugin,
-						   dev);
+			fu_plugin_device_remove (plugin, dev);
 			fu_plugin_cache_remove (plugin, dock_key);
 		}
 	}
-#if defined (HAVE_SYNAPTICS)
+#if defined(HAVE_SYNAPTICS)
 	fu_plugin_request_recoldplug (plugin);
 #endif
 }
@@ -529,18 +509,17 @@ fu_plugin_dell_device_removed_cb (GUsbContext *ctx,
 gboolean
 fu_plugin_get_results (FuPlugin *plugin, FuDevice *device, GError **error)
 {
-	GBytes *de_table = NULL;
-	const gchar *tmp = NULL;
+	GBytes        *de_table = NULL;
+	const gchar   *tmp = NULL;
 	const guint16 *completion_code;
-	gsize len;
+	gsize	  len;
 
 	de_table = fu_plugin_get_smbios_data (plugin, 0xDE);
 	completion_code = g_bytes_get_data (de_table, &len);
 	if (len < 8) {
-		g_set_error (error,
-			     FWUPD_ERROR,
-			     FWUPD_ERROR_INTERNAL,
-			     "ERROR: Unable to read results of %s: %" G_GSIZE_FORMAT " < 8",
+		g_set_error (error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL,
+			     "ERROR: Unable to read results of %s: "
+			     "%" G_GSIZE_FORMAT " < 8",
 			     fu_device_get_name (device), len);
 		return FALSE;
 	}
@@ -552,46 +531,60 @@ fu_plugin_get_results (FuPlugin *plugin, FuDevice *device, GError **error)
 		fu_device_set_update_state (device, FWUPD_UPDATE_STATE_FAILED);
 		switch (completion_code[3]) {
 		case DELL_CONSISTENCY_FAIL:
-			tmp = "The image failed one or more consistency checks.";
+			tmp = "The image failed one or more consistency "
+			      "checks.";
 			break;
 		case DELL_FLASH_MEMORY_FAIL:
-			tmp = "The BIOS could not access the flash-memory device.";
+			tmp = "The BIOS could not access the flash-memory "
+			      "device.";
 			break;
 		case DELL_FLASH_NOT_READY:
-			tmp = "The flash-memory device was not ready when an erase was attempted.";
+			tmp = "The flash-memory device was not ready when an "
+			      "erase was attempted.";
 			break;
 		case DELL_FLASH_DISABLED:
-			tmp = "Flash programming is currently disabled on the system, or the voltage is low.";
+			tmp = "Flash programming is currently disabled on the "
+			      "system, or the voltage is low.";
 			break;
 		case DELL_BATTERY_MISSING:
-			tmp = "A battery must be installed for the operation to complete.";
+			tmp = "A battery must be installed for the operation "
+			      "to complete.";
 			break;
 		case DELL_BATTERY_DEAD:
-			tmp = "A fully-charged battery must be present for the operation to complete.";
+			tmp = "A fully-charged battery must be present for the "
+			      "operation to complete.";
 			break;
 		case DELL_AC_MISSING:
-			tmp = "An external power adapter must be connected for the operation to complete.";
+			tmp = "An external power adapter must be connected for "
+			      "the operation to complete.";
 			break;
 		case DELL_CANT_SET_12V:
-			tmp = "The 12V required to program the flash-memory could not be set.";
+			tmp = "The 12V required to program the flash-memory "
+			      "could not be set.";
 			break;
 		case DELL_CANT_UNSET_12V:
-			tmp = "The 12V required to program the flash-memory could not be removed.";
+			tmp = "The 12V required to program the flash-memory "
+			      "could not be removed.";
 			break;
-		case DELL_FAILURE_BLOCK_ERASE :
-			tmp = "A flash-memory failure occurred during a block-erase operation.";
+		case DELL_FAILURE_BLOCK_ERASE:
+			tmp = "A flash-memory failure occurred during a "
+			      "block-erase operation.";
 			break;
 		case DELL_GENERAL_FAILURE:
-			tmp = "A general failure occurred during the flash programming.";
+			tmp = "A general failure occurred during the flash "
+			      "programming.";
 			break;
 		case DELL_DATA_MISCOMPARE:
-			tmp = "A data miscompare error occurred during the flash programming.";
+			tmp = "A data miscompare error occurred during the "
+			      "flash programming.";
 			break;
 		case DELL_IMAGE_MISSING:
-			tmp = "The image could not be found in memory, i.e. the header could not be located.";
+			tmp = "The image could not be found in memory, i.e. "
+			      "the header could not be located.";
 			break;
 		case DELL_DID_NOTHING:
-			tmp = "No update operation has been performed on the system.";
+			tmp = "No update operation has been performed on the "
+			      "system.";
 			break;
 		default:
 			break;
@@ -607,10 +600,10 @@ gboolean
 fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
-	const gchar *tpm_mode;
-	const gchar *tpm_mode_alt;
-	guint16 system_id = 0;
-	gboolean can_switch_modes = FALSE;
+	const gchar  *tpm_mode;
+	const gchar  *tpm_mode_alt;
+	guint16       system_id = 0;
+	gboolean      can_switch_modes = FALSE;
 	g_autofree gchar *pretty_tpm_name_alt = NULL;
 	g_autofree gchar *pretty_tpm_name = NULL;
 	g_autofree gchar *tpm_guid_raw_alt = NULL;
@@ -619,10 +612,10 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 	g_autofree gchar *tpm_guid_raw = NULL;
 	g_autofree gchar *tpm_id_alt = NULL;
 	g_autofree gchar *tpm_id = NULL;
-	g_autofree gchar *version_str = NULL;
+	g_autofree gchar  *version_str = NULL;
 	struct tpm_status *out = NULL;
-	g_autoptr (FuDevice) dev_alt = NULL;
-	g_autoptr (FuDevice) dev = NULL;
+	g_autoptr(FuDevice) dev_alt = NULL;
+	g_autoptr(FuDevice) dev = NULL;
 	const gchar *product_name = "Unknown";
 
 	fu_dell_clear_smi (data->smi_obj);
@@ -630,14 +623,14 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 
 	/* execute TPM Status Query */
 	data->smi_obj->input[0] = DACI_FLASH_ARG_TPM;
-	if (!fu_dell_execute_simple_smi (data->smi_obj,
-					 DACI_FLASH_INTERFACE_CLASS,
+	if (!fu_dell_execute_simple_smi (data->smi_obj, DACI_FLASH_INTERFACE_CLASS,
 					 DACI_FLASH_INTERFACE_SELECT))
 		return FALSE;
 
 	if (out->ret != 0) {
 		g_debug ("Failed to query system for TPM information: "
-			 "(%" G_GUINT32_FORMAT ")", out->ret);
+			 "(%" G_GUINT32_FORMAT ")",
+			 out->ret);
 		return FALSE;
 	}
 	/* HW version is output in second /input/ arg
@@ -686,8 +679,7 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 
 	g_debug ("Creating primary TPM GUID %s and secondary TPM GUID %s",
 		 tpm_guid_raw, tpm_guid_raw_alt);
-	version_str = as_utils_version_from_uint32 (out->fw_version,
-						    AS_VERSION_PARSE_FLAG_NONE);
+	version_str = as_utils_version_from_uint32 (out->fw_version, AS_VERSION_PARSE_FLAG_NONE);
 
 	/* make it clear that the TPM is a discrete device of the product */
 	if (!data->smi_obj->fake_smbios) {
@@ -715,8 +707,7 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 		}
 		fu_device_set_flashes_left (dev, out->flashes_left);
 	} else {
-		g_debug ("%s updating disabled due to TPM ownership",
-			pretty_tpm_name);
+		g_debug ("%s updating disabled due to TPM ownership", pretty_tpm_name);
 	}
 	fu_plugin_device_register (plugin, dev);
 
@@ -727,13 +718,15 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 		fu_device_add_guid (dev_alt, tpm_guid_alt);
 		fu_device_set_vendor (dev, "Dell Inc.");
 		fu_device_set_name (dev_alt, pretty_tpm_name_alt);
-		fu_device_set_summary (dev_alt, "Alternate mode for platform TPM device");
+		fu_device_set_summary (dev_alt, "Alternate mode for platform "
+						"TPM device");
 		fu_device_add_flag (dev_alt, FWUPD_DEVICE_FLAG_INTERNAL);
 		fu_device_add_flag (dev_alt, FWUPD_DEVICE_FLAG_REQUIRE_AC);
 		fu_device_add_flag (dev_alt, FWUPD_DEVICE_FLAG_LOCKED);
 		fu_device_add_icon (dev_alt, "computer");
 		fu_device_set_alternate_id (dev_alt, fu_device_get_id (dev));
-		fu_device_set_metadata (dev_alt, FU_DEVICE_METADATA_UEFI_DEVICE_KIND, "system-firmware");
+		fu_device_set_metadata (dev_alt, FU_DEVICE_METADATA_UEFI_DEVICE_KIND,
+					"system-firmware");
 		fu_device_add_parent_guid (dev_alt, tpm_guid);
 
 		/* If TPM is not owned and at least 1 flash left allow mode switching
@@ -744,14 +737,11 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 		if ((out->status & TPM_OWN_MASK) == 0 && out->flashes_left > 0) {
 			fu_device_set_flashes_left (dev_alt, out->flashes_left);
 		} else {
-			g_debug ("%s mode switch disabled due to TPM ownership",
-				 pretty_tpm_name);
+			g_debug ("%s mode switch disabled due to TPM ownership", pretty_tpm_name);
 		}
 		fu_plugin_device_register (plugin, dev_alt);
-	}
-	else
-		g_debug ("System %04x does not offer TPM modeswitching",
-			system_id);
+	} else
+		g_debug ("System %04x does not offer TPM modeswitching", system_id);
 
 	return TRUE;
 }
@@ -759,48 +749,41 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 gboolean
 fu_plugin_unlock (FuPlugin *plugin, FuDevice *device, GError **error)
 {
-	FuDevice *device_alt = NULL;
+	FuDevice        *device_alt = NULL;
 	FwupdDeviceFlags device_flags_alt = 0;
-	guint flashes_left = 0;
-	guint flashes_left_alt = 0;
+	guint		 flashes_left = 0;
+	guint		 flashes_left_alt = 0;
 
 	/* for unlocking TPM1.2 <-> TPM2.0 switching */
 	g_debug ("Unlocking upgrades for: %s (%s)", fu_device_get_name (device),
 		 fu_device_get_id (device));
 	device_alt = fu_device_get_alternate (device);
 	if (device_alt == NULL) {
-		g_set_error (error,
-			     FWUPD_ERROR,
-			     FWUPD_ERROR_NOT_SUPPORTED,
-			     "No alternate device for %s",
-			     fu_device_get_name (device));
+		g_set_error (error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED,
+			     "No alternate device for %s", fu_device_get_name (device));
 		return FALSE;
 	}
-	g_debug ("Preventing upgrades for: %s (%s)", fu_device_get_name (device_alt),
-		 fu_device_get_id (device_alt));
+	g_debug ("Preventing upgrades for: %s (%s)",
+		 fu_device_get_name (device_alt), fu_device_get_id (device_alt));
 
 	flashes_left = fu_device_get_flashes_left (device);
 	flashes_left_alt = fu_device_get_flashes_left (device_alt);
 	if (flashes_left == 0) {
 		/* flashes left == 0 on both means no flashes left */
 		if (flashes_left_alt == 0) {
-			g_set_error (error,
-				     FWUPD_ERROR,
-				     FWUPD_ERROR_NOT_SUPPORTED,
+			g_set_error (error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED,
 				     "ERROR: %s has no flashes left.",
 				     fu_device_get_name (device));
-		/* flashes left == 0 on just unlocking device is ownership */
+			/* flashes left == 0 on just unlocking device is ownership */
 		} else {
-			g_set_error (error,
-				     FWUPD_ERROR,
-				     FWUPD_ERROR_NOT_SUPPORTED,
+			g_set_error (error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED,
 				     "ERROR: %s is currently OWNED. "
-				     "Ownership must be removed to switch modes.",
+				     "Ownership must be removed to switch "
+				     "modes.",
 				     fu_device_get_name (device_alt));
 		}
 		return FALSE;
 	}
-
 
 	/* clone the info from real device but prevent it from being flashed */
 	device_flags_alt = fu_device_get_flags (device_alt);
@@ -823,7 +806,7 @@ fu_plugin_device_registered (FuPlugin *plugin, FuDevice *device)
 		if (fu_device_get_metadata_boolean (device, FU_DEVICE_METADATA_TBT_IS_SAFE_MODE)) {
 			g_autofree gchar *vendor_id = NULL;
 			g_autofree gchar *device_id = NULL;
-			guint16 system_id = 0;
+			guint16		  system_id = 0;
 
 			vendor_id = g_strdup ("TBT:0x00D4");
 			system_id = fu_dell_get_system_id (plugin);
@@ -840,14 +823,13 @@ fu_plugin_device_registered (FuPlugin *plugin, FuDevice *device)
 }
 
 static gboolean
-fu_dell_toggle_flash (FuPlugin *plugin, FuDevice *device,
-		      gboolean enable, GError **error)
+fu_dell_toggle_flash (FuPlugin *plugin, FuDevice *device, gboolean enable, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
-	gboolean has_host = fu_dell_host_mst_supported (plugin);
-	gboolean has_dock;
-	guint32 dock_location;
-	const gchar *tmp;
+	gboolean      has_host = fu_dell_host_mst_supported (plugin);
+	gboolean      has_dock;
+	guint32       dock_location;
+	const gchar  *tmp;
 
 	if (device) {
 		if (!fu_device_has_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE))
@@ -861,8 +843,7 @@ fu_dell_toggle_flash (FuPlugin *plugin, FuDevice *device,
 	/* Dock MST Hub */
 	has_dock = fu_dell_detect_dock (data->smi_obj, &dock_location);
 	if (has_dock) {
-		if (!fu_dell_toggle_dock_mode (data->smi_obj, enable,
-					       dock_location, error))
+		if (!fu_dell_toggle_dock_mode (data->smi_obj, enable, dock_location, error))
 			g_debug ("unable to change dock to %d", enable);
 		else
 			g_debug ("Toggled dock mode to %d", enable);
@@ -876,7 +857,7 @@ fu_dell_toggle_flash (FuPlugin *plugin, FuDevice *device,
 			g_debug ("Toggled MST hub GPIO to %d", enable);
 	}
 
-#if defined (HAVE_SYNAPTICS)
+#if defined(HAVE_SYNAPTICS)
 	/* set a delay to allow OS response to settling the GPIO change */
 	if (enable && device == NULL && (has_dock || has_host))
 		fu_plugin_set_coldplug_delay (plugin, DELL_FLASH_MODE_DELAY * 1000);
@@ -885,20 +866,15 @@ fu_dell_toggle_flash (FuPlugin *plugin, FuDevice *device,
 }
 
 gboolean
-fu_plugin_update_prepare (FuPlugin *plugin,
-			  FuDevice *device,
-			  GError **error)
+fu_plugin_update_prepare (FuPlugin *plugin, FuDevice *device, GError **error)
 {
-
 	return fu_dell_toggle_flash (plugin, device, TRUE, error);
 }
 
 gboolean
-fu_plugin_update_cleanup (FuPlugin *plugin,
-			  FuDevice *device,
-			  GError **error)
+fu_plugin_update_cleanup (FuPlugin *plugin, FuDevice *device, GError **error)
 {
-	return fu_dell_toggle_flash (plugin, device , FALSE, error);
+	return fu_dell_toggle_flash (plugin, device, FALSE, error);
 }
 
 gboolean
@@ -916,18 +892,16 @@ fu_plugin_coldplug_cleanup (FuPlugin *plugin, GError **error)
 void
 fu_plugin_init (FuPlugin *plugin)
 {
-	FuPluginData *data = fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
+	FuPluginData *data = fu_plugin_alloc_data (plugin, sizeof(FuPluginData));
 	g_autofree gchar *tmp = NULL;
 
-	data->libsmbios_major = smbios_get_library_version_major();
-	data->libsmbios_minor = smbios_get_library_version_minor();
-	g_debug ("Using libsmbios %u.%u", data->libsmbios_major,
-		 data->libsmbios_minor);
-	tmp = g_strdup_printf ("%u.%u", data->libsmbios_major,
-					data->libsmbios_minor);
+	data->libsmbios_major = smbios_get_library_version_major ();
+	data->libsmbios_minor = smbios_get_library_version_minor ();
+	g_debug ("Using libsmbios %u.%u", data->libsmbios_major, data->libsmbios_minor);
+	tmp = g_strdup_printf ("%u.%u", data->libsmbios_major, data->libsmbios_minor);
 	fu_plugin_add_runtime_version (plugin, "com.dell.libsmbios", tmp);
 
-	data->smi_obj = g_malloc0 (sizeof (FuDellSmiObj));
+	data->smi_obj = g_malloc0 (sizeof(FuDellSmiObj));
 	if (g_getenv ("FWUPD_DELL_VERBOSE") != NULL)
 		g_setenv ("LIBSMBIOS_C_DEBUG_OUTPUT_ALL", "1", TRUE);
 	if (fu_dell_supported (plugin))
@@ -943,14 +917,14 @@ fu_plugin_destroy (FuPlugin *plugin)
 	FuPluginData *data = fu_plugin_get_data (plugin);
 	if (data->smi_obj->smi)
 		dell_smi_obj_free (data->smi_obj->smi);
-	g_free(data->smi_obj);
+	g_free (data->smi_obj);
 }
 
 gboolean
 fu_plugin_startup (FuPlugin *plugin, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
-	GUsbContext *usb_ctx = fu_plugin_get_usb_context (plugin);
+	GUsbContext  *usb_ctx = fu_plugin_get_usb_context (plugin);
 	g_autofree gchar *sysfsfwdir = NULL;
 	g_autofree gchar *esrtdir = NULL;
 
@@ -962,17 +936,13 @@ fu_plugin_startup (FuPlugin *plugin, GError **error)
 	}
 
 	if (!fu_dell_supported (plugin)) {
-		g_set_error (error,
-			     FWUPD_ERROR,
-			     FWUPD_ERROR_NOT_SUPPORTED,
+		g_set_error (error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED,
 			     "Firmware updating not supported");
 		return FALSE;
 	}
 
 	if (data->smi_obj->smi == NULL) {
-		g_set_error (error,
-			     FWUPD_ERROR,
-			     FWUPD_ERROR_INTERNAL,
+		g_set_error (error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL,
 			     "failed to initialize libsmbios library");
 		return FALSE;
 	}
@@ -992,11 +962,9 @@ fu_plugin_startup (FuPlugin *plugin, GError **error)
 
 	if (usb_ctx != NULL) {
 		g_signal_connect (usb_ctx, "device-added",
-				  G_CALLBACK (fu_plugin_dell_device_added_cb),
-				  plugin);
+				  G_CALLBACK (fu_plugin_dell_device_added_cb), plugin);
 		g_signal_connect (usb_ctx, "device-removed",
-				  G_CALLBACK (fu_plugin_dell_device_removed_cb),
-				  plugin);
+				  G_CALLBACK (fu_plugin_dell_device_removed_cb), plugin);
 	}
 
 	return TRUE;

--- a/plugins/dell/fu-plugin-dell.h
+++ b/plugins/dell/fu-plugin-dell.h
@@ -8,37 +8,36 @@
 #ifndef __FU_PLUGIN_DELL_H
 #define __FU_PLUGIN_DELL_H
 
-#include <gusb.h>
-#include "fu-plugin.h"
 #include "fu-dell-smi.h"
+#include "fu-plugin.h"
+#include <gusb.h>
 
 struct FuPluginData {
-	FuDellSmiObj		*smi_obj;
-	guint16			fake_vid;
-	guint16			fake_pid;
-	gboolean		can_switch_modes;
-	gboolean		capsule_supported;
-	guint			libsmbios_major;
-	guint			libsmbios_minor;
+	FuDellSmiObj *smi_obj;
+	guint16       fake_vid;
+	guint16       fake_pid;
+	gboolean      can_switch_modes;
+	gboolean      capsule_supported;
+	guint	 libsmbios_major;
+	guint	 libsmbios_minor;
 };
 
 void
 fu_plugin_dell_inject_fake_data (FuPlugin *plugin,
-				 guint32 *output, guint16 vid, guint16 pid,
-				 guint8 *buf, gboolean can_switch_modes);
+				 guint32  *output,
+				 guint16   vid,
+				 guint16   pid,
+				 guint8   *buf,
+				 gboolean  can_switch_modes);
 
 gboolean
 fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error);
 
 void
-fu_plugin_dell_device_added_cb (GUsbContext *ctx,
-				GUsbDevice *device,
-				FuPlugin *plugin);
+fu_plugin_dell_device_added_cb (GUsbContext *ctx, GUsbDevice *device, FuPlugin *plugin);
 
 void
-fu_plugin_dell_device_removed_cb (GUsbContext *ctx,
-				  GUsbDevice *device,
-				  FuPlugin *plugin);
+fu_plugin_dell_device_removed_cb (GUsbContext *ctx, GUsbDevice *device, FuPlugin *plugin);
 
 /* These are nodes that will indicate information about
  * the TPM status
@@ -49,10 +48,10 @@ struct tpm_status {
 	guint32 status;
 	guint32 flashes_left;
 };
-#define TPM_EN_MASK	0x0001
-#define TPM_OWN_MASK	0x0004
-#define TPM_TYPE_MASK	0x0F00
-#define TPM_1_2_MODE	0x0001
-#define TPM_2_0_MODE	0x0002
+#define TPM_EN_MASK 0x0001
+#define TPM_OWN_MASK 0x0004
+#define TPM_TYPE_MASK 0x0F00
+#define TPM_1_2_MODE 0x0001
+#define TPM_2_0_MODE 0x0002
 
 #endif /* __FU_PLUGIN_DELL_H */


### PR DESCRIPTION
In an effort to try to keep style consistent (and be helpful to new submitters) I want to keep a .clang-format that does things at least mostly right.  Personally I'd like to use it with VS code's automatic clang format on save functionality.

There are some things I know clang format wont' be able to get right (such as `#define` block alignment; see https://stackoverflow.com/questions/38620019/can-clang-format-align-a-block-of-defines-for-me) and for those I'd like to just use `//clang-format off //clang-format` on wrappers (see https://philwrightdev.wordpress.com/2014/10/01/making-clang-format-ignore-sections/)

So here's a first pass at a `.clang-format` and an example of what it does to one of the plugins.  I used https://zed0.co.uk/clang-format-configurator/ to build it and I didn't use any //clang-format controls to block it from running on anything.

Thoughts?

My hope is that we can come up with something that looks good enough, run it on the whole project to get good starting points and then adopt exceptions when needed.
