### PR TITLE
libfwupd: Add fwupd_device_add_default_guid

### DIFF
--- a/libfwupd/fwupd-device.c
+++ b/libfwupd/fwupd-device.c
@@ -304,6 +304,25 @@ fwupd_device_add_guid (FwupdDevice *device, const gchar *guid)
 }
 
 /**
+ * fwupd_device_add_default_guid:
+ * @device: A #FwupdDevice
+ * @guid: the GUID, e.g. `2082b5e0-7a64-478a-b1b2-e3404fab6dad`
+ *
+ * Adds the GUID if it does not already exist and sets it as the default.
+ *
+ * Since: 1.1.1
+ **/
+void
+fwupd_device_add_default_guid (FwupdDevice *device, const gchar *guid)
+{
+	FwupdDevicePrivate *priv = GET_PRIVATE (device);
+	g_return_if_fail (FWUPD_IS_DEVICE (device));
+	if (fwupd_device_has_guid (device, guid))
+		return;
+	g_ptr_array_insert (priv->guids, 0, g_strdup (guid));
+}
+
+/**
  * fwupd_device_get_guid_default:
  * @device: A #FwupdDevice
  *

--- a/libfwupd/fwupd-device.h
+++ b/libfwupd/fwupd-device.h
@@ -92,6 +92,8 @@ void		 fwupd_device_set_vendor_id		(FwupdDevice	*device,
 							 const gchar	*vendor_id);
 void		 fwupd_device_add_guid			(FwupdDevice	*device,
 							 const gchar	*guid);
+void		 fwupd_device_add_default_guid		(FwupdDevice	*device,
+							 const gchar	*guid);
 gboolean	 fwupd_device_has_guid			(FwupdDevice	*device,
 							 const gchar	*guid);
 GPtrArray	*fwupd_device_get_guids			(FwupdDevice	*device);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -261,6 +261,7 @@ LIBFWUPD_1.1.0 {
 
 LIBFWUPD_1.1.1 {
   global:
+    fwupd_device_add_default_guid;
     fwupd_device_compare;
   local: *;
 } LIBFWUPD_1.1.0;

--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -474,6 +474,33 @@ fu_device_add_guid (FuDevice *device, const gchar *guid)
 }
 
 /**
+ * fu_device_add_default_guid:
+ * @device: A #FuDevice
+ * @guid: A GUID, e.g. `2082b5e0-7a64-478a-b1b2-e3404fab6dad`
+ *
+ * Adds a GUID to the device. If the @guid argument is not a valid GUID then it
+ * is converted to a GUID using as_utils_guid_from_string().
+ *
+ * This GUID is set as the default GUID for the FuDevice.
+ *
+ * Since: 1.1.0
+ **/
+void
+fu_device_add_default_guid (FuDevice *device, const gchar *guid)
+{
+	/* make valid */
+	if (!as_utils_guid_is_valid (guid)) {
+		g_autofree gchar *tmp = as_utils_guid_from_string (guid);
+		g_debug ("using %s for %s", tmp, guid);
+		fwupd_device_add_default_guid (FWUPD_DEVICE (device), tmp);
+		return;
+	}
+
+	/* already valid */
+	fwupd_device_add_default_guid (FWUPD_DEVICE (device), guid);
+}
+
+/**
  * fu_device_get_guids_as_str:
  * @device: A #FuDevice
  *

--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -107,6 +107,8 @@ void		 fu_device_set_equivalent_id		(FuDevice	*device,
 							 const gchar	*equivalent_id);
 void		 fu_device_add_guid			(FuDevice	*device,
 							 const gchar	*guid);
+void		 fu_device_add_default_guid		(FuDevice	*device,
+							 const gchar	*guid);
 gchar		*fu_device_get_guids_as_str		(FuDevice	*device);
 FuDevice	*fu_device_get_alternate		(FuDevice	*device);
 FuDevice	*fu_device_get_parent			(FuDevice	*device);


### PR DESCRIPTION
When adding a GUID to a FwupdDevice this sets the GUID to be the
GUID selected as "default" for calls to fwupd_device_get_guid_default()
