### PR TITLE
trivial: move all Dell dock related quirks into dell.quirk

### DIFF
--- a/plugins/dell/dell.quirk
+++ b/plugins/dell/dell.quirk
@@ -2,6 +2,37 @@
 [DeviceInstanceId=USB\VID_0BDA&PID_8153]
 Plugin = dell
 
+# Dell TB16/TB18 cable
+[Guid=TBT-00d4b051]
+Plugin = thunderbolt
+ParentGuid = e7ca1f36-bf73-4574-afe6-a4ccacabf479
+
+# Dell TB16/TB18 dock
+[Guid=TBT-00d4b054]
+Plugin = thunderbolt
+ParentGuid = e7ca1f36-bf73-4574-afe6-a4ccacabf479
+
+# Dell WD15 dock
+[Guid=MST-wd15-vmm3332-274]
+Plugin = synapticsmst
+ParentGuid = e7ca1f36-bf73-4574-afe6-a4ccacabf479
+
+# Dell TB16 dock
+[Guid=MST-tb16-vmm3320-274]
+Plugin = synapticsmst
+ParentGuid = e7ca1f36-bf73-4574-afe6-a4ccacabf479
+[Guid=MST-tb16-vmm3330-274]
+Plugin = synapticsmst
+ParentGuid = e7ca1f36-bf73-4574-afe6-a4ccacabf479
+
+#Dell TB18 dock
+[Guid=MST-tb18-vmm3320-274]
+Plugin = synapticsmst
+ParentGuid = e7ca1f36-bf73-4574-afe6-a4ccacabf479
+[Guid=MST-tb18-vmm3330-274]
+Plugin = synapticsmst
+ParentGuid = e7ca1f36-bf73-4574-afe6-a4ccacabf479
+
 [SmbiosManufacturer=Dell Inc.]
 UefiVersionFormat = quad
 

--- a/plugins/synapticsmst/synapticsmst.quirk
+++ b/plugins/synapticsmst/synapticsmst.quirk
@@ -38,24 +38,3 @@ DeviceKind = wld15
 [SynapticsMSTBoardID=277]
 Name = Dell Rugged Platform
 DeviceKind = system
-
-# Dell WD15 dock
-[Guid=MST-wd15-vmm3332-274]
-Plugin = synapticsmst
-ParentGuid = e7ca1f36-bf73-4574-afe6-a4ccacabf479
-
-# Dell TB16 dock
-[Guid=MST-tb16-vmm3320-274]
-Plugin = synapticsmst
-ParentGuid = e7ca1f36-bf73-4574-afe6-a4ccacabf479
-[Guid=MST-tb16-vmm3330-274]
-Plugin = synapticsmst
-ParentGuid = e7ca1f36-bf73-4574-afe6-a4ccacabf479
-
-#Dell TB18 dock
-[Guid=MST-tb18-vmm3320-274]
-Plugin = synapticsmst
-ParentGuid = e7ca1f36-bf73-4574-afe6-a4ccacabf479
-[Guid=MST-tb18-vmm3330-274]
-Plugin = synapticsmst
-ParentGuid = e7ca1f36-bf73-4574-afe6-a4ccacabf479

--- a/plugins/thunderbolt/meson.build
+++ b/plugins/thunderbolt/meson.build
@@ -1,9 +1,5 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginThunderbolt"']
 
-install_data(['thunderbolt.quirk'],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
 fu_plugin_thunderbolt = shared_module('fu_plugin_thunderbolt',
   sources : [
     'fu-plugin-thunderbolt.c',

--- a/plugins/thunderbolt/thunderbolt.quirk
+++ b/plugins/thunderbolt/thunderbolt.quirk
@@ -1,9 +1,0 @@
-# Dell TB16/TB18 cable
-[Guid=TBT-00d4b051]
-Plugin = thunderbolt
-ParentGuid = e7ca1f36-bf73-4574-afe6-a4ccacabf479
-
-# Dell TB16/TB18 dock
-[Guid=TBT-00d4b054]
-Plugin = thunderbolt
-ParentGuid = e7ca1f36-bf73-4574-afe6-a4ccacabf479


### PR DESCRIPTION
These quirks aren't really needed if compiled without the Dell plugin
since they just set the parentage.