### PR TITLE
unifying: Close devices when receiving a uevent for removal

### DIFF
--- a/plugins/unifying/lu-common.c
+++ b/plugins/unifying/lu-common.c
@@ -39,6 +39,9 @@ lu_dump_raw (const gchar *title, const guint8 *data, gsize len)
 	g_autoptr(GString) str = g_string_new (NULL);
 	if (len == 0)
 		return;
+        if (g_getenv ("FWUPD_UNIFYING_VERBOSE") == NULL)
+		return;
+
 	g_string_append_printf (str, "%s:", title);
 	for (gsize i = strlen (title); i < 16; i++)
 		g_string_append (str, " ");

--- a/plugins/unifying/lu-context.c
+++ b/plugins/unifying/lu-context.c
@@ -246,6 +246,16 @@ lu_context_remove_device (LuContext *ctx, LuDevice *device)
 		      "udev-device", NULL,
 		      NULL);
 
+	if (lu_device_get_kind (device) == LU_DEVICE_KIND_RUNTIME) {
+		g_autoptr(GError) error_local = NULL;
+
+		g_object_set (device,
+			      "usb-device-locker", NULL,
+			      NULL);
+		if (!lu_device_close (device, &error_local))
+			g_warning ("%s", error_local->message);
+	}
+
 	if (lu_device_has_flag (device, LU_DEVICE_FLAG_ACTIVE))
 		g_signal_emit (ctx, signals[SIGNAL_REMOVED], 0, device);
 	g_ptr_array_remove (ctx->devices, device);

--- a/plugins/unifying/lu-device.c
+++ b/plugins/unifying/lu-device.c
@@ -47,6 +47,7 @@ enum {
 	PROP_FLAGS,
 	PROP_UDEV_DEVICE,
 	PROP_USB_DEVICE,
+	PROP_USB_DEVICE_LOCKER,
 	PROP_LAST
 };
 
@@ -833,7 +834,7 @@ lu_device_close (LuDevice *device, GError **error)
 	g_clear_object (&priv->usb_device);
 
 	/* HID */
-	if (priv->udev_device != NULL && priv->udev_device_fd > 0) {
+	if (priv->udev_device_fd > 0) {
 		if (!g_close (priv->udev_device_fd, error))
 			return FALSE;
 		priv->udev_device_fd = 0;
@@ -991,6 +992,9 @@ lu_device_get_property (GObject *object, guint prop_id,
 	case PROP_USB_DEVICE:
 		g_value_set_object (value, priv->usb_device);
 		break;
+	case PROP_USB_DEVICE_LOCKER:
+		g_value_set_object (value, priv->usb_device_locker);
+		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
 		break;
@@ -1019,6 +1023,9 @@ lu_device_set_property (GObject *object, guint prop_id,
 	case PROP_USB_DEVICE:
 		priv->usb_device = g_value_dup_object (value);
 		lu_device_update_platform_id (device);
+		break;
+	case PROP_USB_DEVICE_LOCKER:
+		priv->usb_device_locker = g_value_dup_object (value);
 		break;
 	default:
 		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -1098,6 +1105,12 @@ lu_device_class_init (LuDeviceClass *klass)
 				     G_USB_TYPE_DEVICE,
 				     G_PARAM_READWRITE | G_PARAM_CONSTRUCT);
 	g_object_class_install_property (object_class, PROP_USB_DEVICE, pspec);
+
+	pspec = g_param_spec_object ("usb-device-locker", NULL, NULL,
+				     G_USB_TYPE_DEVICE,
+				     G_PARAM_READWRITE | G_PARAM_CONSTRUCT);
+	g_object_class_install_property (object_class, PROP_USB_DEVICE_LOCKER, pspec);
+
 }
 
 LuDevice *


### PR DESCRIPTION
I'm not familiar with this codebase, but I believe this should fix #429 (at least it does for me in quick testing).

From what I can tell the plugin opens up the hidraw device and keeps it's `fd` but I can't find any indication that it was getting closed when the device was unplugged.