### PR TITLE
uefi: Add special handling for /efi (Closes #680)

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -40,7 +40,7 @@ if get_option('systemd')
   rw_directories += join_paths (localstatedir, 'lib', 'fwupd')
   rw_directories += join_paths (default_sysconfdir, 'fwupd', 'remotes.d')
   if get_option('plugin_uefi')
-    rw_directories += ['-/boot/efi', '-/efi', '-/boot/EFI']
+    rw_directories += ['-/boot/efi', '-/efi/EFI', '-/boot/EFI']
   endif
 
   dynamic_options = []

--- a/plugins/uefi/fu-uefi-common.c
+++ b/plugins/uefi/fu-uefi-common.c
@@ -294,6 +294,17 @@ fu_uefi_check_esp_path (const gchar *path, GError **error)
 				     "%s/EFI does not exist", path);
 			return FALSE;
 		}
+	/* /efi is a special case because systemd sandboxing marks
+	 * it read-only, but we need to write to /efi/EFI
+	 */
+	} else if (g_strcmp0 (path, "/efi") == 0) {
+		if (!g_file_test ("/efi/EFI", G_FILE_TEST_IS_DIR)) {
+			g_set_error (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED,
+				     "%s/EFI does not exist", path);
+			return FALSE;
+		}
 	} else if (g_unix_mount_is_readonly (mount)) {
 		g_set_error (error,
 			     FWUPD_ERROR,


### PR DESCRIPTION
This is a similar problem to #627 (which was fixed by 9bdbbc5ca).
Add special handling to allow writing to `/efi/EFI`