### PR TITLE
fu-plugin: don't reset plugin on device add if it's already been set

### DIFF
--- a/src/fu-plugin.c
+++ b/src/fu-plugin.c
@@ -350,8 +350,10 @@ fu_plugin_device_add (FuPlugin *plugin, FuDevice *device)
 	g_debug ("emit added from %s: %s",
 		 fu_plugin_get_name (plugin),
 		 fu_device_get_id (device));
-	fu_device_set_created (device, (guint64) g_get_real_time () / G_USEC_PER_SEC);
-	fu_device_set_plugin (device, fu_plugin_get_name (plugin));
+	if (fu_device_get_created (device) == 0)
+		fu_device_set_created (device, (guint64) g_get_real_time () / G_USEC_PER_SEC);
+	if (fu_device_get_plugin (device) == NULL)
+		fu_device_set_plugin (device, fu_plugin_get_name (plugin));
 	g_signal_emit (plugin, signals[SIGNAL_DEVICE_ADDED], 0, device);
 
 	/* add children */


### PR DESCRIPTION
This issue comes from a complicated set of circumstances related to
coldplug/recoldplug and device order.

The device has to be detected in the first coldplug pass and have a
parent in another plugin.

When recoldplug is called from the other plugin, parents get adjusted
along with `fu_plugin_device_add` getting called for the parent and
all children with the parent as the argument.  If that set of circumstances aligns, then the parents
plugin gets reset on the child.

This causes the second plugin to be unable to de-dupe device IDs
using `BETTER_THAN` because it looks like both devices came from the
same plugin.