### PR TITLE
meson: Add a new configuration option 'python3'

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -242,7 +242,9 @@ if get_option('plugin_uefi')
           gnu_efi_arch = ''
   endif
   conf.set_quoted('EFI_MACHINE_TYPE_NAME', EFI_MACHINE_TYPE_NAME)
-  r = run_command('po/test-deps')
+
+  python3 = find_program('python3')
+  r = run_command([python3, 'po/test-deps'])
   if r.returncode() != 0
     error(r.stdout())
   endif

--- a/po/make-images.sh
+++ b/po/make-images.sh
@@ -7,9 +7,10 @@
 #
 
 LOCALEDIR=${DESTDIR}$1
+PYTHON3=$2
 
 install -m 0755 -d $LOCALEDIR
-${MESON_SOURCE_ROOT}/po/make-images "Installing firmware update…" $LOCALEDIR ${MESON_SOURCE_ROOT}/po/LINGUAS
+${PYTHON3} ${MESON_SOURCE_ROOT}/po/make-images "Installing firmware update…" $LOCALEDIR ${MESON_SOURCE_ROOT}/po/LINGUAS
 for x in ${LOCALEDIR}/*/LC_IMAGES/*.bmp ; do
     gzip -fn9 ${x}
 done

--- a/po/meson.build
+++ b/po/meson.build
@@ -6,5 +6,5 @@ i18n.gettext(meson.project_name(),
 )
 
 if get_option('plugin_uefi')
-meson.add_install_script('make-images.sh', localedir)
+meson.add_install_script('make-images.sh', localedir, python3.path())
 endif


### PR DESCRIPTION
This overrides the interpreter used for building UEFI labels.