### PR TITLE
trivial: Add a virtual provide of com.redhat.fwupdate

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -3579,6 +3579,7 @@ fu_engine_init (FuEngine *self)
 
 	/* add some runtime versions of things the daemon depends on */
 	fu_engine_add_runtime_version (self, "org.freedesktop.fwupd", VERSION);
+	fu_engine_add_runtime_version (self, "com.redhat.fwupdate", "12");
 #if AS_CHECK_VERSION(0,7,8)
 	fu_engine_add_runtime_version (self, "org.freedesktop.appstream-glib", as_version_string ());
 #endif
@@ -3586,6 +3587,9 @@ fu_engine_init (FuEngine *self)
 	fu_engine_add_runtime_version (self, "org.freedesktop.gusb", g_usb_version_string ());
 #endif
 
+	g_hash_table_insert (self->compile_versions,
+			     g_strdup ("com.redhat.fwupdate"),
+			     g_strdup ("12"));
 	g_hash_table_insert (self->compile_versions,
 			     g_strdup ("org.freedesktop.fwupd"),
 			     g_strdup (VERSION));


### PR DESCRIPTION
Some firmware depends on this component, which we absorbed in the last release.

See also: https://github.com/hughsie/fwupd/issues/614