### PR TITLE
Composite device replug support

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1421,6 +1421,22 @@ fu_engine_install_blob (FuEngine *self,
 	/* save the chosen device ID in case the device goes away */
 	device_id_orig = g_strdup (fu_device_get_id (device));
 
+	/* in case another device caused us to go into replug before starting */
+	device = fu_device_list_get_by_id (self->device_list, device_id_orig, error);
+	if (device == NULL) {
+		g_prefix_error (error, "failed to get device ID after detach: ");
+		return FALSE;
+	}
+	if (!fu_device_list_wait_for_replug (self->device_list, device, error)) {
+		g_prefix_error (error, "failed to wait for detach replug: ");
+		return FALSE;
+	}
+	device = fu_device_list_get_by_id (self->device_list, device_id_orig, error);
+	if (device == NULL) {
+		g_prefix_error (error, "failed to get device ID after detach replug: ");
+		return FALSE;
+	}
+
 	/* mark this as modified even if we actually fail to do the update */
 	fu_device_set_modified (device, (guint64) g_get_real_time () / G_USEC_PER_SEC);
 


### PR DESCRIPTION
This sets up handling for replug on composite devices.  If one device causes another to go into replug, the plugin can indicate this in `composite_prepare`  and then the daemon will do the right thing to find the device before calling update on it.

Regarding tests, I'm aware that this is fragile and I would like some advice which aspect should actually have the tests because it almost feels like the whole flow needs to be modeled in a test meaning a test that produces a few devices like this, instantiates a plugin, sets up relationships and then calls out to the daemon to do install tasks from a CAB with a few things in it.  It's sorta a big test then..