### PR TITLE
uefi: Add 'autofs' to supported filesystems (Closes: #660)

### DIFF
--- a/plugins/uefi/fu-uefi-common.c
+++ b/plugins/uefi/fu-uefi-common.c
@@ -274,7 +274,7 @@ fu_uefi_read_file_as_uint64 (const gchar *path, const gchar *attr_name)
 gboolean
 fu_uefi_check_esp_path (const gchar *path, GError **error)
 {
-	const gchar *fs_types[] = { "vfat", "ntfs", "exfat", NULL };
+	const gchar *fs_types[] = { "vfat", "ntfs", "exfat", "autofs", NULL };
 	g_autoptr(GUnixMountEntry) mount = g_unix_mount_at (path, NULL);
 	if (mount == NULL) {
 		g_set_error (error,


### PR DESCRIPTION
systemd-automount will unmount the ESP when not in use for some
people.  This causes automatic ESP detection to fail.

In this case the ESP will need to be added to the conf file and
then this commit will let it keep working.