### PR TITLE
trivial: Move out the byte-array chunking to libfwupdprivate

### DIFF
--- a/plugins/colorhug/meson.build
+++ b/plugins/colorhug/meson.build
@@ -14,7 +14,6 @@ shared_module('fu_plugin_colorhug',
   ],
   include_directories : [
     include_directories('../..'),
-    include_directories('../dfu'),
     include_directories('../../src'),
     include_directories('../../libfwupd'),
   ],
@@ -23,8 +22,5 @@ shared_module('fu_plugin_colorhug',
   c_args : cargs,
   dependencies : [
     plugin_deps,
-  ],
-  link_with : [
-    dfu,
   ],
 )

--- a/plugins/dfu/dfu-self-test.c
+++ b/plugins/dfu/dfu-self-test.c
@@ -10,7 +10,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "dfu-chunked.h"
 #include "dfu-cipher-xtea.h"
 #include "dfu-common.h"
 #include "dfu-device-private.h"
@@ -798,50 +797,6 @@ dfu_patch_func (void)
 	g_debug ("serialized blob %s", serialized_str);
 }
 
-static void
-dfu_chunked_func (void)
-{
-	g_autofree gchar *chunked1_str = NULL;
-	g_autofree gchar *chunked2_str = NULL;
-	g_autofree gchar *chunked3_str = NULL;
-	g_autofree gchar *chunked4_str = NULL;
-	g_autoptr(GPtrArray) chunked1 = NULL;
-	g_autoptr(GPtrArray) chunked2 = NULL;
-	g_autoptr(GPtrArray) chunked3 = NULL;
-	g_autoptr(GPtrArray) chunked4 = NULL;
-
-	chunked3 = dfu_chunked_new ((const guint8 *) "123456", 6, 0x0, 3, 3);
-	chunked3_str = dfu_chunked_to_string (chunked3);
-	g_print ("\n%s", chunked3_str);
-	g_assert_cmpstr (chunked3_str, ==, "#00: page:00 addr:0000 len:03 123\n"
-					   "#01: page:01 addr:0000 len:03 456\n");
-
-	chunked4 = dfu_chunked_new ((const guint8 *) "123456", 6, 0x4, 4, 4);
-	chunked4_str = dfu_chunked_to_string (chunked4);
-	g_print ("\n%s", chunked4_str);
-	g_assert_cmpstr (chunked4_str, ==, "#00: page:01 addr:0000 len:04 1234\n"
-					   "#01: page:02 addr:0000 len:02 56\n");
-
-	chunked1 = dfu_chunked_new ((const guint8 *) "0123456789abcdef", 16, 0x0, 10, 4);
-	chunked1_str = dfu_chunked_to_string (chunked1);
-	g_print ("\n%s", chunked1_str);
-	g_assert_cmpstr (chunked1_str, ==, "#00: page:00 addr:0000 len:04 0123\n"
-					   "#01: page:00 addr:0004 len:04 4567\n"
-					   "#02: page:00 addr:0008 len:02 89\n"
-					   "#03: page:01 addr:0000 len:04 abcd\n"
-					   "#04: page:01 addr:0004 len:02 ef\n");
-
-	chunked2 = dfu_chunked_new ((const guint8 *) "XXXXXXYYYYYYZZZZZZ", 18, 0x0, 6, 4);
-	chunked2_str = dfu_chunked_to_string (chunked2);
-	g_print ("\n%s", chunked2_str);
-	g_assert_cmpstr (chunked2_str, ==, "#00: page:00 addr:0000 len:04 XXXX\n"
-					   "#01: page:00 addr:0004 len:02 XX\n"
-					   "#02: page:01 addr:0000 len:04 YYYY\n"
-					   "#03: page:01 addr:0004 len:02 YY\n"
-					   "#04: page:02 addr:0000 len:04 ZZZZ\n"
-					   "#05: page:02 addr:0004 len:02 ZZ\n");
-}
-
 int
 main (int argc, char **argv)
 {
@@ -855,7 +810,6 @@ main (int argc, char **argv)
 
 	/* tests go here */
 	g_test_add_func ("/dfu/firmware{srec}", dfu_firmware_srec_func);
-	g_test_add_func ("/dfu/chunked", dfu_chunked_func);
 	g_test_add_func ("/dfu/patch", dfu_patch_func);
 	g_test_add_func ("/dfu/patch{merges}", dfu_patch_merges_func);
 	g_test_add_func ("/dfu/patch{apply}", dfu_patch_apply_func);

--- a/plugins/dfu/dfu-target-stm.c
+++ b/plugins/dfu/dfu-target-stm.c
@@ -10,7 +10,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "dfu-chunked.h"
 #include "dfu-common.h"
 #include "dfu-sector.h"
 #include "dfu-target-stm.h"

--- a/plugins/dfu/meson.build
+++ b/plugins/dfu/meson.build
@@ -7,7 +7,6 @@ install_data(['dfu.quirk'],
 dfu = static_library(
   'dfu',
   sources : [
-    'dfu-chunked.c',
     'dfu-cipher-xtea.c',
     'dfu-common.c',
     'dfu-device.c',

--- a/plugins/wacomhid/fu-wac-device.c
+++ b/plugins/wacomhid/fu-wac-device.c
@@ -8,13 +8,13 @@
 
 #include <string.h>
 
+#include "fu-chunk.h"
 #include "fu-wac-device.h"
 #include "fu-wac-common.h"
 #include "fu-wac-firmware.h"
 #include "fu-wac-module-bluetooth.h"
 #include "fu-wac-module-touch.h"
 
-#include "dfu-chunked.h"
 #include "dfu-common.h"
 #include "dfu-firmware.h"
 
@@ -600,14 +600,14 @@ fu_wac_device_write_firmware (FuDevice *device, GBytes *blob, GError **error)
 			return FALSE;
 
 		/* write block in chunks */
-		chunks = dfu_chunked_new_from_bytes (blob_block,
-						     fd->start_addr,
-						     0, /* page_sz */
-						     self->write_block_sz);
+		chunks = fu_chunk_array_new_from_bytes (blob_block,
+							fd->start_addr,
+							0, /* page_sz */
+							self->write_block_sz);
 		for (guint j = 0; j < chunks->len; j++) {
-			DfuChunkedPacket *pkt = g_ptr_array_index (chunks, j);
-			g_autoptr(GBytes) blob_chunk = g_bytes_new (pkt->data, pkt->data_sz);
-			if (!fu_wac_device_write_block (self, pkt->address, blob_chunk, error))
+			FuChunk *chk = g_ptr_array_index (chunks, j);
+			g_autoptr(GBytes) blob_chunk = g_bytes_new (chk->data, chk->data_sz);
+			if (!fu_wac_device_write_block (self, chk->address, blob_chunk, error))
 				return FALSE;
 		}
 

--- a/plugins/wacomhid/fu-wac-module-bluetooth.c
+++ b/plugins/wacomhid/fu-wac-module-bluetooth.c
@@ -12,8 +12,6 @@
 #include "fu-wac-device.h"
 #include "fu-wac-module-bluetooth.h"
 
-#include "dfu-chunked.h"
-
 struct _FuWacModuleBluetooth
 {
 	FuWacModule		 parent_instance;

--- a/plugins/wacomhid/fu-wac-module.c
+++ b/plugins/wacomhid/fu-wac-module.c
@@ -13,7 +13,6 @@
 #include "fu-wac-device.h"
 
 #include "dfu-common.h"
-#include "dfu-chunked.h"
 #include "dfu-firmware.h"
 
 #define FU_WAC_MODLE_STATUS_OK				0

--- a/src/fu-chunk.h
+++ b/src/fu-chunk.h
@@ -1,11 +1,11 @@
 /*
- * Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2017-2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */
 
-#ifndef __DFU_CHUNKED_H
-#define __DFU_CHUNKED_H
+#ifndef __FU_CHUNK_H
+#define __FU_CHUNK_H
 
 #include <glib.h>
 #include <gusb.h>
@@ -18,26 +18,26 @@ typedef struct {
 	guint32		 address;
 	const guint8	*data;
 	guint32		 data_sz;
-} DfuChunkedPacket;
+} FuChunk;
 
-DfuChunkedPacket *dfu_chunked_packet_new		(guint32	 idx,
+FuChunk		*fu_chunk_new				(guint32	 idx,
 							 guint32	 page,
 							 guint32	 address,
 							 const guint8	*data,
 							 guint32	 data_sz);
-gchar		*dfu_chunked_packet_to_string		(DfuChunkedPacket	*item);
+gchar		*fu_chunk_to_string			(FuChunk	*item);
 
-gchar		*dfu_chunked_to_string			(GPtrArray	*chunked);
-GPtrArray	*dfu_chunked_new			(const guint8	*data,
+gchar		*fu_chunk_array_to_string		(GPtrArray	*chunked);
+GPtrArray	*fu_chunk_array_new			(const guint8	*data,
 							 guint32	 data_sz,
 							 guint32	 addr_start,
 							 guint32	 page_sz,
 							 guint32	 packet_sz);
-GPtrArray	*dfu_chunked_new_from_bytes		(GBytes		*blob,
+GPtrArray	*fu_chunk_array_new_from_bytes		(GBytes		*blob,
 							 guint32	 addr_start,
 							 guint32	 page_sz,
 							 guint32	 packet_sz);
 
 G_END_DECLS
 
-#endif /* __DFU_CHUNKED_H */
+#endif /* __FU_CHUNK_H */

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -16,6 +16,7 @@
 #include <string.h>
 
 #include "fu-common-cab.h"
+#include "fu-chunk.h"
 #include "fu-config.h"
 #include "fu-device-list.h"
 #include "fu-device-private.h"
@@ -2275,6 +2276,50 @@ fu_device_incorporate_func (void)
 	g_assert_cmpint (fu_device_get_icons(device)->len, ==, 1);
 }
 
+static void
+fu_chunk_func (void)
+{
+	g_autofree gchar *chunked1_str = NULL;
+	g_autofree gchar *chunked2_str = NULL;
+	g_autofree gchar *chunked3_str = NULL;
+	g_autofree gchar *chunked4_str = NULL;
+	g_autoptr(GPtrArray) chunked1 = NULL;
+	g_autoptr(GPtrArray) chunked2 = NULL;
+	g_autoptr(GPtrArray) chunked3 = NULL;
+	g_autoptr(GPtrArray) chunked4 = NULL;
+
+	chunked3 = fu_chunk_array_new ((const guint8 *) "123456", 6, 0x0, 3, 3);
+	chunked3_str = fu_chunk_array_to_string (chunked3);
+	g_print ("\n%s", chunked3_str);
+	g_assert_cmpstr (chunked3_str, ==, "#00: page:00 addr:0000 len:03 123\n"
+					   "#01: page:01 addr:0000 len:03 456\n");
+
+	chunked4 = fu_chunk_array_new ((const guint8 *) "123456", 6, 0x4, 4, 4);
+	chunked4_str = fu_chunk_array_to_string (chunked4);
+	g_print ("\n%s", chunked4_str);
+	g_assert_cmpstr (chunked4_str, ==, "#00: page:01 addr:0000 len:04 1234\n"
+					   "#01: page:02 addr:0000 len:02 56\n");
+
+	chunked1 = fu_chunk_array_new ((const guint8 *) "0123456789abcdef", 16, 0x0, 10, 4);
+	chunked1_str = fu_chunk_array_to_string (chunked1);
+	g_print ("\n%s", chunked1_str);
+	g_assert_cmpstr (chunked1_str, ==, "#00: page:00 addr:0000 len:04 0123\n"
+					   "#01: page:00 addr:0004 len:04 4567\n"
+					   "#02: page:00 addr:0008 len:02 89\n"
+					   "#03: page:01 addr:0000 len:04 abcd\n"
+					   "#04: page:01 addr:0004 len:02 ef\n");
+
+	chunked2 = fu_chunk_array_new ((const guint8 *) "XXXXXXYYYYYYZZZZZZ", 18, 0x0, 6, 4);
+	chunked2_str = fu_chunk_array_to_string (chunked2);
+	g_print ("\n%s", chunked2_str);
+	g_assert_cmpstr (chunked2_str, ==, "#00: page:00 addr:0000 len:04 XXXX\n"
+					   "#01: page:00 addr:0004 len:02 XX\n"
+					   "#02: page:01 addr:0000 len:04 YYYY\n"
+					   "#03: page:01 addr:0004 len:02 YY\n"
+					   "#04: page:02 addr:0000 len:04 ZZZZ\n"
+					   "#05: page:02 addr:0004 len:02 ZZ\n");
+}
+
 int
 main (int argc, char **argv)
 {
@@ -2326,6 +2371,7 @@ main (int argc, char **argv)
 	g_test_add_func ("/fwupd/plugin{quirks}", fu_plugin_quirks_func);
 	g_test_add_func ("/fwupd/keyring{gpg}", fu_keyring_gpg_func);
 	g_test_add_func ("/fwupd/keyring{pkcs7}", fu_keyring_pkcs7_func);
+	g_test_add_func ("/fwupd/chunk", fu_chunk_func);
 	g_test_add_func ("/fwupd/common{endian}", fu_common_endian_func);
 	g_test_add_func ("/fwupd/common{cab-success}", fu_common_store_cab_func);
 	g_test_add_func ("/fwupd/common{cab-success-unsigned}", fu_common_store_cab_unsigned_func);

--- a/src/meson.build
+++ b/src/meson.build
@@ -28,6 +28,7 @@ libfwupdprivate = static_library(
   'fwupdprivate',
   sources : [
     'fu-common.c',
+    'fu-chunk.c',
     'fu-device.c',
     'fu-device-locker.c',
     'fu-hwids.c',
@@ -246,6 +247,7 @@ if get_option('tests')
     sources : [
       keyring_src,
       'fu-self-test.c',
+      'fu-chunk.c',
       'fu-common.c',
       'fu-common-cab.c',
       'fu-config.c',


### PR DESCRIPTION
Five plugins (soon to be 7) are linking to the DFU plugin just for this simple
segment-aware chunking functionality. Move this into common code to make
building simpler.