### PR TITLE
fu-tool: Fix a segfault caused by cleanup of USB plugins

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -214,6 +214,8 @@ fu_util_private_free (FuUtilPrivate *priv)
 {
 	if (priv->cmd_array != NULL)
 		g_ptr_array_unref (priv->cmd_array);
+	if (priv->current_device != NULL)
+		g_object_unref (priv->current_device);
 	if (priv->engine != NULL)
 		g_object_unref (priv->engine);
 	if (priv->loop != NULL)
@@ -224,8 +226,6 @@ fu_util_private_free (FuUtilPrivate *priv)
 		g_object_unref (priv->progressbar);
 	if (priv->context != NULL)
 		g_option_context_free (priv->context);
-	if (priv->current_device != NULL)
-		g_object_unref (priv->current_device);
 	g_free (priv);
 }
 


### PR DESCRIPTION
This is the same problem that happened with 3f9a1c182a4b05d641680e9505c24e10d75cfe3e.
The USB plugins got closed but left a dangling reference to a device.