### PR TITLE
Allow overriding AC power requirements with --force

### DIFF
--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -865,6 +865,7 @@ fu_dell_toggle_flash (FuPlugin *plugin, FuDevice *device,
 
 gboolean
 fu_plugin_update_prepare (FuPlugin *plugin,
+			  FwupdInstallFlags flags,
 			  FuDevice *device,
 			  GError **error)
 {
@@ -874,6 +875,7 @@ fu_plugin_update_prepare (FuPlugin *plugin,
 
 gboolean
 fu_plugin_update_cleanup (FuPlugin *plugin,
+			  FwupdInstallFlags flags,
 			  FuDevice *device,
 			  GError **error)
 {

--- a/plugins/thunderbolt-power/fu-plugin-thunderbolt-power.c
+++ b/plugins/thunderbolt-power/fu-plugin-thunderbolt-power.c
@@ -238,6 +238,7 @@ fu_plugin_device_registered (FuPlugin *plugin, FuDevice *device)
 
 gboolean
 fu_plugin_update_prepare (FuPlugin *plugin,
+			  FwupdInstallFlags flags,
 			  FuDevice *device,
 			  GError **error)
 {
@@ -288,6 +289,7 @@ fu_plugin_update_prepare (FuPlugin *plugin,
 
 gboolean
 fu_plugin_update_cleanup (FuPlugin *plugin,
+			  FwupdInstallFlags flags,
 			  FuDevice *device,
 			  GError **error)
 {

--- a/plugins/upower/fu-plugin-upower.c
+++ b/plugins/upower/fu-plugin-upower.c
@@ -49,6 +49,7 @@ fu_plugin_startup (FuPlugin *plugin, GError **error)
 
 gboolean
 fu_plugin_update_prepare (FuPlugin *plugin,
+			  FwupdInstallFlags flags,
 			  FuDevice *device,
 			  GError **error)
 {

--- a/plugins/upower/fu-plugin-upower.c
+++ b/plugins/upower/fu-plugin-upower.c
@@ -64,12 +64,12 @@ fu_plugin_update_prepare (FuPlugin *plugin,
 		g_warning ("failed to get OnBattery value, assume on AC power");
 		return TRUE;
 	}
-	if (g_variant_get_boolean (value)) {
+	if (g_variant_get_boolean (value) && (flags & FWUPD_INSTALL_FLAG_FORCE) == 0) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_AC_POWER_REQUIRED,
 				     "Cannot install update "
-				     "when not on AC power");
+				     "when not on AC power unless forced");
 		return FALSE;
 	}
 	return TRUE;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1395,7 +1395,7 @@ fu_engine_install_blob (FuEngine *self,
 	plugins = fu_plugin_list_get_all (self->plugin_list);
 	for (guint j = 0; j < plugins->len; j++) {
 		FuPlugin *plugin_tmp = g_ptr_array_index (plugins, j);
-		if (!fu_plugin_runner_update_prepare (plugin_tmp, device, error))
+		if (!fu_plugin_runner_update_prepare (plugin_tmp, flags, device, error))
 			return FALSE;
 	}
 
@@ -1466,6 +1466,7 @@ fu_engine_install_blob (FuEngine *self,
 			FuPlugin *plugin_tmp = g_ptr_array_index (plugins, j);
 			g_autoptr(GError) error_cleanup = NULL;
 			if (!fu_plugin_runner_update_cleanup (plugin_tmp,
+							      flags,
 							      device,
 							      &error_cleanup)) {
 				g_warning ("failed to update-cleanup "
@@ -1503,7 +1504,7 @@ fu_engine_install_blob (FuEngine *self,
 	for (guint j = 0; j < plugins->len; j++) {
 		FuPlugin *plugin_tmp = g_ptr_array_index (plugins, j);
 		g_autoptr(GError) error_cleanup = NULL;
-		if (!fu_plugin_runner_update_cleanup (plugin_tmp, device, &error_cleanup)) {
+		if (!fu_plugin_runner_update_cleanup (plugin_tmp, flags, device, &error_cleanup)) {
 			g_warning ("failed to update-cleanup: %s",
 				   error_cleanup->message);
 		}

--- a/src/fu-plugin-private.h
+++ b/src/fu-plugin-private.h
@@ -59,9 +59,11 @@ gboolean	 fu_plugin_runner_coldplug_cleanup	(FuPlugin	*plugin,
 gboolean	 fu_plugin_runner_recoldplug		(FuPlugin	*plugin,
 							 GError		**error);
 gboolean	 fu_plugin_runner_update_prepare	(FuPlugin	*plugin,
+							 FwupdInstallFlags flags,
 							 FuDevice	*device,
 							 GError		**error);
 gboolean	 fu_plugin_runner_update_cleanup	(FuPlugin	*plugin,
+							 FwupdInstallFlags flags,
 							 FuDevice	*device,
 							 GError		**error);
 gboolean	 fu_plugin_runner_composite_prepare	(FuPlugin	*plugin,

--- a/src/fu-plugin-vfuncs.h
+++ b/src/fu-plugin-vfuncs.h
@@ -52,9 +52,11 @@ gboolean	 fu_plugin_update_reload		(FuPlugin	*plugin,
 							 FuDevice	*dev,
 							 GError		**error);
 gboolean	 fu_plugin_update_prepare		(FuPlugin	*plugin,
+							 FwupdInstallFlags flags,
 							 FuDevice	*dev,
 							 GError		**error);
 gboolean	 fu_plugin_update_cleanup		(FuPlugin	*plugin,
+							 FwupdInstallFlags flags,
 							 FuDevice	*dev,
 							 GError		**error);
 gboolean	 fu_plugin_composite_prepare		(FuPlugin	*plugin,


### PR DESCRIPTION
Configure the UEFI plugin to support reading in quirks for the flags, and for Dell systems to specifically not require AC for the update to be scheduled.
