### PR TITLE
Redfish: enable device listing and the tentative update function

### DIFF
--- a/plugins/redfish/fu-plugin-redfish.c
+++ b/plugins/redfish/fu-plugin-redfish.c
@@ -18,6 +18,18 @@ struct FuPluginData {
 };
 
 gboolean
+fu_plugin_update (FuPlugin *plugin,
+		  FuDevice *device,
+		  GBytes *blob_fw,
+		  FwupdInstallFlags flags,
+		  GError **error)
+{
+	FuPluginData *data = fu_plugin_get_data (plugin);
+
+	return fu_redfish_client_update (data->client, device, blob_fw, error);
+}
+
+gboolean
 fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);

--- a/plugins/redfish/fu-redfish-client.c
+++ b/plugins/redfish/fu-redfish-client.c
@@ -454,7 +454,6 @@ gboolean
 fu_redfish_client_setup (FuRedfishClient *self, GBytes *smbios_table, GError **error)
 {
 	JsonNode *node_root;
-	JsonObject *obj_links = NULL;
 	JsonObject *obj_root = NULL;
 	JsonObject *obj_update_service = NULL;
 	const gchar *data_id;
@@ -557,18 +556,8 @@ fu_redfish_client_setup (FuRedfishClient *self, GBytes *smbios_table, GError **e
 	g_debug ("UUID:     %s",
 		 json_object_get_string_member (obj_root, "UUID"));
 
-	/* look for UpdateService in Links */
-	if (json_object_has_member (obj_root, "Links"))
-		obj_links = json_object_get_object_member (obj_root, "Links");
-	if (obj_links == NULL) {
-		g_set_error_literal (error,
-				     FWUPD_ERROR,
-				     FWUPD_ERROR_INVALID_FILE,
-				     "no Links object");
-		return FALSE;
-	}
-	if (json_object_has_member (obj_links, "UpdateService"))
-		obj_update_service = json_object_get_object_member (obj_links, "UpdateService");
+	if (json_object_has_member (obj_root, "UpdateService"))
+		obj_update_service = json_object_get_object_member (obj_root, "UpdateService");
 	if (obj_update_service == NULL) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,

--- a/plugins/redfish/fu-redfish-client.c
+++ b/plugins/redfish/fu-redfish-client.c
@@ -518,7 +518,7 @@ fu_redfish_client_setup (FuRedfishClient *self, GBytes *smbios_table, GError **e
 		g_debug ("Password: %s", self->password);
 
 	/* try to connect */
-	blob = fu_redfish_client_fetch_data (self, "/redfish/v1", error);
+	blob = fu_redfish_client_fetch_data (self, "/redfish/v1/", error);
 	if (blob == NULL)
 		return FALSE;
 

--- a/plugins/redfish/fu-redfish-client.c
+++ b/plugins/redfish/fu-redfish-client.c
@@ -89,8 +89,17 @@ fu_redfish_client_coldplug_member (FuRedfishClient *self,
 		if (json_object_get_boolean_member (member, "Updateable"))
 			fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_UPDATABLE);
 	}
-	if (json_object_has_member (member, "SoftwareId"))
+	if (json_object_has_member (member, "SoftwareId")) {
 		fu_device_add_guid (dev, json_object_get_string_member (member, "SoftwareId"));
+	} else if (json_object_has_member (member, "Oem")) {
+		JsonObject *oem = json_object_get_object_member (member, "Oem");
+		if (json_object_has_member (oem, "Hpe")) {
+			JsonObject *hpe = json_object_get_object_member (oem, "Hpe");
+			const gchar *dev_class = json_object_get_string_member (hpe, "DeviceClass");
+			if (dev_class != NULL)
+				fu_device_add_guid (dev, dev_class);
+		}
+	}
 
 	/* success */
 	g_ptr_array_add (self->devices, g_steal_pointer (&dev));

--- a/plugins/redfish/fu-redfish-client.c
+++ b/plugins/redfish/fu-redfish-client.c
@@ -85,9 +85,12 @@ fu_redfish_client_coldplug_member (FuRedfishClient *self,
 		fu_device_set_version_lowest (dev, json_object_get_string_member (member, "LowestSupportedVersion"));
 	if (json_object_has_member (member, "Description"))
 		fu_device_set_description (dev, json_object_get_string_member (member, "Description"));
-	if (json_object_get_boolean_member (member, "Updateable"))
-		fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_UPDATABLE);
-	fu_device_add_guid (dev, json_object_get_string_member (member, "SoftwareId"));
+	if (json_object_has_member (member, "Updateable")) {
+		if (json_object_get_boolean_member (member, "Updateable"))
+			fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_UPDATABLE);
+	}
+	if (json_object_has_member (member, "SoftwareId"))
+		fu_device_add_guid (dev, json_object_get_string_member (member, "SoftwareId"));
 
 	/* success */
 	g_ptr_array_add (self->devices, g_steal_pointer (&dev));

--- a/plugins/redfish/fu-redfish-client.c
+++ b/plugins/redfish/fu-redfish-client.c
@@ -93,8 +93,32 @@ fu_redfish_client_coldplug_member (FuRedfishClient *self,
 				   JsonObject *member,
 				   GError **error)
 {
-	g_autoptr(FuDevice) dev = fu_device_new ();
+	g_autoptr(FuDevice) dev = NULL;
+	const gchar *guid = NULL;
+	g_autofree gchar *id = NULL;
 
+	if (json_object_has_member (member, "SoftwareId")) {
+		guid = json_object_get_string_member (member, "SoftwareId");
+	} else if (json_object_has_member (member, "Oem")) {
+		JsonObject *oem = json_object_get_object_member (member, "Oem");
+		if (json_object_has_member (oem, "Hpe")) {
+			JsonObject *hpe = json_object_get_object_member (oem, "Hpe");
+			if (json_object_has_member (hpe, "DeviceClass"))
+				guid = json_object_get_string_member (hpe, "DeviceClass");
+		}
+	}
+
+	/* Skip the devices without guid */
+	if (guid == NULL)
+		return TRUE;
+
+	dev = fu_device_new ();
+
+	id = g_strdup_printf ("Redfish-Inventory-%s",
+			      json_object_get_string_member (member, "Id"));
+	fu_device_set_id (dev, id);
+
+	fu_device_add_guid (dev, guid);
 	fu_device_set_name (dev, json_object_get_string_member (member, "Name"));
 	fu_device_set_summary (dev, "Redfish device");
 	fu_device_set_version (dev, json_object_get_string_member (member, "Version"));
@@ -105,17 +129,6 @@ fu_redfish_client_coldplug_member (FuRedfishClient *self,
 	if (json_object_has_member (member, "Updateable")) {
 		if (json_object_get_boolean_member (member, "Updateable"))
 			fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_UPDATABLE);
-	}
-	if (json_object_has_member (member, "SoftwareId")) {
-		fu_device_add_guid (dev, json_object_get_string_member (member, "SoftwareId"));
-	} else if (json_object_has_member (member, "Oem")) {
-		JsonObject *oem = json_object_get_object_member (member, "Oem");
-		if (json_object_has_member (oem, "Hpe")) {
-			JsonObject *hpe = json_object_get_object_member (oem, "Hpe");
-			const gchar *dev_class = json_object_get_string_member (hpe, "DeviceClass");
-			if (dev_class != NULL)
-				fu_device_add_guid (dev, dev_class);
-		}
 	}
 
 	/* success */

--- a/plugins/redfish/fu-redfish-client.c
+++ b/plugins/redfish/fu-redfish-client.c
@@ -28,11 +28,36 @@ struct _FuRedfishClient
 	gchar			*username;
 	gchar			*password;
 	gchar			*update_uri_path;
+	gchar			*push_uri_path;
 	gboolean		 auth_created;
 	GPtrArray		*devices;
 };
 
 G_DEFINE_TYPE (FuRedfishClient, fu_redfish_client, G_TYPE_OBJECT)
+
+static void
+fu_redfish_client_set_auth (FuRedfishClient *self, SoupURI *uri,
+			    SoupMessage *msg)
+{
+	SoupAuthManager *manager;
+	g_autoptr(SoupAuth) auth = NULL;
+
+	if ((self->username != NULL && self->password != NULL) &&
+	    self->auth_created == FALSE) {
+		/*
+		 * Some redfish implementations miss WWW-Authenticate
+		 * header for a 401 response, and SoupAuthManager couldn't
+		 * generate SoupAuth accordingly. Since DSP0266 makes
+		 * Basic Authorization a requirement for redfish it shall be
+		 * safe to use Basic Auth for all redfish implementations.
+		 */
+		manager = SOUP_AUTH_MANAGER (soup_session_get_feature (self->session, SOUP_TYPE_AUTH_MANAGER));
+		auth = soup_auth_new (SOUP_TYPE_AUTH_BASIC, msg, "Basic");
+		soup_auth_authenticate (auth, self->username, self->password);
+		soup_auth_manager_use_auth (manager, uri, auth);
+		self->auth_created = TRUE;
+	}
+}
 
 static GBytes *
 fu_redfish_client_fetch_data (FuRedfishClient *self, const gchar *uri_path, GError **error)
@@ -57,24 +82,7 @@ fu_redfish_client_fetch_data (FuRedfishClient *self, const gchar *uri_path, GErr
 			     "failed to create message for URI %s", tmp);
 		return NULL;
 	}
-	if ((self->username != NULL && self->password != NULL) &&
-	    self->auth_created == FALSE) {
-		/*
-		 * Some redfish implementations miss WWW-Authenticate
-		 * header for a 401 response, and SoupAuthManager couldn't
-		 * generate SoupAuth accordingly. Since DSP0266 makes
-		 * Basic Authorization a requirement for redfish it shall be
-		 * safe to use Basic Auth for all redfish implementations.
-		 */
-		SoupAuthManager *manager;
-		g_autoptr(SoupAuth) auth = NULL;
-
-		manager = SOUP_AUTH_MANAGER (soup_session_get_feature (self->session, SOUP_TYPE_AUTH_MANAGER));
-		auth = soup_auth_new (SOUP_TYPE_AUTH_BASIC, msg, "Basic");
-		soup_auth_authenticate (auth, self->username, self->password);
-		soup_auth_manager_use_auth (manager, uri, auth);
-		self->auth_created = TRUE;
-	}
+	fu_redfish_client_set_auth (self, uri, msg);
 	status_code = soup_session_send_message (self->session, msg);
 	if (status_code != SOUP_STATUS_OK) {
 		g_autofree gchar *tmp = soup_uri_to_string (uri, FALSE);
@@ -308,6 +316,21 @@ fu_redfish_client_coldplug (FuRedfishClient *self, GError **error)
 				     "service is not enabled");
 		return FALSE;
 	}
+	if (!json_object_has_member (obj_root, "HttpPushUri")) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED,
+				     "HttpPushUri is not available");
+		return FALSE;
+	}
+	self->push_uri_path = g_strdup (json_object_get_string_member (obj_root, "HttpPushUri"));
+	if (self->push_uri_path == NULL) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED,
+				     "HttpPushUri is invalid");
+		return FALSE;
+	}
 	if (json_object_has_member (obj_root, "FirmwareInventory")) {
 		JsonObject *tmp = json_object_get_object_member (obj_root, "FirmwareInventory");
 		return fu_redfish_client_coldplug_inventory (self, tmp, error);
@@ -537,6 +560,74 @@ fu_redfish_client_set_smbios_interfaces (FuRedfishClient *self,
 }
 
 gboolean
+fu_redfish_client_update (FuRedfishClient *self, FuDevice *device, GBytes *blob_fw,
+			  GError **error)
+{
+	GPtrArray *rel_array;
+	g_autofree gchar *filename = NULL;
+
+	guint status_code;
+	g_autoptr(SoupMessage) msg = NULL;
+	g_autoptr(SoupURI) uri = NULL;
+	g_autoptr(SoupMultipart) multipart = NULL;
+	g_autoptr(SoupBuffer) buffer = NULL;
+	g_autofree gchar *uri_str = NULL;
+
+	/* Get the update version */
+	rel_array = fwupd_device_get_releases (FWUPD_DEVICE (device));
+	if (rel_array->len > 0) {
+		FwupdRelease *rel;
+		rel = FWUPD_RELEASE (g_ptr_array_index(rel_array,
+						       rel_array->len - 1));
+		filename = g_strdup_printf ("%s-%s.bin",
+					    fu_device_get_name (device),
+					    fwupd_release_get_version (rel));
+	} else {
+		filename = g_strdup_printf ("%s.bin",
+					    fu_device_get_name (device));
+	}
+
+	/* create URI */
+	uri = soup_uri_new (NULL);
+	soup_uri_set_scheme (uri, g_strcmp0 (self->hostname, "localhost") == 0 ?
+				  "http" : "https");
+	soup_uri_set_path (uri, self->push_uri_path);
+	soup_uri_set_host (uri, self->hostname);
+	soup_uri_set_port (uri, self->port);
+	uri_str = soup_uri_to_string (uri, FALSE);
+
+	/* Create the multipart request */
+	multipart = soup_multipart_new (SOUP_FORM_MIME_TYPE_MULTIPART);
+	buffer = soup_buffer_new (SOUP_MEMORY_COPY,
+				  g_bytes_get_data (blob_fw, NULL),
+				  g_bytes_get_size (blob_fw));
+	soup_multipart_append_form_file (multipart, filename, filename,
+					 "application/octet-stream",
+					 buffer);
+	msg = soup_form_request_new_from_multipart (uri_str, multipart);
+	if (msg == NULL) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_INVALID_FILE,
+			     "failed to create message for URI %s", uri_str);
+		return FALSE;
+	}
+	fu_redfish_client_set_auth (self, uri, msg);
+	status_code = soup_session_send_message (self->session, msg);
+	if (status_code != SOUP_STATUS_OK) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_INVALID_FILE,
+			     "failed to upload %s to %s: %s",
+			     filename, uri_str,
+			     soup_status_get_phrase (status_code));
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+gboolean
 fu_redfish_client_setup (FuRedfishClient *self, GBytes *smbios_table, GError **error)
 {
 	JsonNode *node_root;
@@ -703,6 +794,7 @@ fu_redfish_client_finalize (GObject *object)
 	if (self->session != NULL)
 		g_object_unref (self->session);
 	g_free (self->update_uri_path);
+	g_free (self->push_uri_path);
 	g_free (self->hostname);
 	g_free (self->username);
 	g_free (self->password);

--- a/plugins/redfish/fu-redfish-client.c
+++ b/plugins/redfish/fu-redfish-client.c
@@ -129,6 +129,9 @@ fu_redfish_client_coldplug_member (FuRedfishClient *self,
 	if (json_object_has_member (member, "Updateable")) {
 		if (json_object_get_boolean_member (member, "Updateable"))
 			fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_UPDATABLE);
+	} else {
+		/* Assume the device is updatable */
+		fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_UPDATABLE);
 	}
 
 	/* success */

--- a/plugins/redfish/fu-redfish-client.h
+++ b/plugins/redfish/fu-redfish-client.h
@@ -26,6 +26,10 @@ void		 fu_redfish_client_set_password	(FuRedfishClient	*self,
 						 const gchar		*password);
 void		 fu_redfish_client_set_port	(FuRedfishClient	*self,
 						 guint			 port);
+gboolean	 fu_redfish_client_update       (FuRedfishClient	*self,
+						 FuDevice		*device,
+						 GBytes			*blob_fw,
+						 GError			**error);
 gboolean	 fu_redfish_client_setup	(FuRedfishClient	*self,
 						 GBytes			*smbios_table,
 						 GError			**error);

--- a/plugins/redfish/meson.build
+++ b/plugins/redfish/meson.build
@@ -21,6 +21,10 @@ shared_module('fu_plugin_redfish',
   ],
 )
 
+install_data(['redfish.conf'],
+  install_dir:  join_paths(sysconfdir, 'fwupd')
+)
+
 if get_option('tests')
   e = executable(
     'redfish-self-test',

--- a/plugins/redfish/redfish.conf
+++ b/plugins/redfish/redfish.conf
@@ -1,0 +1,9 @@
+[redfish]
+
+# The IP and port of Redfish in the format <ip>:<port>
+# ex: 10.160.0.10:443
+#RedfishUri=
+
+# The username and password to the Redfish service
+#Username=
+#Password=


### PR DESCRIPTION
This series of patches fixes some issues in the redfish plugin when enumerating the devices. I've tested the plugin in a HPE Gen10 machine, and at least "fwupdmgr get-devices" showed the devices from FirmwareInventory. However, the HPE Gen10 machine doesn't provide the service IP in SMBIOS, so I have to add a conf file for the service IP and username/password. I'm not sure if there is any other method to discover the IP.

I followed the HPE document(*) to implement update, but it's not guaranteed to work due to lack of a valid firmware update file for testing.

(*) https://github.com/HewlettPackard/ilo-rest-api-docs/blob/master/source/includes/_ilo5_updateservicedoc.md