### PR TITLE
uefi: Fix encoding the GUID into the capsule EFI variable

### DIFF
--- a/plugins/uefi/fu-uefi-device.c
+++ b/plugins/uefi/fu-uefi-device.c
@@ -323,7 +323,6 @@ fu_uefi_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
 	info.capsule_flags = self->capsule_flags;
 	info.update_info_version = 0x7;
 	info.hw_inst = self->fmp_hardware_instance;
-	memcpy (&guid, &info.guid, sizeof(efi_guid_t));
 	if (efi_str_to_guid (self->fw_class, &guid) < 0) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
@@ -331,6 +330,7 @@ fu_uefi_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
 				     "failed to get convert GUID");
 		return FALSE;
 	}
+	memcpy (&info.guid, &guid, sizeof(efi_guid_t));
 
 	/* set the body as the device path */
 	if (g_getenv ("FWUPD_UEFI_ESP_PATH") == NULL) {


### PR DESCRIPTION
Before:

```
$ /usr/lib/fwupd/fwupdate --info
Information for the update status entry 0:
  Information Version: 7
  Firmware GUID: {00000000-0000-0000-0000-000000000000}
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  Capsule Flags: 0x00131072x
  Hardware Instance: 0
  Update Status: attempt-update
  Capsule File Path: /EFI/ubuntu/fw/fwupd-7ceaf7a8-0611-4480-9e30-64d8de420c7c.cap
```
After:

```
$ /usr/lib/fwupd/fwupdate --info
Information for the update status entry 0:
  Information Version: 7
  Firmware GUID: {7ceaf7a8-0611-4480-9e30-64d8de420c7c}
  Capsule Flags: 0x00131072x
  Hardware Instance: 0
  Update Status: attempt-update
  Capsule File Path: /EFI/ubuntu/fw/fwupd-7ceaf7a8-0611-4480-9e30-64d8de420c7c.cap
```