### PR TITLE
uefi: Check the user-supplied ESP path

### DIFF
--- a/plugins/uefi/fu-uefi-common.c
+++ b/plugins/uefi/fu-uefi-common.c
@@ -275,6 +275,7 @@ fu_uefi_read_file_as_uint64 (const gchar *path, const gchar *attr_name)
 gboolean
 fu_uefi_check_esp_path (const gchar *path, GError **error)
 {
+	const gchar *fs_types[] = { "vfat", "ntfs", "exfat", NULL };
 	g_autoptr(GUnixMountEntry) mount = g_unix_mount_at (path, NULL);
 	if (mount == NULL) {
 		g_set_error (error,
@@ -288,6 +289,15 @@ fu_uefi_check_esp_path (const gchar *path, GError **error)
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_NOT_SUPPORTED,
 			     "%s is read only", path);
+		return FALSE;
+	}
+	if (!g_strv_contains (fs_types, g_unix_mount_get_fs_type (mount))) {
+		g_autofree gchar *supported = g_strjoinv ("|", (gchar **) fs_types);
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_NOT_SUPPORTED,
+			     "%s has an invalid type, expected %s",
+			     path, supported);
 		return FALSE;
 	}
 	return TRUE;

--- a/plugins/uefi/fu-uefi-common.h
+++ b/plugins/uefi/fu-uefi-common.h
@@ -72,6 +72,8 @@ gboolean	 fu_uefi_get_framebuffer_size	(guint32	*width,
 						 GError		**error);
 gboolean	 fu_uefi_secure_boot_enabled	(void);
 gchar		*fu_uefi_guess_esp_path		(void);
+gboolean	 fu_uefi_check_esp_path		(const gchar	*path,
+						 GError		**error);
 gchar		*fu_uefi_get_esp_path_for_os	(const gchar	*esp_path);
 GPtrArray	*fu_uefi_get_esrt_entry_paths	(const gchar	*esrt_path,
 						 GError		**error);

--- a/plugins/uefi/fu-uefi-tool.c
+++ b/plugins/uefi/fu-uefi-tool.c
@@ -153,7 +153,14 @@ main (int argc, char *argv[])
 		g_print ("fwupd version: %s\n", PACKAGE_VERSION);
 
 	/* override the default ESP path */
-	if (esp_path == NULL) {
+	if (esp_path != NULL) {
+		if (!fu_uefi_check_esp_path (esp_path, &error)) {
+			/* TRANSLATORS: ESP is EFI System Partition */
+			g_print ("%s: %s\n", _("ESP specified was not valid"),
+				 error->message);
+			return EXIT_FAILURE;
+		}
+	} else {
 		esp_path = fu_uefi_guess_esp_path ();
 		if (esp_path == NULL) {
 			g_printerr ("Unable to determine EFI system partition "


### PR DESCRIPTION
Additionally, if the user specified something invalid, do not autodetect the
ESP but return with a journal error. It seems wrong to ignore what the user
explicitly set and perhaps do something dangerous.

Alternative to https://github.com/hughsie/fwupd/pull/599