### PR TITLE
trivial: fu-engine: downgrade "Using Plugins %s" to debug

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2773,7 +2773,7 @@ fu_engine_plugins_coldplug (FuEngine *self, gboolean is_recoldplug)
 	}
 	if (str->len > 2) {
 		g_string_truncate (str, str->len - 2);
-		g_message ("using plugins: %s", str->str);
+		g_debug ("using plugins: %s", str->str);
 	}
 
 	/* we can recoldplug from this point on */


### PR DESCRIPTION
This isn't useful for most people and just takes up space in the logs.
When there is a problem it's typically specifically with a plugin
and at that time we ask them to run the daemon with verbose anyway.