### PR TITLE
synapticsmst: Drop the dependency on Dell plugin to populate devices

### DIFF
--- a/plugins/synapticsmst/synapticsmst-device.h
+++ b/plugins/synapticsmst/synapticsmst-device.h
@@ -63,7 +63,7 @@ SynapticsMSTDevice	*synapticsmst_device_new	(SynapticsMSTDeviceKind kind,
 SynapticsMSTDeviceKind synapticsmst_device_kind_from_string	(const gchar	*kind);
 const gchar	*synapticsmst_device_kind_to_string		(SynapticsMSTDeviceKind kind);
 const gchar	*synapticsmst_device_board_id_to_string		(SynapticsMSTDeviceBoardID board_id);
-const gchar 	*synapticsmst_device_get_guid 			(SynapticsMSTDevice *device);
+GPtrArray 	*synapticsmst_device_get_guids 			(SynapticsMSTDevice *device);
 gboolean	 synapticsmst_device_scan_cascade_device 	(SynapticsMSTDevice *device,
 								 GError **error,
 								 guint8 tx_port);


### PR DESCRIPTION
At least in my experience there's some situations that dock information doesn't show up, but this shouldn't block synaptics from init.

If the dock information is available then show that in the device name
and restrict the GUIDs created.

If it's not available, then just create GUIDs for all known docks