### PR TITLE
po: Use /usr/bin/env python3 again

### DIFF
--- a/po/make-images
+++ b/po/make-images
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """ This thing rasterizes text for use later """
 
 # pylint: disable=wrong-import-position,too-many-locals,unused-argument

--- a/po/test-deps
+++ b/po/test-deps
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """ Check dependencies needed for rasterization """
 
 """


### PR DESCRIPTION
Commit 70c9ab02883455b0ff4aaa42a2504988850d2fe2 changed the shebang
in some parts of the python binaries used for the build process.
This causes the snapped daemon branch to fail to build.

Revert the parts that are important for build process.