### PR TITLE
Include serial number in daemon device output when trusted

### DIFF
--- a/libfwupd/fwupd-device-private.h
+++ b/libfwupd/fwupd-device-private.h
@@ -15,6 +15,8 @@ G_BEGIN_DECLS
 
 FwupdDevice	*fwupd_device_from_variant		(GVariant	*data);
 GVariant	*fwupd_device_to_variant		(FwupdDevice	*device);
+GVariant	*fwupd_device_to_variant_full		(FwupdDevice	*device,
+							 FwupdDeviceFlags flags);
 void		 fwupd_device_incorporate		(FwupdDevice	*self,
 							 FwupdDevice	*donor);
 

--- a/libfwupd/fwupd-device.h
+++ b/libfwupd/fwupd-device.h
@@ -45,6 +45,9 @@ void		 fwupd_device_set_parent		(FwupdDevice	*device,
 const gchar	*fwupd_device_get_name			(FwupdDevice	*device);
 void		 fwupd_device_set_name			(FwupdDevice	*device,
 							 const gchar	*name);
+const gchar	*fwupd_device_get_serial		(FwupdDevice	*device);
+void		 fwupd_device_set_serial		(FwupdDevice	*device,
+							 const gchar	*serial);
 const gchar	*fwupd_device_get_summary		(FwupdDevice	*device);
 void		 fwupd_device_set_summary		(FwupdDevice	*device,
 							 const gchar	*summary);

--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -26,6 +26,7 @@
 #define FWUPD_RESULT_KEY_PLUGIN			"Plugin"	/* s */
 #define FWUPD_RESULT_KEY_RELEASE		"Release"	/* a{sv} */
 #define FWUPD_RESULT_KEY_REMOTE_ID		"RemoteId"	/* s */
+#define FWUPD_RESULT_KEY_SERIAL			"Serial"	/* s */
 #define FWUPD_RESULT_KEY_SIZE			"Size"		/* t */
 #define FWUPD_RESULT_KEY_SUMMARY		"Summary"	/* s */
 #define FWUPD_RESULT_KEY_TRUST_FLAGS		"TrustFlags"	/* t */

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -80,6 +80,7 @@ typedef enum {
  * @FWUPD_DEVICE_FLAG_IS_BOOTLOADER:		Is currently in bootloader mode
  * @FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG:		The hardware is waiting to be replugged
  * @FWUPD_DEVICE_FLAG_IGNORE_VALIDATION:	Ignore validation safety checks when flashing this device
+ * @FWUPD_DEVICE_FLAG_TRUSTED:			Extra metadata can be exposed about this device
  *
  * The device flags.
  **/
@@ -100,6 +101,7 @@ typedef enum {
 #define FWUPD_DEVICE_FLAG_IS_BOOTLOADER		(1u << 13)	/* Since: 1.0.8 */
 #define FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG	(1u << 14)	/* Since: 1.1.2 */
 #define FWUPD_DEVICE_FLAG_IGNORE_VALIDATION	(1u << 15)	/* Since: 1.1.2 */
+#define FWUPD_DEVICE_FLAG_TRUSTED		(1u << 16)	/* Since: 1.1.2 */
 #define FWUPD_DEVICE_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 0.7.3 */
 typedef guint64 FwupdDeviceFlags;
 

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -264,3 +264,11 @@ LIBFWUPD_1.1.1 {
     fwupd_device_compare;
   local: *;
 } LIBFWUPD_1.1.0;
+
+LIBFWUPD_1.1.2 {
+  global:
+    fwupd_device_get_serial;
+    fwupd_device_set_serial;
+    fwupd_device_to_variant_full;
+  local: *;
+} LIBFWUPD_1.1.1;

--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -1056,40 +1056,6 @@ fu_device_get_physical_id (FuDevice *self)
 	return fu_device_get_metadata (self, "physical-id");
 }
 
-/**
- * fu_device_set_serial:
- * @self: A #FuDevice
- * @serial: a serial number string, e.g. `0000123`
- *
- * Sets the serial number for the device.
- *
- * Since: 1.0.3
- **/
-void
-fu_device_set_serial (FuDevice *self, const gchar *serial)
-{
-	g_return_if_fail (FU_IS_DEVICE (self));
-	g_return_if_fail (serial != NULL);
-	fu_device_set_metadata (self, "serial", serial);
-}
-
-/**
- * fu_device_get_serial:
- * @self: A #FuDevice
- *
- * Gets the serial number for the device.
- *
- * Returns: a string value, or %NULL if never set.
- *
- * Since: 1.0.3
- **/
-const gchar *
-fu_device_get_serial (FuDevice *self)
-{
-	g_return_val_if_fail (FU_IS_DEVICE (self), NULL);
-	return fu_device_get_metadata (self, "serial");
-}
-
 static void
 fu_device_set_custom_flag (FuDevice *self, const gchar *hint)
 {

--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -85,6 +85,7 @@ FuDevice	*fu_device_new				(void);
 #define fu_device_has_guid(d,v)			fwupd_device_has_guid(FWUPD_DEVICE(d),v)
 #define fu_device_set_modified(d,v)		fwupd_device_set_modified(FWUPD_DEVICE(d),v)
 #define fu_device_set_plugin(d,v)		fwupd_device_set_plugin(FWUPD_DEVICE(d),v)
+#define fu_device_set_serial(d,v)		fwupd_device_set_serial(FWUPD_DEVICE(d),v)
 #define fu_device_set_summary(d,v)		fwupd_device_set_summary(FWUPD_DEVICE(d),v)
 #define fu_device_set_update_error(d,v)		fwupd_device_set_update_error(FWUPD_DEVICE(d),v)
 #define fu_device_set_update_state(d,v)		fwupd_device_set_update_state(FWUPD_DEVICE(d),v)
@@ -102,6 +103,7 @@ FuDevice	*fu_device_new				(void);
 #define fu_device_get_guid_default(d)		fwupd_device_get_guid_default(FWUPD_DEVICE(d))
 #define fu_device_get_icons(d)			fwupd_device_get_icons(FWUPD_DEVICE(d))
 #define fu_device_get_name(d)			fwupd_device_get_name(FWUPD_DEVICE(d))
+#define fu_device_get_serial(d)			fwupd_device_get_serial(FWUPD_DEVICE(d))
 #define fu_device_get_summary(d)		fwupd_device_get_summary(FWUPD_DEVICE(d))
 #define fu_device_get_id(d)			fwupd_device_get_id(FWUPD_DEVICE(d))
 #define fu_device_get_plugin(d)			fwupd_device_get_plugin(FWUPD_DEVICE(d))
@@ -157,9 +159,6 @@ void		 fu_device_set_physical_id		(FuDevice	*self,
 const gchar	*fu_device_get_logical_id		(FuDevice	*self);
 void		 fu_device_set_logical_id		(FuDevice	*self,
 							 const gchar	*logical_id);
-const gchar	*fu_device_get_serial			(FuDevice	*self);
-void		 fu_device_set_serial			(FuDevice	*self,
-							 const gchar	*serial);
 const gchar	*fu_device_get_custom_flags		(FuDevice	*self);
 gboolean	 fu_device_has_custom_flag		(FuDevice	*self,
 							 const gchar	*hint);


### PR DESCRIPTION
This moves the storing of the serial number into the daemon and
when the calling process is UID 0 includes it in device output