### PR TITLE
uefi: Don't override _FORTIFY_SOURCE when building the EFI binary

### DIFF
--- a/plugins/uefi/efi/meson.build
+++ b/plugins/uefi/efi/meson.build
@@ -50,7 +50,6 @@ message('efi-includedir: "@0@"'.format(efi_incdir))
 debugdir = join_paths (libdir, 'debug')
 compile_args = ['-Og',
                 '-g3',
-                '-Wp,-D_FORTIFY_SOURCE=2',
                 '--param=ssp-buffer-size=4',
                 '-fexceptions',
                 '-Wall',


### PR DESCRIPTION
Fixes https://github.com/hughsie/fwupd/issues/631