### PR TITLE
fu-engine: Don't fail get-details if compiled without GPG/PKCS7

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2014,6 +2014,7 @@ fu_engine_get_result_from_app (FuEngine *self, AsApp *app, GError **error)
 	g_autoptr(FuInstallTask) task = NULL;
 	g_autoptr(FwupdDevice) dev = NULL;
 	g_autoptr(FwupdRelease) rel = NULL;
+	g_autoptr(GError) error_local = NULL;
 
 	dev = fwupd_device_new ();
 	provides = as_app_get_provides (app);
@@ -2057,8 +2058,24 @@ fu_engine_get_result_from_app (FuEngine *self, AsApp *app, GError **error)
 
 	/* verify trust */
 	release = as_app_get_release_default (app);
-	if (!fu_keyring_get_release_trust_flags (release, &trust_flags, error))
-		return NULL;
+	if (!fu_keyring_get_release_trust_flags (release,
+						 &trust_flags,
+						 &error_local)) {
+		AsChecksum *csum = as_release_get_checksum_by_target (release,
+						    AS_CHECKSUM_TARGET_CONTENT);
+		if (g_error_matches (error_local,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED) \
+				     && csum != NULL) {
+			g_warning ("Ignoring verification for %s: %s",
+				   as_checksum_get_filename (csum),
+				   error_local->message);
+		} else {
+			g_propagate_error (error,
+					   g_steal_pointer (&error_local));
+			return NULL;
+		}
+	}
 
 	/* create a result with all the metadata in */
 	fwupd_device_set_description (dev, as_app_get_description (app, NULL));


### PR DESCRIPTION
Similar to commit 7d35278 regarding the install option with a daemon compiled without
GPG, but now, if you also have a daemon compiled without GPG, and if you have downloaded a
CAB file from LVFS and ran get-details, it would fail to display the contents
of the associated CAB file.

This allows it to still display the contents of the CAB file, and
a warning will be displayed in the logs.