### PR TITLE
synapticsmst: Allow using a custom flag 'skip-restart'

### DIFF
--- a/plugins/synapticsmst/synapticsmst-device.c
+++ b/plugins/synapticsmst/synapticsmst-device.c
@@ -1228,6 +1228,7 @@ synapticsmst_device_write_firmware (SynapticsMSTDevice *device,
 				    GBytes *fw,
 				    GFileProgressCallback progress_cb,
 				    gpointer progress_data,
+				    gboolean reboot,
 				    GError **error)
 {
 	const guint8 *payload_data;
@@ -1272,10 +1273,17 @@ synapticsmst_device_write_firmware (SynapticsMSTDevice *device,
 	}
 
 	/* enable remote control and disable on exit */
-	locker = fu_device_locker_new_full (device,
-					    (FuDeviceLockerFunc) synapticsmst_device_enable_remote_control,
-					    (FuDeviceLockerFunc) synapticsmst_device_restart,
-					    error);
+	if (reboot) {
+		locker = fu_device_locker_new_full (device,
+						(FuDeviceLockerFunc) synapticsmst_device_enable_remote_control,
+						(FuDeviceLockerFunc) synapticsmst_device_restart,
+						error);
+	} else {
+		locker = fu_device_locker_new_full (device,
+						(FuDeviceLockerFunc) synapticsmst_device_enable_remote_control,
+						(FuDeviceLockerFunc) synapticsmst_device_disable_remote_control,
+						error);
+	}
 	if (locker == NULL)
 		return FALSE;
 

--- a/plugins/synapticsmst/synapticsmst-device.h
+++ b/plugins/synapticsmst/synapticsmst-device.h
@@ -82,6 +82,7 @@ gboolean	 synapticsmst_device_write_firmware		(SynapticsMSTDevice *device,
 								 GBytes	*fw,
 								 GFileProgressCallback	progress_cb,
 								 gpointer user_data,
+								 gboolean reboot,
 								 GError	**error);
 
 G_END_DECLS

--- a/plugins/synapticsmst/synapticsmst.quirk
+++ b/plugins/synapticsmst/synapticsmst.quirk
@@ -10,6 +10,10 @@
 # DeviceKind != system
 #  * Will map to a GUID containing each comma delimitted substring
 #  * These GUIDs will look like MST-${DEVICEKIND}-${CHIPID}-${BOARDID}
+#
+# By default the Synaptics MST device will restart after update
+# To override this behavior add the custom flag "skip-restart"
+#
 
 [SynapticsMSTBoardID=0]
 Name = Synaptics EVB development board


### PR DESCRIPTION
This flag is intended for devices that the restart procedure will
be performed as part of a transactional update by an external
controller.

None of the currently supported devices need this flag.