### PR TITLE
trivial: Do not use AsProfile

### DIFF
--- a/plugins/udev/fu-plugin-udev.c
+++ b/plugins/udev/fu-plugin-udev.c
@@ -71,8 +71,6 @@ fu_plugin_udev_device_added (FuPlugin *plugin, FuUdevDevice *device, GError **er
 	GUdevDevice *udev_device = fu_udev_device_get_dev (FU_UDEV_DEVICE (device));
 	const gchar *guid = NULL;
 	g_autofree gchar *rom_fn = NULL;
-	g_autoptr(AsProfile) profile = as_profile_new ();
-	g_autoptr(AsProfileTask) ptask = NULL;
 
 	/* interesting device? */
 	if (g_strcmp0 (fu_udev_device_get_subsystem (device), "pci") != 0)
@@ -80,10 +78,6 @@ fu_plugin_udev_device_added (FuPlugin *plugin, FuUdevDevice *device, GError **er
 	guid = g_udev_device_get_property (udev_device, "FWUPD_GUID");
 	if (guid == NULL)
 		return TRUE;
-
-	/* get data */
-	ptask = as_profile_start (profile, "FuPluginUdev:client-add{%s}", guid);
-	g_assert (ptask != NULL);
 
 	/* set the physical ID */
 	if (!fu_udev_device_set_physical_id (device, "pci", error))

--- a/plugins/udev/fu-rom.c
+++ b/plugins/udev/fu-rom.c
@@ -715,14 +715,10 @@ fu_rom_load_file (FuRom *self, GFile *file, FuRomLoadFlags flags,
 	g_autofree gchar *fn = NULL;
 	g_autofree guint8 *buffer = NULL;
 	g_autoptr(GFileOutputStream) output_stream = NULL;
-	g_autoptr(AsProfile) profile = as_profile_new ();
-	g_autoptr(AsProfileTask) ptask = NULL;
 
 	g_return_val_if_fail (FU_IS_ROM (self), FALSE);
 
 	/* open file */
-	ptask = as_profile_start_literal (profile, "FuRom:reading-data");
-	g_assert (ptask != NULL);
 	self->stream = G_INPUT_STREAM (g_file_read (file, cancellable, &error_local));
 	if (self->stream == NULL) {
 		g_set_error_literal (error,

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -30,7 +30,6 @@ gboolean	 fu_engine_load				(FuEngine	*self,
 gboolean	 fu_engine_load_plugins			(FuEngine	*self,
 							 GError		**error);
 FwupdStatus	 fu_engine_get_status			(FuEngine	*self);
-void		 fu_engine_profile_dump			(FuEngine	*self);
 AsStore		*fu_engine_get_store_from_blob		(FuEngine	*self,
 							 GBytes		*blob_cab,
 							 GError		**error);

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -1093,10 +1093,6 @@ fu_main_on_bus_acquired_cb (GDBusConnection *connection,
 		g_warning ("cannot connect to DBus: %s", error->message);
 		return;
 	}
-
-	/* dump startup profile data */
-	if (g_getenv ("FWUPD_VERBOSE") != NULL)
-		fu_engine_profile_dump (priv->engine);
 }
 
 static void

--- a/src/fu-usb-device.c
+++ b/src/fu-usb-device.c
@@ -111,8 +111,6 @@ fu_usb_device_open (FuDevice *device, GError **error)
 	FuUsbDevicePrivate *priv = GET_PRIVATE (self);
 	FuUsbDeviceClass *klass = FU_USB_DEVICE_GET_CLASS (device);
 	guint idx;
-	g_autoptr(AsProfile) profile = as_profile_new ();
-	g_autoptr(AsProfileTask) ptask = NULL;
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
 	g_return_val_if_fail (FU_IS_USB_DEVICE (self), FALSE);
@@ -121,12 +119,6 @@ fu_usb_device_open (FuDevice *device, GError **error)
 	/* already open */
 	if (priv->usb_device_locker != NULL)
 		return TRUE;
-
-	/* profile */
-	ptask = as_profile_start (profile, "added{%04x:%04x}",
-				  g_usb_device_get_vid (priv->usb_device),
-				  g_usb_device_get_pid (priv->usb_device));
-	g_assert (ptask != NULL);
 
 	/* open */
 	locker = fu_device_locker_new (priv->usb_device, error);


### PR DESCRIPTION
The profiling data is of limited use, and better data can be obtained using
kcachegrind and massif. Additionally, the profile samples were the cause of the
small RSS growth over time, when in reality the data would only be shown when
the verbose switch is used at daemon startup.