### PR TITLE
ci: enable synaptics plugin to run in more architectures

### DIFF
--- a/contrib/ci/debian_s390x.sh
+++ b/contrib/ci/debian_s390x.sh
@@ -13,7 +13,6 @@ meson .. \
 	-Dplugin_uefi=false \
 	-Dplugin_dell=false \
 	-Dplugin_redfish=false \
-	-Dplugin_synaptics=false \
 	-Dintrospection=false \
 	-Dgtkdoc=false \
 	-Dman=false

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -33,9 +33,9 @@ endif
 
 override_dh_auto_configure:
 	if pkg-config --exists libsmbios_c; then \
-		export DELL="-Dplugin_dell=true -Dplugin_synaptics=true"; \
+		export DELL="-Dplugin_dell=true"; \
 	else \
-		export DELL="-Dplugin_dell=false -Dplugin_synaptics=false"; \
+		export DELL="-Dplugin_dell=false"; \
 	fi; \
 	if pkg-config --exists efivar; then \
 		export UEFI="-Dplugin_uefi=true -Dplugin_redfish=true"; \


### PR DESCRIPTION
Although it's only used on Dell devices, those devices could potentially
be plugged in via a bus on a different architecture too.

Make sure that CI runs on s390x and also allow them to compile for all of Debian's port architectures on released uploads.