### PR TITLE
Fix a few warnings

### DIFF
--- a/plugins/unifying/lu-device-peripheral.c
+++ b/plugins/unifying/lu-device-peripheral.c
@@ -120,7 +120,6 @@ lu_device_peripheral_fetch_firmware_info (LuDevice *device, GError **error)
 		    msg->data[2] == 0x00 &&
 		    msg->data[3] == 0x00 &&
 		    msg->data[4] == 0x00 &&
-		    msg->data[4] == 0x00 &&
 		    msg->data[5] == 0x00 &&
 		    msg->data[6] == 0x00 &&
 		    msg->data[7] == 0x00) {

--- a/plugins/wacomhid/fu-wac-device.c
+++ b/plugins/wacomhid/fu-wac-device.c
@@ -170,7 +170,7 @@ fu_wac_device_get_feature_report (FuWacDevice *self,
 	fu_wac_buffer_dump ("GE2", cmd, buf, sz);
 
 	/* check packet */
-	if (flags && FU_WAC_DEVICE_FEATURE_FLAG_ALLOW_TRUNC == 0 && sz != bufsz) {
+	if ((flags & FU_WAC_DEVICE_FEATURE_FLAG_ALLOW_TRUNC) == 0 && sz != bufsz) {
 		g_set_error (error,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_INTERNAL,
@@ -219,7 +219,7 @@ fu_wac_device_set_feature_report (FuWacDevice *self,
 	}
 
 	/* check packet */
-	if (flags && FU_WAC_DEVICE_FEATURE_FLAG_ALLOW_TRUNC == 0 && sz != bufsz) {
+	if ((flags & FU_WAC_DEVICE_FEATURE_FLAG_ALLOW_TRUNC) == 0 && sz != bufsz) {
 		g_set_error (error,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_INTERNAL,


### PR DESCRIPTION
This fixes a trivial duplicated line, and corrects a check if a flag is set in an error path. This is just to fix some warnings, and is untested as I do not have wacom hardware to test with.