### PR TITLE
Add a new device flag "force" that will always override validation

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -147,6 +147,8 @@ fwupd_device_flag_to_string (FwupdDeviceFlags device_flag)
 		return "is-bootloader";
 	if (device_flag == FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG)
 		return "wait-for-replug";
+	if (device_flag == FWUPD_DEVICE_FLAG_IGNORE_VALIDATION)
+		return "ignore-validation";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -199,6 +201,8 @@ fwupd_device_flag_from_string (const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_IS_BOOTLOADER;
 	if (g_strcmp0 (device_flag, "wait-for-replug") == 0)
 		return FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG;
+	if (g_strcmp0 (device_flag, "ignore-validation") == 0)
+		return FWUPD_DEVICE_FLAG_IGNORE_VALIDATION;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -79,6 +79,7 @@ typedef enum {
  * @FWUPD_DEVICE_FLAG_INSTALL_PARENT_FIRST:	Install composite firmware on the parent before the child
  * @FWUPD_DEVICE_FLAG_IS_BOOTLOADER:		Is currently in bootloader mode
  * @FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG:		The hardware is waiting to be replugged
+ * @FWUPD_DEVICE_FLAG_IGNORE_VALIDATION:	Ignore validation safety checks when flashing this device
  *
  * The device flags.
  **/
@@ -98,6 +99,7 @@ typedef enum {
 #define FWUPD_DEVICE_FLAG_INSTALL_PARENT_FIRST	(1u << 12)	/* Since: 1.0.8 */
 #define FWUPD_DEVICE_FLAG_IS_BOOTLOADER		(1u << 13)	/* Since: 1.0.8 */
 #define FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG	(1u << 14)	/* Since: 1.1.2 */
+#define FWUPD_DEVICE_FLAG_IGNORE_VALIDATION	(1u << 15)	/* Since: 1.1.2 */
 #define FWUPD_DEVICE_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 0.7.3 */
 typedef guint64 FwupdDeviceFlags;
 

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -815,7 +815,8 @@ fu_plugin_update (FuPlugin *plugin,
 	guint64 status;
 	g_autoptr(GUdevDevice) udevice = NULL;
 	g_autoptr(GError) error_local = NULL;
-	gboolean force = (flags & FWUPD_INSTALL_FLAG_FORCE) != 0;
+	gboolean install_force = (flags & FWUPD_INSTALL_FLAG_FORCE) != 0;
+	gboolean device_ignore_validation = fu_device_has_flag (dev, FWUPD_DEVICE_FLAG_IGNORE_VALIDATION);
 	FuPluginValidation validation;
 
 	devpath = fu_device_get_metadata (dev, "sysfs-path");
@@ -847,7 +848,7 @@ fu_plugin_update (FuPlugin *plugin,
 		default:
 			break;
 		}
-		if (!force) {
+		if (!install_force && !device_ignore_validation) {
 			g_set_error (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_INVALID_FILE,

--- a/src/fu-install-task.c
+++ b/src/fu-install-task.c
@@ -207,7 +207,9 @@ fu_install_task_check_requirements (FuInstallTask *self,
 
 	/* compare to the lowest supported version, if it exists */
 	version_lowest = fu_device_get_version_lowest (self->device);
-	if (version_lowest != NULL && as_utils_vercmp (version_lowest, version) > 0) {
+	if (version_lowest != NULL &&
+	    as_utils_vercmp (version_lowest, version) > 0 &&
+	    (flags & FWUPD_INSTALL_FLAG_FORCE) == 0) {
 		g_set_error (error,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_VERSION_NEWER,

--- a/src/fu-install-task.c
+++ b/src/fu-install-task.c
@@ -212,7 +212,7 @@ fu_install_task_check_requirements (FuInstallTask *self,
 			     FWUPD_ERROR,
 			     FWUPD_ERROR_VERSION_NEWER,
 			     "Specified firmware is older than the minimum "
-			     "required version '%s < %s'", version_lowest, version);
+			     "required version '%s < %s'", version, version_lowest);
 		return FALSE;
 	}
 


### PR DESCRIPTION
This flag isn't really intended for production, but more for development
to allow setting a quirk for a device during a transition period.

Setting the flag causes FwupdInstallFlags to contain
FWUPD_INSTALL_FLAGS_FORCE whether or not --force was passed on the tool
command line.

As an example use case earlier versions of a Thunderbolt module may contain DROM corresponding to one model ID and transition to another model ID.  Even if lying about the GUIDs supported by the device via a quirk the Thunderbolt validation will fail because the device isn't intended for that system.