### PR TITLE
uefi: Handle /boot properly (Closes: #627)

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -40,7 +40,7 @@ if get_option('systemd')
   rw_directories += join_paths (localstatedir, 'lib', 'fwupd')
   rw_directories += join_paths (default_sysconfdir, 'fwupd', 'remotes.d')
   if get_option('plugin_uefi')
-    rw_directories += ['-/boot/efi', '-/boot', '-/efi']
+    rw_directories += ['-/boot/efi', '-/efi', '-/boot/EFI']
   endif
 
   dynamic_options = []

--- a/plugins/uefi/fu-uefi-common.c
+++ b/plugins/uefi/fu-uefi-common.c
@@ -283,7 +283,18 @@ fu_uefi_check_esp_path (const gchar *path, GError **error)
 			     "%s was not mounted", path);
 		return FALSE;
 	}
-	if (g_unix_mount_is_readonly (mount)) {
+	/* /boot is a special case because systemd sandboxing marks
+	 * it read-only, but we need to write to /boot/EFI
+	 */
+	if (g_strcmp0 (path, "/boot") == 0) {
+		if (!g_file_test ("/boot/EFI", G_FILE_TEST_IS_DIR)) {
+			g_set_error (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED,
+				     "%s/EFI does not exist", path);
+			return FALSE;
+		}
+	} else if (g_unix_mount_is_readonly (mount)) {
 		g_set_error (error,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_NOT_SUPPORTED,


### PR DESCRIPTION
/boot is a special cased directory when using ProtectSystem=full

Due to this, it's marked read only even if it's listed in ReadWritePaths.

Allow folks to use this for their ESP, but they need to create /boot/EFI
in advance of starting fwupd.