### PR TITLE
trivial: Use the new subclassed device methods

### DIFF
--- a/plugins/dfu/dfu-device.c
+++ b/plugins/dfu/dfu-device.c
@@ -1610,7 +1610,7 @@ dfu_device_wait_for_replug (DfuDevice *device, guint timeout, GError **error)
 	g_autoptr(GUsbDevice) usb_device2  = NULL;
 
 	/* close */
-	fu_usb_device_close (FU_USB_DEVICE (device), NULL);
+	fu_device_close (FU_DEVICE (device), NULL);
 
 	/* watch the device disappear and re-appear */
 	usb_device2 = g_usb_context_wait_for_replug (priv->usb_context,
@@ -1623,7 +1623,7 @@ dfu_device_wait_for_replug (DfuDevice *device, guint timeout, GError **error)
 	/* re-open with new device set */
 	fu_device_set_status (FU_DEVICE (device), FWUPD_STATUS_IDLE);
 	fu_usb_device_set_dev (FU_USB_DEVICE (device), usb_device2);
-	if (!fu_usb_device_open (FU_USB_DEVICE (device), error))
+	if (!fu_device_open (FU_DEVICE (device), error))
 		return FALSE;
 	if (!dfu_device_refresh_and_clear (device, error))
 		return FALSE;

--- a/plugins/dfu/dfu-tool.c
+++ b/plugins/dfu/dfu-tool.c
@@ -252,7 +252,7 @@ dfu_tool_get_default_device (DfuToolPrivate *priv, GError **error)
 		g_autoptr(DfuDevice) device = dfu_device_new (usb_device);
 		fu_device_set_quirks (FU_DEVICE (device), priv->quirks);
 		dfu_device_set_usb_context (device, usb_context);
-		if (fu_usb_device_probe (FU_USB_DEVICE (device), NULL))
+		if (fu_device_probe (FU_DEVICE (device), NULL))
 			return g_steal_pointer (&device);
 	}
 
@@ -2034,7 +2034,7 @@ dfu_tool_list (DfuToolPrivate *priv, gchar **values, GError **error)
 		device = dfu_device_new (usb_device);
 		fu_device_set_quirks (FU_DEVICE (device), priv->quirks);
 		dfu_device_set_usb_context (device, usb_context);
-		if (!fu_usb_device_probe (FU_USB_DEVICE (device), NULL))
+		if (!fu_device_probe (FU_DEVICE (device), NULL))
 			continue;
 		version = as_utils_version_from_uint16 (g_usb_device_get_release (usb_device),
 							AS_VERSION_PARSE_FLAG_USE_BCD);

--- a/src/fu-device-locker.c
+++ b/src/fu-device-locker.c
@@ -72,8 +72,8 @@ fu_device_locker_init (FuDeviceLocker *self)
  * manually closed using g_clear_object().
  *
  * The functions used for opening and closing the device are set automatically.
- * If the @device is not a type or supertype of #GUsbDevice, #FuUsbDevice or
- * #FuDevice then this function will not work.
+ * If the @device is not a type or supertype of #GUsbDevice or #FuDevice then
+ * this function will not work.
  *
  * For custom objects please use fu_device_locker_new_full().
  *
@@ -94,14 +94,6 @@ fu_device_locker_new (gpointer device, GError **error)
 		return fu_device_locker_new_full (device,
 						  (FuDeviceLockerFunc) g_usb_device_open,
 						  (FuDeviceLockerFunc) g_usb_device_close,
-						  error);
-	}
-
-	/* FuUsbDevice */
-	if (FU_IS_USB_DEVICE (device)) {
-		return fu_device_locker_new_full (device,
-						  (FuDeviceLockerFunc) fu_usb_device_open,
-						  (FuDeviceLockerFunc) fu_usb_device_close,
 						  error);
 	}
 

--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -1344,6 +1344,29 @@ fu_device_probe (FuDevice *device, GError **error)
 }
 
 /**
+ * fu_device_probe_invalidate:
+ * @device: A #FuDevice
+ *
+ * Normally when calling fu_device_probe() multiple times it is only done once.
+ * Calling this method causes the next fu_device_probe() call to actually
+ * probe the hardware.
+ *
+ * This should be done in case the backing device has changed, for instance if
+ * a USB device has been replugged.
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 1.1.2
+ **/
+void
+fu_device_probe_invalidate (FuDevice *device)
+{
+	FuDevicePrivate *priv = GET_PRIVATE (device);
+	g_return_if_fail (FU_IS_DEVICE (device));
+	priv->done_probe = FALSE;
+}
+
+/**
  * fu_device_incorporate:
  * @device: A #FuDevice
  * @donor: Another #FuDevice

--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -184,6 +184,7 @@ gboolean	 fu_device_close			(FuDevice	*device,
 							 GError		**error);
 gboolean	 fu_device_probe			(FuDevice	*device,
 							 GError		**error);
+void		 fu_device_probe_invalidate		(FuDevice	*device);
 
 G_END_DECLS
 

--- a/src/fu-usb-device.c
+++ b/src/fu-usb-device.c
@@ -23,7 +23,6 @@ typedef struct
 {
 	GUsbDevice		*usb_device;
 	FuDeviceLocker		*usb_device_locker;
-	gboolean		 done_probe;
 } FuUsbDevicePrivate;
 
 G_DEFINE_TYPE_WITH_PRIVATE (FuUsbDevice, fu_usb_device, FU_TYPE_DEVICE)
@@ -140,24 +139,6 @@ fu_usb_device_init (FuUsbDevice *device)
 			  G_CALLBACK (fu_usb_device_notify_quirks_cb), NULL);
 }
 
-static void
-fu_usb_device_class_init (FuUsbDeviceClass *klass)
-{
-	GObjectClass *object_class = G_OBJECT_CLASS (klass);
-	GParamSpec *pspec;
-
-	object_class->finalize = fu_usb_device_finalize;
-	object_class->get_property = fu_usb_device_get_property;
-	object_class->set_property = fu_usb_device_set_property;
-
-	pspec = g_param_spec_object ("usb-device", NULL, NULL,
-				     G_USB_TYPE_DEVICE,
-				     G_PARAM_READWRITE |
-				     G_PARAM_CONSTRUCT |
-				     G_PARAM_STATIC_NAME);
-	g_object_class_install_property (object_class, PROP_USB_DEVICE, pspec);
-}
-
 /**
  * fu_usb_device_is_open:
  * @device: A #FuUsbDevice
@@ -176,37 +157,23 @@ fu_usb_device_is_open (FuUsbDevice *device)
 	return priv->usb_device_locker != NULL;
 }
 
-/**
- * fu_usb_device_open:
- * @device: A #FuUsbDevice
- * @error: A #GError, or %NULL
- *
- * Opens a USB device, optionally running a object-specific vfunc.
- *
- * Returns: %TRUE for success
- *
- * Since: 1.0.2
- **/
-gboolean
-fu_usb_device_open (FuUsbDevice *device, GError **error)
+static gboolean
+fu_usb_device_open (FuDevice *device, GError **error)
 {
-	FuUsbDevicePrivate *priv = GET_PRIVATE (device);
+	FuUsbDevice *self = FU_USB_DEVICE (device);
+	FuUsbDevicePrivate *priv = GET_PRIVATE (self);
 	FuUsbDeviceClass *klass = FU_USB_DEVICE_GET_CLASS (device);
 	guint idx;
 	g_autoptr(AsProfile) profile = as_profile_new ();
 	g_autoptr(AsProfileTask) ptask = NULL;
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
-	g_return_val_if_fail (FU_IS_USB_DEVICE (device), FALSE);
+	g_return_val_if_fail (FU_IS_USB_DEVICE (self), FALSE);
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
 	/* already open */
 	if (priv->usb_device_locker != NULL)
 		return TRUE;
-
-	/* probe */
-	if (!fu_usb_device_probe (device, error))
-		return FALSE;
 
 	/* profile */
 	ptask = as_profile_start (profile, "added{%04x:%04x}",
@@ -220,7 +187,7 @@ fu_usb_device_open (FuUsbDevice *device, GError **error)
 		return FALSE;
 
 	/* get vendor */
-	if (fu_device_get_vendor (FU_DEVICE (device)) == NULL) {
+	if (fu_device_get_vendor (device) == NULL) {
 		idx = g_usb_device_get_manufacturer_index (priv->usb_device);
 		if (idx != 0x00) {
 			g_autofree gchar *tmp = NULL;
@@ -228,12 +195,12 @@ fu_usb_device_open (FuUsbDevice *device, GError **error)
 								  idx, error);
 			if (tmp == NULL)
 				return FALSE;
-			fu_device_set_vendor (FU_DEVICE (device), tmp);
+			fu_device_set_vendor (device, tmp);
 		}
 	}
 
 	/* get product */
-	if (fu_device_get_name (FU_DEVICE (device)) == NULL) {
+	if (fu_device_get_name (device) == NULL) {
 		idx = g_usb_device_get_product_index (priv->usb_device);
 		if (idx != 0x00) {
 			g_autofree gchar *tmp = NULL;
@@ -241,12 +208,12 @@ fu_usb_device_open (FuUsbDevice *device, GError **error)
 								  idx, error);
 			if (tmp == NULL)
 				return FALSE;
-			fu_device_set_name (FU_DEVICE (device), tmp);
+			fu_device_set_name (device, tmp);
 		}
 	}
 
 	/* get serial number */
-	if (fu_device_get_serial (FU_DEVICE (device)) == NULL) {
+	if (fu_device_get_serial (device) == NULL) {
 		idx = g_usb_device_get_serial_number_index (priv->usb_device);
 		if (idx != 0x00) {
 			g_autofree gchar *tmp = NULL;
@@ -254,7 +221,7 @@ fu_usb_device_open (FuUsbDevice *device, GError **error)
 								  idx, error);
 			if (tmp == NULL)
 				return FALSE;
-			fu_device_set_serial (FU_DEVICE (device), tmp);
+			fu_device_set_serial (device, tmp);
 		}
 	}
 
@@ -265,7 +232,7 @@ fu_usb_device_open (FuUsbDevice *device, GError **error)
 	if (idx != 0x00) {
 		g_autofree gchar *tmp = NULL;
 		tmp = g_usb_device_get_string_descriptor (priv->usb_device, idx, NULL);
-		fu_device_set_version (FU_DEVICE (device), tmp);
+		fu_device_set_version (device, tmp);
 	}
 
 	/* get GUID from the descriptor if set */
@@ -275,12 +242,12 @@ fu_usb_device_open (FuUsbDevice *device, GError **error)
 	if (idx != 0x00) {
 		g_autofree gchar *tmp = NULL;
 		tmp = g_usb_device_get_string_descriptor (priv->usb_device, idx, NULL);
-		fu_device_add_guid (FU_DEVICE (device), tmp);
+		fu_device_add_guid (device, tmp);
 	}
 
 	/* subclassed */
 	if (klass->open != NULL) {
-		if (!klass->open (device, error))
+		if (!klass->open (self, error))
 			return FALSE;
 	}
 
@@ -289,24 +256,14 @@ fu_usb_device_open (FuUsbDevice *device, GError **error)
 	return TRUE;
 }
 
-/**
- * fu_usb_device_close:
- * @device: A #FuUsbDevice
- * @error: A #GError, or %NULL
- *
- * Closes a USB device, optionally running a object-specific vfunc.
- *
- * Returns: %TRUE for success
- *
- * Since: 1.0.2
- **/
-gboolean
-fu_usb_device_close (FuUsbDevice *device, GError **error)
+static gboolean
+fu_usb_device_close (FuDevice *device, GError **error)
 {
-	FuUsbDevicePrivate *priv = GET_PRIVATE (device);
+	FuUsbDevice *self = FU_USB_DEVICE (device);
+	FuUsbDevicePrivate *priv = GET_PRIVATE (self);
 	FuUsbDeviceClass *klass = FU_USB_DEVICE_GET_CLASS (device);
 
-	g_return_val_if_fail (FU_IS_USB_DEVICE (device), FALSE);
+	g_return_val_if_fail (FU_IS_USB_DEVICE (self), FALSE);
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
 	/* already open */
@@ -315,7 +272,7 @@ fu_usb_device_close (FuUsbDevice *device, GError **error)
 
 	/* subclassed */
 	if (klass->close != NULL) {
-		if (!klass->close (device, error))
+		if (!klass->close (self, error))
 			return FALSE;
 	}
 
@@ -323,38 +280,20 @@ fu_usb_device_close (FuUsbDevice *device, GError **error)
 	return TRUE;
 }
 
-/**
- * fu_usb_device_probe:
- * @device: A #FuUsbDevice
- * @error: A #GError, or %NULL
- *
- * Probes a USB device, setting parameters on the object that does not need
- * the device open or the interface claimed.
- * If the device is not compatible then an error should be returned.
- *
- * Returns: %TRUE for success
- *
- * Since: 1.0.2
- **/
-gboolean
-fu_usb_device_probe (FuUsbDevice *device, GError **error)
+static gboolean
+fu_usb_device_probe (FuDevice *device, GError **error)
 {
-	FuUsbDevicePrivate *priv = GET_PRIVATE (device);
+	FuUsbDevice *self = FU_USB_DEVICE (device);
 	FuUsbDeviceClass *klass = FU_USB_DEVICE_GET_CLASS (device);
 
 	g_return_val_if_fail (FU_IS_USB_DEVICE (device), FALSE);
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
 
-	/* already done */
-	if (priv->done_probe)
-		return TRUE;
-
 	/* subclassed */
 	if (klass->probe != NULL) {
-		if (!klass->probe (device, error))
+		if (!klass->probe (self, error))
 			return FALSE;
 	}
-	priv->done_probe = TRUE;
 	return TRUE;
 }
 
@@ -379,7 +318,7 @@ fu_usb_device_set_dev (FuUsbDevice *device, GUsbDevice *usb_device)
 	g_return_if_fail (FU_IS_USB_DEVICE (device));
 
 	/* need to re-probe hardware */
-	priv->done_probe = FALSE;
+	fu_device_probe_invalidate (FU_DEVICE (device));
 
 	/* allow replacement */
 	g_set_object (&priv->usb_device, usb_device);
@@ -453,4 +392,26 @@ fu_usb_device_new (GUsbDevice *usb_device)
 	FuUsbDevice *device = g_object_new (FU_TYPE_USB_DEVICE, NULL);
 	fu_usb_device_set_dev (device, usb_device);
 	return FU_DEVICE (device);
+}
+
+static void
+fu_usb_device_class_init (FuUsbDeviceClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+	FuDeviceClass *device_class = FU_DEVICE_CLASS (klass);
+	GParamSpec *pspec;
+
+	object_class->finalize = fu_usb_device_finalize;
+	object_class->get_property = fu_usb_device_get_property;
+	object_class->set_property = fu_usb_device_set_property;
+	device_class->open = fu_usb_device_open;
+	device_class->close = fu_usb_device_close;
+	device_class->probe = fu_usb_device_probe;
+
+	pspec = g_param_spec_object ("usb-device", NULL, NULL,
+				     G_USB_TYPE_DEVICE,
+				     G_PARAM_READWRITE |
+				     G_PARAM_CONSTRUCT |
+				     G_PARAM_STATIC_NAME);
+	g_object_class_install_property (object_class, PROP_USB_DEVICE, pspec);
 }

--- a/src/fu-usb-device.h
+++ b/src/fu-usb-device.h
@@ -43,12 +43,6 @@ FuDevice	*fu_usb_device_new			(GUsbDevice	*usb_device);
 GUsbDevice	*fu_usb_device_get_dev			(FuUsbDevice	*device);
 void		 fu_usb_device_set_dev			(FuUsbDevice	*device,
 							 GUsbDevice	*usb_device);
-gboolean	 fu_usb_device_open			(FuUsbDevice	*device,
-							 GError		**error);
-gboolean	 fu_usb_device_close			(FuUsbDevice	*device,
-							 GError		**error);
-gboolean	 fu_usb_device_probe			(FuUsbDevice	*device,
-							 GError		**error);
 gboolean	 fu_usb_device_is_open			(FuUsbDevice	*device);
 
 G_END_DECLS


### PR DESCRIPTION
This just reduces our API surface a little, no behaviour change.