### PR TITLE
contrib: Add a standalone installer creation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 /*.dsc
 /*.xz
 /*.gz
+__pycache__

--- a/contrib/standalone-installer/README.md
+++ b/contrib/standalone-installer/README.md
@@ -1,0 +1,9 @@
+# Standalone installer
+
+This is a script that will build a standalone installer around the fwupd snap or flatpak.
+This can be used for distributing updates that use fwupd on machines without networking and the needed tools.
+
+For usage instructions, view:
+```
+./make.py --help
+```

--- a/contrib/standalone-installer/assets/header.py
+++ b/contrib/standalone-installer/assets/header.py
@@ -1,0 +1,203 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2017 Dell, Inc.
+#
+# SPDX-License-Identifier: LGPL-2.1+
+#
+from base64 import b64decode
+import io
+import os
+import subprocess
+import sys
+import shutil
+import tempfile
+import zipfile
+TAG = b'#\x00'
+
+def parse_args():
+    import argparse
+    parser = argparse.ArgumentParser(description="Self extracting firmware updater")
+    parser.add_argument("--directory", help="Directory to extract to")
+    parser.add_argument("--uninstall", action='store_true', help="Uninstall tools when done with installation")
+    parser.add_argument("--verbose", action='store_true', help="Run the tool in verbose mode")
+    parser.add_argument("command", choices=["install", "extract"], help="Command to run")
+    args = parser.parse_args()
+    return args
+
+def error (msg):
+    print(msg)
+    sys.exit(1)
+
+def bytes_slicer(length, source):
+    start = 0
+    stop = length
+    while start < len(source):
+        yield source[start:stop]
+        start = stop
+        stop += length
+
+def get_zip():
+    script = os.path.realpath (__file__)
+    bytes_out = io.BytesIO()
+    with open(script, 'rb') as source:
+        for line in source:
+            if not line.startswith(TAG):
+                continue
+            bytes_out.write(b64decode(line[len(TAG):-1]))
+    return bytes_out
+
+def unzip (destination):
+    zipf = get_zip ()
+    source = zipfile.ZipFile (zipf, 'r')
+    for item in source.namelist():
+        # extract handles the sanitization
+        source.extract (item, destination)
+
+def copy_cabs (source, target):
+    if not os.path.exists (target):
+        os.makedirs (target)
+    cabs = []
+    for root, dirs, files in os.walk (source):
+        for f in files:
+            if (f.endswith ('.cab')):
+                origf = os.path.join(root, f)
+                shutil.copy (origf, target)
+                cabs.append (os.path.join (target, f))
+    return cabs
+
+
+def install_snap (directory, verbose, uninstall):
+    app = 'fwupd'
+    common = '/root/snap/%s/common' % app
+
+    #check if snap is installed
+    with open(os.devnull, 'w') as devnull:
+        subprocess.run (['snap'], check=True, stdout=devnull, stderr=devnull)
+
+    #check existing installed
+    cmd = ['snap', 'list', app]
+    with open(os.devnull, 'w') as devnull:
+        if verbose:
+            print(cmd)
+        ret = subprocess.run (cmd, stdout=devnull, stderr=devnull)
+        if ret.returncode == 0:
+            cmd = ['snap', 'remove', app]
+            if verbose:
+                print(cmd)
+            subprocess.run (cmd, check=True)
+
+    # install the snap
+    cmd = ['snap', 'ack', os.path.join (directory, 'fwupd.assert')]
+    if verbose:
+        print(cmd)
+    subprocess.run (cmd, check=True)
+    cmd = ['snap', 'install', '--classic', os.path.join (directory, 'fwupd.snap')]
+    if verbose:
+        print(cmd)
+    subprocess.run (cmd, check=True)
+
+    # copy the CAB files
+    cabs = copy_cabs (directory, common)
+
+    # run the snap
+    for cab in cabs:
+        cmd = ["%s.fwupdmgr" % app, 'install', cab]
+        if verbose:
+            cmd += ["--verbose"]
+            print(cmd)
+        subprocess.run (cmd)
+
+    #remove copied cabs
+    for f in cabs:
+        os.remove(f)
+
+    #cleanup
+    if uninstall:
+        cmd = ['snap', 'remove', app]
+        if verbose:
+            print(cmd)
+        subprocess.run (cmd)
+
+def install_flatpak (directory, verbose, uninstall):
+    app = 'org.freedesktop.fwupd'
+    common = '%s/.var/app/%s' % (os.getenv ('HOME'), app)
+
+    #check existing installed
+    cmd = ['flatpak', 'info', app]
+    with open(os.devnull, 'w') as devnull:
+        if verbose:
+            print(cmd)
+        ret = subprocess.run (cmd, stdout=devnull, stderr=devnull)
+        if ret.returncode == 0:
+            cmd = ['flatpak', 'remove', app]
+            if verbose:
+                print(cmd)
+            subprocess.run (cmd, check=True)
+
+    #install the flatpak
+    cmd = ['flatpak', 'install', os.path.join (directory, 'fwupd.flatpak')]
+    if verbose:
+        print(cmd)
+    subprocess.run (cmd, check=True)
+
+    # copy the CAB files
+    cabs = copy_cabs (directory, common)
+
+    #run command
+    for cab in cabs:
+        cmd = ['flatpak', 'run', app, 'install', cab]
+        if verbose:
+            cmd += ["--verbose"]
+            print(cmd)
+        subprocess.run (cmd)
+
+    #remove copied cabs
+    for f in cabs:
+        os.remove(f)
+
+    #cleanup
+    if uninstall:
+        cmd = ['flatpak', 'remove', app]
+        if verbose:
+            print(cmd)
+        subprocess.run (cmd)
+
+
+def run_installation (directory, verbose, uninstall):
+    try_snap = False
+    try_flatpak = False
+
+    # determine what self extracting binary has
+    if os.path.exists (os.path.join (directory, 'fwupd.snap')) and \
+        os.path.exists (os.path.join (directory, 'fwupd.assert')):
+        try_snap = True
+    if os.path.exists (os.path.join (directory, 'fwupd.flatpak')):
+        try_flatpak = True
+
+    if try_snap:
+        try:
+            install_snap (directory, verbose, uninstall)
+            return True
+        except:
+            if verbose:
+                print ("Snap installation failed")
+            if not try_flatpak:
+                error ("Snap installation failed")
+    if try_flatpak:
+        install_flatpak (directory, verbose, uninstall)
+
+if __name__ == '__main__':
+    args = parse_args()
+    if 'extract' in args.command:
+        if args.directory is None:
+            error ("No directory specified")
+        if not os.path.exists (args.directory):
+            print ("Creating %s" % args.directory)
+            os.makedirs (args.directory)
+        unzip (args.directory)
+    elif 'install' in args.command:
+        if os.getuid() != 0:
+            error ("This tool must be run as root")
+        with tempfile.TemporaryDirectory (prefix='fwupd') as target:
+            unzip (target)
+            run_installation (target, args.verbose, args.uninstall)

--- a/contrib/standalone-installer/make.py
+++ b/contrib/standalone-installer/make.py
@@ -1,0 +1,118 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2017 Dell, Inc.
+#
+# SPDX-License-Identifier: LGPL-2.1+
+#
+from base64 import b64encode
+import io
+import os
+import subprocess
+import shutil
+import sys
+import tempfile
+import zipfile
+from assets.header import TAG
+
+def error (msg):
+    print(msg)
+    sys.exit(1)
+
+def parse_args():
+    import argparse
+    parser = argparse.ArgumentParser(description="Generate a standalone firmware updater")
+    parser.add_argument("--disable-snap-download", action='store_true', help="Don't download support for snap")
+    parser.add_argument("--disable-flatpak-download", action='store_true', help="Don't download support for flatpak")
+    parser.add_argument("--snap-channel", help="Channel to download snap from (optional)")
+    parser.add_argument("cab", help="CAB file or directory containing CAB files to automatically install")
+    parser.add_argument('target', help='target file to create')
+    args = parser.parse_args()
+    return args
+
+def bytes_slicer(length, source):
+    start = 0
+    stop = length
+    while start < len(source):
+        yield source[start:stop]
+        start = stop
+        stop += length
+
+def generate_installer (directory, target):
+    asset_base = os.path.join (os.path.dirname(os.path.realpath(__file__)),
+                               "assets")
+
+    #header
+    shutil.copy (os.path.join (asset_base, "header.py"), target)
+
+    #zip file
+    buffer = io.BytesIO()
+    archive = zipfile.ZipFile(buffer, "a")
+    for root, dirs, files in os.walk (directory):
+        for f in files:
+            source = os.path.join(root, f)
+            archive_fname = source.split (directory) [1]
+            archive.write(source, archive_fname)
+    if 'DEBUG' in os.environ:
+        print (archive.namelist())
+    archive.close()
+
+    with open (target, 'ab') as bytes_out:
+        encoded = b64encode(buffer.getvalue())
+        for section in bytes_slicer(64, encoded):
+            bytes_out.write(TAG)
+            bytes_out.write(section)
+            bytes_out.write(b'\n')
+
+def download_snap (directory, channel):
+    cmd = ['snap', 'download', 'fwupd']
+    if channel is not None:
+        cmd += ['--channel', channel]
+    if 'DEBUG' in os.environ:
+        print(cmd)
+    subprocess.run (cmd, cwd=directory, check=True)
+    for f in os.listdir (directory):
+        # the signatures associated with the snap
+        if f.endswith(".assert"):
+            shutil.move (os.path.join(directory, f), os.path.join(directory, 'fwupd.assert'))
+        # the snap binary itself
+        elif f.endswith(".snap"):
+            shutil.move (os.path.join(directory, f), os.path.join(directory, 'fwupd.snap'))
+
+def download_cab_file (directory, uri):
+    cmd = ['wget', uri]
+    if 'DEBUG' in os.environ:
+        print(cmd)
+    subprocess.run (cmd, cwd=directory, check=True)
+
+def download_flatpak (directory):
+    cmd = ['wget', 'https://people.freedesktop.org/~hughsient/temp/fwupd.flatpak', '-O', 'fwupd.flatpak']
+    if 'DEBUG' in os.environ:
+        print(cmd)
+    subprocess.run (cmd, cwd=directory, check=True)
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    if not args.cab.startswith("http"):
+        local = args.cab
+
+    with tempfile.TemporaryDirectory (prefix='fwupd') as directory:
+        if local:
+            if not os.path.exists (local):
+                error ("%s doesn't exist" % local)
+            if not os.path.isdir(local):
+                shutil.copy (local, directory)
+            else:
+                for root, dirs, files in os.walk(local):
+                    for f in files:
+                        shutil.copy (os.path.join(root, f), directory)
+        else:
+            download_cab_file (directory, args.cab)
+
+        if not args.disable_snap_download:
+            download_snap (directory, args.snap_channel)
+
+        if not args.disable_flatpak_download:
+            download_flatpak (directory)
+
+        generate_installer (directory, args.target)


### PR DESCRIPTION
This is meant to produce standalone installer binaries that can operate
on machines without current tools or internet access.

It works by wrapping around the container technologies snap and flatpak
and putting all the pieces together.