### PR TITLE
trivial: dell: drop blacklist of old systems

### DIFF
--- a/plugins/dell/fu-plugin-dell.h
+++ b/plugins/dell/fu-plugin-dell.h
@@ -18,8 +18,6 @@ struct FuPluginData {
 	guint16			fake_pid;
 	gboolean		can_switch_modes;
 	gboolean		capsule_supported;
-	guint			libsmbios_major;
-	guint			libsmbios_minor;
 };
 
 void


### PR DESCRIPTION
The minimum version of libsmbios is now 2.4, so don't include any
code blacklisting running on known failing systems.