### PR TITLE
uefi: Allow upgrades using a self-signed fwupd.efi binary

### DIFF
--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -31,6 +31,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUnixMountEntry, g_unix_mount_free)
 
 struct FuPluginData {
 	gchar			*esp_path;
+	gboolean		 require_shim_for_sb;
 	FuUefiBgrt		*bgrt;
 };
 
@@ -568,6 +569,7 @@ fu_plugin_uefi_ensure_esp_path (FuPlugin *plugin, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
 	const gchar *key = "OverrideESPMountPoint";
+	g_autofree gchar *require_shim_for_sb = NULL;
 
 	/* load from file */
 	data->esp_path = fu_plugin_get_config_value (plugin, key);
@@ -583,6 +585,10 @@ fu_plugin_uefi_ensure_esp_path (FuPlugin *plugin, GError **error)
 		}
 		return TRUE;
 	}
+	require_shim_for_sb = fu_plugin_get_config_value (plugin, "RequireShimForSecureBoot");
+	if (require_shim_for_sb == NULL ||
+	    g_ascii_strcasecmp (require_shim_for_sb, "true") == 0)
+		data->require_shim_for_sb = TRUE;
 
 	/* try to guess from heuristics */
 	data->esp_path = fu_uefi_guess_esp_path ();
@@ -673,6 +679,9 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 			fu_device_set_update_error (FU_DEVICE (dev), error_efivarfs->message);
 		} else {
 			fu_device_set_metadata (FU_DEVICE (dev), "EspPath", data->esp_path);
+			fu_device_set_metadata_boolean (FU_DEVICE (dev),
+							"RequireShimForSecureBoot",
+							data->require_shim_for_sb);
 			fu_device_add_flag (FU_DEVICE (dev), FWUPD_DEVICE_FLAG_UPDATABLE);
 		}
 		fu_plugin_device_add (plugin, FU_DEVICE (dev));

--- a/plugins/uefi/fu-uefi-bootmgr.c
+++ b/plugins/uefi/fu-uefi-bootmgr.c
@@ -292,7 +292,7 @@ fu_uefi_copy_asset (const gchar *source, const gchar *target, GError **error)
 }
 
 gboolean
-fu_uefi_bootmgr_bootnext (const gchar *esp_path, GError **error)
+fu_uefi_bootmgr_bootnext (const gchar *esp_path, FuUefiBootmgrFlags flags, GError **error)
 {
 	gboolean use_fwup_path = FALSE;
 	gsize loader_sz = 0;
@@ -323,7 +323,8 @@ fu_uefi_bootmgr_bootnext (const gchar *esp_path, GError **error)
 	if (shim_app == NULL)
 		return FALSE;
 	if (!g_file_test (shim_app, G_FILE_TEST_EXISTS)) {
-		if (fu_uefi_secure_boot_enabled ()) {
+		if (fu_uefi_secure_boot_enabled () &&
+		    (flags & FU_UEFI_BOOTMGR_FLAG_USE_SHIM_FOR_SB) > 0) {
 			g_set_error_literal (error,
 					     G_IO_ERROR,
 					     G_IO_ERROR_FAILED,

--- a/plugins/uefi/fu-uefi-bootmgr.h
+++ b/plugins/uefi/fu-uefi-bootmgr.h
@@ -13,8 +13,15 @@
 
 G_BEGIN_DECLS
 
-gboolean	 fu_uefi_bootmgr_bootnext	(const gchar	*esp_path,
-						 GError		**error);
+typedef enum {
+	FU_UEFI_BOOTMGR_FLAG_NONE		= 0,
+	FU_UEFI_BOOTMGR_FLAG_USE_SHIM_FOR_SB	= 1 << 0,
+	FU_UEFI_BOOTMGR_FLAG_LAST
+} FuUefiBootmgrFlags;
+
+gboolean	 fu_uefi_bootmgr_bootnext	(const gchar		*esp_path,
+						 FuUefiBootmgrFlags	 flags,
+						 GError			**error);
 
 G_END_DECLS
 

--- a/plugins/uefi/fu-uefi-device.c
+++ b/plugins/uefi/fu-uefi-device.c
@@ -287,6 +287,7 @@ static gboolean
 fu_uefi_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
 {
 	FuUefiDevice *self = FU_UEFI_DEVICE (device);
+	FuUefiBootmgrFlags flags = FU_UEFI_BOOTMGR_FLAG_NONE;
 	const gchar *esp_path = fu_device_get_metadata (device, "EspPath");
 	efi_guid_t guid;
 	efi_update_info_t info;
@@ -351,7 +352,9 @@ fu_uefi_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
 	}
 
 	/* update the firmware before the bootloader runs */
-	if (!fu_uefi_bootmgr_bootnext (esp_path, error))
+	if (fu_device_get_metadata_boolean (device, "RequireShimForSecureBoot"))
+		flags |= FU_UEFI_BOOTMGR_FLAG_USE_SHIM_FOR_SB;
+	if (!fu_uefi_bootmgr_bootnext (esp_path, flags, error))
 		return FALSE;
 
 	/* success! */

--- a/plugins/uefi/uefi.conf
+++ b/plugins/uefi/uefi.conf
@@ -1,5 +1,9 @@
 [uefi]
 
+# the shim loader is required to chainload the fwupd EFI binary unless
+# the fwupd.efi file has been self-signed manually
+RequireShimForSecureBoot=true
+
 # the EFI system partition path used
 # if this is is not /boot/efi, /boot, or /efi
 #OverrideESPMountPoint=


### PR DESCRIPTION
(Saw you forgot to add PR for this)

This doesn't require shim, so for this uncommon case add a configure option.

Fixes https://github.com/hughsie/fwupd/issues/669