### PR TITLE
trivial: dell: correct a potentially fragile include order problem

### DIFF
--- a/plugins/dell/fu-dell-smi.c
+++ b/plugins/dell/fu-dell-smi.c
@@ -5,10 +5,9 @@
  * SPDX-License-Identifier: LGPL-2.1+
  */
 
-#include "config.h"
+#include "fu-dell-smi.h"
 
 #include <appstream-glib.h>
-#include "fu-dell-smi.h"
 
 /* These are for dock query capabilities */
 struct dock_count_in {

--- a/plugins/dell/fu-dell-smi.h
+++ b/plugins/dell/fu-dell-smi.h
@@ -9,6 +9,7 @@
 #define __FU_DELL_COMMON_H
 
 #include "fu-device.h"
+
 #include <smbios_c/smi.h>
 #include <smbios_c/obj/smi.h>
 #include <efivar.h>

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -6,7 +6,10 @@
  * SPDX-License-Identifier: LGPL-2.1+
  */
 
-#include "config.h"
+#include "fu-plugin-dell.h"
+
+#include "fu-device-metadata.h"
+#include "fu-plugin-vfuncs.h"
 
 #include <appstream-glib.h>
 #include <glib/gstdio.h>
@@ -14,10 +17,6 @@
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
-
-#include "fu-plugin-dell.h"
-#include "fu-plugin-vfuncs.h"
-#include "fu-device-metadata.h"
 
 /* These are used to indicate the status of a previous DELL flash */
 #define DELL_SUCCESS			0x0000

--- a/plugins/dell/fu-self-test.c
+++ b/plugins/dell/fu-self-test.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: LGPL-2.1+
  */
 
-#include "config.h"
-
 #include <fwupd.h>
 #include <glib-object.h>
 #include <glib/gstdio.h>


### PR DESCRIPTION
When reshuffled with clang it shows that config.h shouldn't be
directly included in some files since it has been included already
by others.