### PR TITLE
Continue to allow building with older meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('fwupd', 'c',
   version : '1.1.0',
   license : 'LGPL-2.1+',
-  meson_version : '>=0.46.0',
+  meson_version : '>=0.43.0',
   default_options : ['warning_level=2', 'c_std=c99'],
 )
 
@@ -113,8 +113,14 @@ test_link_args = [
   '-Wl,-z,now',
 ]
 foreach arg: test_link_args
-  if cc.has_link_argument(arg)
-    global_link_args += arg
+  if meson.version().version_compare('>=0.46.0')
+    if cc.has_link_argument(arg)
+      global_link_args += arg
+    endif
+  else
+    if cc.has_argument(arg)
+      global_link_args += arg
+    endif
   endif
 endforeach
 add_global_link_arguments(


### PR DESCRIPTION
Commit 83d46b05792 bumped the minimum meson version to 0.46.0
This makes building on current Ubuntu LTS release more difficult
as it contains 0.45.0.

Instead conditionalize the build to run that code when on newer
meson.

This commit can be reverted when it's appropriate to bump meson
build dependency.