### PR TITLE
meson: bump meson requirement to 0.46

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('fwupd', 'c',
   version : '1.1.2',
   license : 'LGPL-2.1+',
-  meson_version : '>=0.43.0',
+  meson_version : '>=0.46.0',
   default_options : ['warning_level=2', 'c_std=c99'],
 )
 


### PR DESCRIPTION
Bump required meson version to 0.46 as needed for `compiler.has_multi_link_argument`