### PR TITLE
Wip/hughsie/quirks two layer hash

### DIFF
--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -562,6 +562,10 @@ fu_device_set_quirk_kv (FuDevice *device,
 		return TRUE;
 	}
 
+	/* optional device-specific method */
+	if (klass->set_quirk_kv != NULL)
+		return klass->set_quirk_kv (device, key, value, error);
+
 	/* failed */
 	g_set_error_literal (error,
 			     G_IO_ERROR,

--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -510,7 +510,7 @@ fu_device_set_quirk_kv (FuDevice *device,
 	FuDeviceClass *klass = FU_DEVICE_GET_CLASS (device);
 
 	if (g_strcmp0 (key, FU_QUIRKS_PLUGIN) == 0) {
-		// FIXME
+		fu_device_set_plugin (device, value);
 		return TRUE;
 	}
 	if (g_strcmp0 (key, FU_QUIRKS_FLAGS) == 0) {

--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -40,8 +40,12 @@ struct _FuDeviceClass
 	GBytes			*(*prepare_firmware)	(FuDevice	*device,
 							 GBytes		*fw,
 							 GError		**error);
+	gboolean		 (*set_quirk_kv)	(FuDevice	*device,
+							 const gchar	*key,
+							 const gchar	*value,
+							 GError		**error);
 	/*< private >*/
-	gpointer	padding[24];
+	gpointer	padding[23];
 };
 
 /**

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2988,7 +2988,7 @@ static void
 fu_engine_udev_device_add (FuEngine *self, GUdevDevice *udev_device)
 {
 	GPtrArray *plugins = fu_plugin_list_get_all (self->plugin_list);
-	g_autofree gchar *plugin_name = NULL;
+	const gchar *plugin_name;
 	g_autoptr(FuDevice) device = fu_udev_device_new (udev_device);
 	g_autoptr(GError) error_local = NULL;
 
@@ -3001,10 +3001,8 @@ fu_engine_udev_device_add (FuEngine *self, GUdevDevice *udev_device)
 		return;
 	}
 
-	/* does the quirk specify the plugin to use */
-	plugin_name = fu_quirks_lookup_by_guids (self->quirks,
-						 fu_device_get_guids (device),
-						 FU_QUIRKS_PLUGIN);
+	/* can be specified using a quirk */
+	plugin_name = fu_device_get_plugin (device);
 	if (plugin_name != NULL) {
 		g_autoptr(GError) error = NULL;
 		FuPlugin *plugin = fu_plugin_list_find_by_name (self->plugin_list,
@@ -3344,7 +3342,7 @@ fu_engine_usb_device_added_cb (GUsbContext *ctx,
 			       FuEngine *self)
 {
 	GPtrArray *plugins = fu_plugin_list_get_all (self->plugin_list);
-	g_autofree gchar *plugin_name = NULL;
+	const gchar *plugin_name;
 	g_autoptr(FuDevice) device = fu_usb_device_new (usb_device);
 	g_autoptr(GError) error_local = NULL;
 
@@ -3357,10 +3355,8 @@ fu_engine_usb_device_added_cb (GUsbContext *ctx,
 		return;
 	}
 
-	/* does the quirk specify the plugin to use */
-	plugin_name = fu_quirks_lookup_by_guids (self->quirks,
-						 fu_device_get_guids (device),
-						 FU_QUIRKS_PLUGIN);
+	/* can be specified using a quirk */
+	plugin_name = fu_device_get_plugin (device);
 	if (plugin_name != NULL) {
 		g_autoptr(GError) error = NULL;
 		FuPlugin *plugin = fu_plugin_list_find_by_name (self->plugin_list,

--- a/src/fu-quirks.c
+++ b/src/fu-quirks.c
@@ -160,6 +160,29 @@ fu_quirks_lookup_by_guid (FuQuirks *self, const gchar *guid, const gchar *key)
 }
 
 /**
+ * fu_quirks_get_kvs_for_guid:
+ * @self: A #FuPlugin
+ * @guid: a GUID
+ * @iter: A #GHashTableIter, typically allocated on the stack by the caller
+ *
+ * Looks up all entries in the hardware database using a GUID value.
+ *
+ * Returns: %TRUE if the GUID was found, and @iter was set
+ *
+ * Since: 1.1.2
+ **/
+gboolean
+fu_quirks_get_kvs_for_guid (FuQuirks *self, const gchar *guid, GHashTableIter *iter)
+{
+	GHashTable *kvs;
+	kvs = g_hash_table_lookup (self->hash, guid);
+	if (kvs == NULL)
+		return FALSE;
+	g_hash_table_iter_init (iter, kvs);
+	return TRUE;
+}
+
+/**
  * fu_quirks_lookup_by_guids:
  * @self: A #FuPlugin
  * @guid: GUID array

--- a/src/fu-quirks.c
+++ b/src/fu-quirks.c
@@ -133,33 +133,6 @@ fu_quirks_lookup_by_id (FuQuirks *self, const gchar *group, const gchar *key)
 }
 
 /**
- * fu_quirks_lookup_by_guid:
- * @self: A #FuPlugin
- * @guid: a GUID
- * @key: An ID to match the entry, e.g. "Name"
- *
- * Looks up an entry in the hardware database using a GUID value.
- *
- * Returns: (transfer none): values from the database, or %NULL if not found
- *
- * Since: 1.1.2
- **/
-const gchar *
-fu_quirks_lookup_by_guid (FuQuirks *self, const gchar *guid, const gchar *key)
-{
-	GHashTable *kvs;
-
-	g_return_val_if_fail (FU_IS_QUIRKS (self), NULL);
-	g_return_val_if_fail (guid != NULL, NULL);
-	g_return_val_if_fail (key != NULL, NULL);
-
-	kvs = g_hash_table_lookup (self->hash, guid);
-	if (kvs == NULL)
-		return NULL;
-	return g_hash_table_lookup (kvs, key);
-}
-
-/**
  * fu_quirks_get_kvs_for_guid:
  * @self: A #FuPlugin
  * @guid: a GUID
@@ -180,39 +153,6 @@ fu_quirks_get_kvs_for_guid (FuQuirks *self, const gchar *guid, GHashTableIter *i
 		return FALSE;
 	g_hash_table_iter_init (iter, kvs);
 	return TRUE;
-}
-
-/**
- * fu_quirks_lookup_by_guids:
- * @self: A #FuPlugin
- * @guid: GUID array
- * @key: An ID to match the entry, e.g. "Name"
- *
- * Looks up an entry in the hardware database using a GUID value. If multiple
- * values match then they are joined using the ',' character.
- *
- * Returns: (transfer full): values from the database, or %NULL if not found
- *
- * Since: 1.1.2
- **/
-gchar *
-fu_quirks_lookup_by_guids (FuQuirks *self, GPtrArray *guids, const gchar *key)
-{
-	g_autoptr(GString) str = g_string_new (NULL);
-	for (guint i = 0; i < guids->len; i++) {
-		const gchar *guid = g_ptr_array_index (guids, i);
-		const gchar *tmp = fu_quirks_lookup_by_guid (self, guid, key);
-		if (tmp != NULL) {
-			if (g_strcmp0 (tmp, str->str) == 0)
-				continue;
-			if (str->len > 0)
-				g_string_append_c (str, ',');
-			g_string_append (str, tmp);
-		}
-	}
-	if (str->len == 0)
-		return NULL;
-	return g_string_free (g_steal_pointer (&str), FALSE);
 }
 
 static gchar *

--- a/src/fu-quirks.h
+++ b/src/fu-quirks.h
@@ -31,6 +31,9 @@ void		 fu_quirks_add_value			(FuQuirks	*self,
 							 const gchar	*group,
 							 const gchar	*key,
 							 const gchar	*value);
+gboolean	 fu_quirks_get_kvs_for_guid		(FuQuirks	*self,
+							 const gchar	*guid,
+							 GHashTableIter *iter);
 
 /**
  * FU_QUIRKS_PLUGIN:

--- a/src/fu-quirks.h
+++ b/src/fu-quirks.h
@@ -21,12 +21,6 @@ gboolean	 fu_quirks_load				(FuQuirks	*self,
 const gchar	*fu_quirks_lookup_by_id			(FuQuirks	*self,
 							 const gchar	*group,
 							 const gchar	*key);
-const gchar	*fu_quirks_lookup_by_guid		(FuQuirks	*self,
-							 const gchar	*guid,
-							 const gchar	*key);
-gchar		*fu_quirks_lookup_by_guids		(FuQuirks	*self,
-							 GPtrArray	*guids,
-							 const gchar	*key);
 void		 fu_quirks_add_value			(FuQuirks	*self,
 							 const gchar	*group,
 							 const gchar	*key,


### PR DESCRIPTION
This makes fwupd use less memory, start up faster, and smell nicer. It also makes implementing things like https://github.com/hughsie/fwupd/pull/685 much easier as we can just implement one vfunc and get quirks set in the derived objects. It also allows us to add quirks with impunity without worrying about query performance.