### PR TITLE
Do not use /usr/bin/env in the shebang line

### DIFF
--- a/contrib/firmware-packager/firmware-packager
+++ b/contrib/firmware-packager/firmware-packager
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 #
 # Copyright (C) 2017 Max Ehrlich max.ehr@gmail.com
 #

--- a/libfwupd/generate-version-script.py
+++ b/libfwupd/generate-version-script.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 # pylint: disable=invalid-name,missing-docstring
 #
 # Copyright (C) 2017 Richard Hughes <richard@hughsie.com>

--- a/plugins/dfu/contrib/parse-avrdude-conf.py
+++ b/plugins/dfu/contrib/parse-avrdude-conf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """ This parses avrdude.conf and generates quirks for fwupd """
 
 # pylint: disable=wrong-import-position,pointless-string-statement

--- a/po/make-images
+++ b/po/make-images
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """ This thing rasterizes text for use later """
 
 # pylint: disable=wrong-import-position,too-many-locals,unused-argument

--- a/po/test-deps
+++ b/po/test-deps
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 """ Check dependencies needed for rasterization """
 
 """


### PR DESCRIPTION
According to Fedora policy env must not be used as it could be overridden by
values in the PATH.

For details, https://fedoraproject.org/wiki/Packaging:Guidelines#Shebang_lines