### PR TITLE
trivial: fu-device: Downgrade warnings about overwiting same name to …

### DIFF
--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -869,8 +869,8 @@ fu_device_set_name (FuDevice *device, const gchar *value)
 
 	/* overwriting? */
 	if (g_strcmp0 (value, fu_device_get_name (device)) == 0) {
-		g_warning ("device %s overwriting same name value: %s",
-			   fu_device_get_id (device), value);
+		g_debug ("device %s overwriting same name value: %s",
+			 fu_device_get_id (device), value);
 		return;
 	}
 


### PR DESCRIPTION
…debug

Commit 0f72ef2f887 causes probe to be re-run on FuDevices.
Any devices derived from FuUsbDevice that set the "Name" key will have the
quirks re-evaluated when GUIDs are added again leading to warnings like this:

```
(fwupdtool:8259): Fu-WARNING **: 23:04:43.144: device 970e85c8400ed95ec5c02b86e52a0ca4ce6fc051 overwriting same name value: Dell USB hub
```