### PR TITLE
trivial: nvme: Remove quirk for Hynix SSD

### DIFF
--- a/plugins/nvme/meson.build
+++ b/plugins/nvme/meson.build
@@ -1,11 +1,5 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginNvme"']
 
-install_data([
-  'nvme.quirk',
-  ],
-  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
-)
-
 shared_module('fu_plugin_nvme',
   sources : [
     'fu-plugin-nvme.c',

--- a/plugins/nvme/nvme.quirk
+++ b/plugins/nvme/nvme.quirk
@@ -1,3 +1,0 @@
-# SK hynix
-[DeviceInstanceId=NVME\VEN_1C5C]
-NvmeVersionFormat = quad


### PR DESCRIPTION
I've seen a firmware image that the version was "80001C0T" for this
disk and as such this is not a "quad" version number.