### PR TITLE
NVM image validation for Titan Ridge devices and other improvements

### DIFF
--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -32,7 +32,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevDevice, g_object_unref)
 #pragma clang diagnostic pop
 #endif
 
-#define TBT_NVM_RETRY_TIMEOUT	20 /* ms */
+#define TBT_NVM_RETRY_TIMEOUT	200 /* ms */
 
 typedef void (*UEventNotify) (FuPlugin	  *plugin,
 			      GUdevDevice *udevice,

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -175,6 +175,24 @@ fu_plugin_thunderbolt_find_nvmem (GUdevDevice  *udevice,
 	return NULL;
 }
 
+static const gchar *
+fu_plugin_thunderbolt_udev_get_version (GUdevDevice *udevice)
+{
+	const gchar *version = NULL;
+
+	for (guint i = 0; i < 50; i++) {
+		version = g_udev_device_get_sysfs_attr (udevice, "nvm_version");
+		if (version != NULL)
+			break;
+		g_debug ("Attempt %u: Failed to read NVM version", i);
+		if (errno != EAGAIN)
+			break;
+		g_usleep (TBT_NVM_RETRY_TIMEOUT * 1000);
+	}
+
+	return version;
+}
+
 static gboolean
 fu_plugin_thunderbolt_is_native (GUdevDevice *udevice, gboolean *is_native, GError **error)
 {
@@ -286,15 +304,8 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 	dev = fu_device_new ();
 
 	is_host = fu_plugin_thunderbolt_is_host (device);
-	for (guint i = 0; i < 50; i++) {
-		version_raw = g_udev_device_get_sysfs_attr (device, "nvm_version");
-		if (version_raw != NULL)
-			break;
-		g_debug ("Attempt %u: Failed to read NVM version", i);
-		if (errno != EAGAIN)
-			break;
-		g_usleep (TBT_NVM_RETRY_TIMEOUT * 1000);
-	}
+
+	version_raw = fu_plugin_thunderbolt_udev_get_version (device);
 	/* test for safe mode */
 	version = fu_plugin_thunderbolt_parse_version (version_raw);
 	if (is_host && version == NULL) {
@@ -414,7 +425,7 @@ fu_plugin_thunderbolt_change (FuPlugin *plugin, GUdevDevice *device)
 		return;
 	}
 
-	version = g_udev_device_get_sysfs_attr (device, "nvm_version");
+	version = fu_plugin_thunderbolt_udev_get_version (device);
 	fu_device_set_version (dev, version);
 }
 
@@ -627,7 +638,7 @@ on_wait_for_device_added (FuPlugin    *plugin,
 
 	/* make sure the version is correct, might have changed
 	 * after update. */
-	version = g_udev_device_get_sysfs_attr (device, "nvm_version");
+	version = fu_plugin_thunderbolt_udev_get_version (device);
 	fu_device_set_version (dev, version);
 
 	id = fu_plugin_thunderbolt_gen_id (device);

--- a/plugins/thunderbolt/fu-thunderbolt-image.c
+++ b/plugins/thunderbolt/fu-thunderbolt-image.c
@@ -55,7 +55,9 @@ get_hw_info (guint16 id)
 		{ 0x15DA, 3, 1 }, /* AR-C 2C */
 
 		{ 0x15E7, 3, 1 }, /* TR 2C */
+		{ 0x15E8, 3, 1 }, /* TR 2C */
 		{ 0x15EA, 3, 2 }, /* TR 4C */
+		{ 0x15EB, 3, 2 }, /* TR 4C */
 		{ 0x15EF, 3, 2 }, /* TR 4C device */
 
 		{ 0 }
@@ -425,7 +427,9 @@ get_host_locations (guint16 id)
 	case 0x15C0:
 		return AR_LP;
 	case 0x15E7:
+	case 0x15E8:
 	case 0x15EA:
+	case 0x15EB:
 		return TR;
 	default:
 		return NULL;

--- a/plugins/thunderbolt/fu-thunderbolt-image.c
+++ b/plugins/thunderbolt/fu-thunderbolt-image.c
@@ -406,6 +406,7 @@ get_host_locations (guint16 id)
 		{ .offset = 0x136, .len = 1, .description = "Src0", .mask = 0xF0 },
 		{ .offset = 0xB6,  .len = 1, .description = "PA/PB (USB2)", .mask = 0xC0 },
 		{ .offset = 0x5E,  .len = 1, .description = "Aux", .mask = 0x0F },
+		{ .offset = 0x45,  .len = 1, .description = "Flash Size", .mask = 0x07 },
 		{ 0 },
 
 		{ .offset = 0x13,  .len = 1, .description = "PB", .mask = 0xCC, .section = DRAM_UCODE_SECTION },

--- a/plugins/thunderbolt/fu-thunderbolt-image.c
+++ b/plugins/thunderbolt/fu-thunderbolt-image.c
@@ -407,6 +407,7 @@ get_host_locations (guint16 id)
 		{ .offset = 0xB6,  .len = 1, .description = "PA/PB (USB2)", .mask = 0xC0 },
 		{ .offset = 0x5E,  .len = 1, .description = "Aux", .mask = 0x0F },
 		{ .offset = 0x45,  .len = 1, .description = "Flash Size", .mask = 0x07 },
+		{ .offset = 0x7B,  .len = 1, .description = "Native", .mask = 0x20 },
 		{ 0 },
 
 		{ .offset = 0x13,  .len = 1, .description = "PB", .mask = 0xCC, .section = DRAM_UCODE_SECTION },


### PR DESCRIPTION
This adds NVM image validation for Titan Ridge based Thunderbolt 3 devices. In addition there are few other improvements over the current code:

 -  PD (Power Delivery) pointer validation
 -  EAGAIN handling to other places reading nvm_version