### PR TITLE
Add support for counterpart GUIDs

### DIFF
--- a/plugins/altos/fu-plugin-altos.c
+++ b/plugins/altos/fu-plugin-altos.c
@@ -42,7 +42,7 @@ fu_plugin_usb_device_added (FuPlugin *plugin, GUsbDevice *usb_device, GError **e
 		if (dev_runtime != NULL) {
 			const gchar *guid = fu_device_get_guid_default (dev_runtime);
 			g_debug ("adding runtime GUID of %s", guid);
-			fu_device_add_guid (FU_DEVICE (dev), guid);
+			fu_device_add_counterpart_guid (FU_DEVICE (dev), guid);
 			fu_device_set_version (FU_DEVICE (dev),
 					       fu_device_get_version (dev_runtime));
 		}

--- a/plugins/colorhug/colorhug.quirk
+++ b/plugins/colorhug/colorhug.quirk
@@ -5,12 +5,15 @@ Flags = is-bootloader
 Guid = 40338ceb-b966-4eae-adae-9c32edfcc484
 FirmwareSizeMin = 0x2000
 FirmwareSizeMax = 0x8000
+CounterpartGuid = USB\VID_273F&PID_1001
+
 [DeviceInstanceId=USB\VID_273F&PID_1001]
 Plugin = colorhug
 Flags = none
 Summary = An open source display colorimeter
 Icon = colorimeter-colorhug
 Guid = 40338ceb-b966-4eae-adae-9c32edfcc484
+CounterpartGuid = USB\VID_273F&PID_1000
 
 # ColorHug2
 [DeviceInstanceId=USB\VID_273F&PID_1004]
@@ -21,10 +24,13 @@ Icon = colorimeter-colorhug
 Guid = 2082b5e0-7a64-478a-b1b2-e3404fab6dad
 FirmwareSizeMin = 0x2000
 FirmwareSizeMax = 0x8000
+CounterpartGuid = USB\VID_273F&PID_1005
+
 [DeviceInstanceId=USB\VID_273F&PID_1005]
 Plugin = colorhug
 Flags = is-bootloader
 Guid = 2082b5e0-7a64-478a-b1b2-e3404fab6dad
+CounterpartGuid = USB\VID_273F&PID_1004
 
 # ColorHugALS
 [DeviceInstanceId=USB\VID_273F&PID_1007]
@@ -34,7 +40,10 @@ Summary = An open source ambient light sensor
 Guid = 84f40464-9272-4ef7-9399-cd95f12da696
 FirmwareSizeMin = 0x1000
 FirmwareSizeMax = 0x4000
+CounterpartGuid = USB\VID_273F&PID_1006
+
 [DeviceInstanceId=USB\VID_273F&PID_1006]
 Plugin = colorhug
 Flags = halfsize,is-bootloader
 Guid = 84f40464-9272-4ef7-9399-cd95f12da696
+CounterpartGuid = USB\VID_273F&PID_1007

--- a/plugins/dfu/dfu.quirk
+++ b/plugins/dfu/dfu.quirk
@@ -60,28 +60,28 @@ DfuFlags = no-dfu-runtime,action-required
 Plugin = dfu
 DfuFlags = no-dfu-runtime
 DfuJabraDetach = 0201
-Guid = USB\VID_0B0E&PID_0411
+CounterpartGuid = USB\VID_0B0E&PID_0411
 
 # Jabra 510
 [DeviceInstanceId=USB\VID_0B0E&PID_0420]
 Plugin = dfu
 DfuFlags = no-dfu-runtime
 DfuJabraDetach = 0201
-Guid = USB\VID_0B0E&PID_0421
+CounterpartGuid = USB\VID_0B0E&PID_0421
 
 # Jabra 710
 [DeviceInstanceId=USB\VID_0B0E&PID_2475]
 Plugin = dfu
 DfuFlags = no-dfu-runtime
 DfuJabraDetach = 0508
-Guid = USB\VID_0B0E&PID_0982
+CounterpartGuid = USB\VID_0B0E&PID_0982
 
 # Jabra 810
 [DeviceInstanceId=USB\VID_0B0E&PID_2456]
 Plugin = dfu
 DfuFlags = no-dfu-runtime
 DfuJabraDetach = 0508
-Guid = USB\VID_0B0E&PID_0971
+CounterpartGuid = USB\VID_0B0E&PID_0971
 
 [DeviceInstanceId=USB\VID_0B0E&PID_0411]
 Plugin = dfu

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -560,8 +560,8 @@ fu_ebitdo_device_probe (FuUsbDevice *device, GError **error)
 
 	/* only the bootloader can do the update */
 	if (!fu_device_has_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_IS_BOOTLOADER)) {
-		fu_device_add_guid (FU_DEVICE (device), "USB\\VID_0483&PID_5750");
-		fu_device_add_guid (FU_DEVICE (device), "USB\\VID_2DC8&PID_5750");
+		fu_device_add_counterpart_guid (FU_DEVICE (device), "USB\\VID_0483&PID_5750");
+		fu_device_add_counterpart_guid (FU_DEVICE (device), "USB\\VID_2DC8&PID_5750");
 		fu_device_add_flag (FU_DEVICE (device),
 				    FWUPD_DEVICE_FLAG_NEEDS_BOOTLOADER);
 	}

--- a/plugins/nitrokey/nitrokey.quirk
+++ b/plugins/nitrokey/nitrokey.quirk
@@ -2,6 +2,6 @@
 [DeviceInstanceId=USB\VID_20A0&PID_4109]
 Plugin = nitrokey
 Flags = needs-bootloader,use-runtime-version
-Guid = USB\VID_03EB&PID_2FF1
+CounterpartGuid = USB\VID_03EB&PID_2FF1
 Summary = A secure memory stick
 Icon = media-removable

--- a/plugins/unifying/lu-device-runtime.c
+++ b/plugins/unifying/lu-device-runtime.c
@@ -77,7 +77,7 @@ lu_device_runtime_open (LuDevice *device, GError **error)
 			devid2 = g_strdup_printf ("USB\\VID_%04X&PID_%04X",
 						  (guint) LU_DEVICE_VID,
 						  (guint) LU_DEVICE_PID_BOOTLOADER_NORDIC);
-			fu_device_add_guid (FU_DEVICE (device), devid2);
+			fu_device_add_counterpart_guid (FU_DEVICE (device), devid2);
 			version_bl_major = 0x01;
 			break;
 		case 0x2400:
@@ -85,7 +85,7 @@ lu_device_runtime_open (LuDevice *device, GError **error)
 			devid2 = g_strdup_printf ("USB\\VID_%04X&PID_%04X",
 						  (guint) LU_DEVICE_VID,
 						  (guint) LU_DEVICE_PID_BOOTLOADER_TEXAS);
-			fu_device_add_guid (FU_DEVICE (device), devid2);
+			fu_device_add_counterpart_guid (FU_DEVICE (device), devid2);
 			version_bl_major = 0x03;
 			break;
 		default:

--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -359,7 +359,7 @@ fu_device_list_add_missing_guids (FuDevice *device_new, FuDevice *device_old)
 		const gchar *guid_tmp = g_ptr_array_index (guids_old, i);
 		if (!fu_device_has_guid (device_new, guid_tmp)) {
 			g_debug ("adding GUID %s to device", guid_tmp);
-			fu_device_add_guid (device_new, guid_tmp);
+			fu_device_add_counterpart_guid (device_new, guid_tmp);
 		}
 	}
 }

--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -1643,6 +1643,9 @@ fu_device_close (FuDevice *device, GError **error)
 		if (!klass->close (device, error))
 			return FALSE;
 	}
+
+	/* probe if we re-open */
+	priv->done_probe = FALSE;
 	return TRUE;
 }
 

--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -542,6 +542,10 @@ fu_device_set_quirk_kv (FuDevice *device,
 		fu_device_add_guid (device, value);
 		return TRUE;
 	}
+	if (g_strcmp0 (key, FU_QUIRKS_COUNTERPART_GUID) == 0) {
+		fu_device_add_counterpart_guid (device, value);
+		return TRUE;
+	}
 	if (g_strcmp0 (key, FU_QUIRKS_PARENT_GUID) == 0) {
 		fu_device_add_parent_guid (device, value);
 		return TRUE;
@@ -665,6 +669,35 @@ fu_device_add_guid (FuDevice *device, const gchar *guid)
 
 	/* already valid */
 	fu_device_add_guid_safe (device, guid);
+}
+
+/**
+ * fu_device_add_counterpart_guid:
+ * @device: A #FuDevice
+ * @guid: A GUID, e.g. `2082b5e0-7a64-478a-b1b2-e3404fab6dad`
+ *
+ * Adds a GUID to the device. If the @guid argument is not a valid GUID then it
+ * is converted to a GUID using as_utils_guid_from_string().
+ *
+ * A counterpart GUID is typically the GUID of the same device in bootloader
+ * or runtime mode, if they have a different device PCI or USB ID. Adding this
+ * type of GUID does not cause a "cascade" by matching using the quirk database.
+ *
+ * Since: 1.1.2
+ **/
+void
+fu_device_add_counterpart_guid (FuDevice *device, const gchar *guid)
+{
+	/* make valid */
+	if (!as_utils_guid_is_valid (guid)) {
+		g_autofree gchar *tmp = as_utils_guid_from_string (guid);
+		g_debug ("using %s for counterpart %s", tmp, guid);
+		fwupd_device_add_guid (FWUPD_DEVICE (device), tmp);
+		return;
+	}
+
+	/* already valid */
+	fwupd_device_add_guid (FWUPD_DEVICE (device), guid);
 }
 
 /**

--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -128,6 +128,8 @@ void		 fu_device_add_child			(FuDevice	*device,
 							 FuDevice	*child);
 void		 fu_device_add_parent_guid		(FuDevice	*device,
 							 const gchar	*guid);
+void		 fu_device_add_counterpart_guid		(FuDevice	*device,
+							 const gchar	*guid);
 const gchar	*fu_device_get_metadata			(FuDevice	*device,
 							 const gchar	*key);
 gboolean	 fu_device_get_metadata_boolean		(FuDevice	*device,

--- a/src/fu-quirks.h
+++ b/src/fu-quirks.h
@@ -131,6 +131,22 @@ gboolean	 fu_quirks_get_kvs_for_guid		(FuQuirks	*self,
 #define	FU_QUIRKS_GUID				"Guid"
 
 /**
+ * FU_QUIRKS_COUNTERPART_GUID:
+ * @key: the USB device ID, e.g. `DeviceInstanceId=USB\VID_0763&PID_2806`
+ * @value: the GUID, e.g. `537f7800-8529-5656-b2fa-b0901fe91696`
+ *
+ * Adds an counterpart GUID for a specific hardware device. If the value
+ * provided is not already a suitable GUID, it will be converted to one.
+ *
+ * A counterpart GUID is typically the GUID of the same device in bootloader
+ * or runtime mode, if they have a different device PCI or USB ID. Adding this
+ * type of GUID does not cause a "cascade" by matching using the quirk database.
+ *
+ * Since: 1.1.2
+ */
+#define	FU_QUIRKS_COUNTERPART_GUID		"CounterpartGuid"
+
+/**
  * FU_QUIRKS_PARENT_GUID:
  * @key: the USB device ID, e.g. `DeviceInstanceId=USB\VID_0763&PID_2806`
  * @value: the GUID, e.g. `537f7800-8529-5656-b2fa-b0901fe91696`


### PR DESCRIPTION
These are GUIDs that are related to the main device, but should not be used for
quirk matching. For instance, we might want to list the GUIDs for a bootloader
mode, but we don't want to import all the quirks for the bootloader when in the
runtime mode.