### PR TITLE
plugins: Set platform IDs for non-USB/non-UDEV plugins

### DIFF
--- a/plugins/amt/fu-plugin-amt.c
+++ b/plugins/amt/fu-plugin-amt.c
@@ -416,7 +416,7 @@ fu_plugin_amt_create_device (GError **error)
 	memcpy (&ver, response->data, sizeof(struct amt_code_versions));
 
 	dev = fu_device_new ();
-	fu_device_set_id (dev, "/dev/mei");
+	fu_device_set_platform_id (dev, "/dev/mei0");
 	fu_device_set_vendor (dev, "Intel Corporation");
 	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_INTERNAL);
 	fu_device_add_icon (dev, "computer");

--- a/plugins/synapticsmst/fu-plugin-synapticsmst.c
+++ b/plugins/synapticsmst/fu-plugin-synapticsmst.c
@@ -152,6 +152,7 @@ fu_plugin_synaptics_add_device (FuPlugin *plugin,
 	dev_id_str = g_strdup_printf ("MST-%s-%s-%u-%u",
 				      kind_str, aux_node, layer, rad);
 	fu_device_set_id (dev, dev_id_str);
+	fu_device_set_platform_id (dev, aux_node);
 	fu_device_set_metadata (dev, "SynapticsMSTKind", kind_str);
 	fu_device_set_metadata (dev, "SynapticsMSTAuxNode", aux_node);
 	layer_str = g_strdup_printf ("%u", layer);

--- a/plugins/uefi/fu-uefi-device.c
+++ b/plugins/uefi/fu-uefi-device.c
@@ -419,7 +419,7 @@ fu_uefi_device_new_from_entry (const gchar *entry_path)
 	/* set ID */
 	id = g_strdup_printf ("UEFI-%s-dev%" G_GUINT64_FORMAT,
 			      self->fw_class, self->fmp_hardware_instance);
-	fu_device_set_id (FU_DEVICE (self), id);
+	fu_device_set_platform_id (FU_DEVICE (self), entry_path);
 
 	return self;
 }

--- a/src/fu-device-list.c
+++ b/src/fu-device-list.c
@@ -196,6 +196,8 @@ fu_device_list_find_by_guid (FuDeviceList *self, const gchar *guid)
 static FuDeviceItem *
 fu_device_list_find_by_platform_id (FuDeviceList *self, const gchar *platform_id)
 {
+	if (platform_id == NULL)
+		return NULL;
 	for (guint i = 0; i < self->devices->len; i++) {
 		FuDeviceItem *item_tmp = g_ptr_array_index (self->devices, i);
 		FuDevice *device = item_tmp->device;


### PR DESCRIPTION
Recent changes in the daemon have caused these devices to start matching
as existing devices based on platform ID comparisons.