### PR TITLE
Add support for devices to show an estimated flash time (Closes: #765)

### DIFF
--- a/libfwupd/fwupd-device.h
+++ b/libfwupd/fwupd-device.h
@@ -66,6 +66,9 @@ void		 fwupd_device_set_version_bootloader	(FwupdDevice	*device,
 guint32		 fwupd_device_get_flashes_left		(FwupdDevice	*device);
 void		 fwupd_device_set_flashes_left		(FwupdDevice	*device,
 							 guint32	flashes_left);
+guint32		 fwupd_device_get_install_duration	(FwupdDevice	*device);
+void		 fwupd_device_set_install_duration	(FwupdDevice	*device,
+							 guint32	 duration);
 guint64		 fwupd_device_get_flags			(FwupdDevice	*device);
 void		 fwupd_device_set_flags			(FwupdDevice	*device,
 							 guint64	 flags);

--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -16,6 +16,7 @@
 #define FWUPD_RESULT_KEY_FILENAME		"Filename"	/* s */
 #define FWUPD_RESULT_KEY_FLAGS			"Flags"		/* t */
 #define FWUPD_RESULT_KEY_FLASHES_LEFT		"FlashesLeft"	/* u */
+#define FWUPD_RESULT_KEY_INSTALL_DURATION	"InstallDuration"	/* u */
 #define FWUPD_RESULT_KEY_GUID			"Guid"		/* as */
 #define FWUPD_RESULT_KEY_HOMEPAGE		"Homepage"	/* s */
 #define FWUPD_RESULT_KEY_ICON			"Icon"		/* as */

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -272,3 +272,10 @@ LIBFWUPD_1.1.2 {
     fwupd_device_to_variant_full;
   local: *;
 } LIBFWUPD_1.1.1;
+
+LIBFWUPD_1.1.3 {
+  global:
+    fwupd_device_get_install_duration;
+    fwupd_device_set_install_duration;
+  local: *;
+} LIBFWUPD_1.1.2;

--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -670,6 +670,10 @@ fu_device_set_quirk_kv (FuDevice *self,
 		fu_device_set_firmware_size_max (self, fu_common_strtoull (value));
 		return TRUE;
 	}
+	if (g_strcmp0 (key, FU_QUIRKS_INSTALL_DURATION) == 0) {
+		fu_device_set_install_duration (self, fu_common_strtoull (value));
+		return TRUE;
+	}
 	if (g_strcmp0 (key, FU_QUIRKS_CHILDREN) == 0) {
 		g_auto(GStrv) sections = g_strsplit (value, ",", -1);
 		for (guint i = 0; sections[i] != NULL; i++) {

--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -97,6 +97,7 @@ FuDevice	*fu_device_new				(void);
 #define fu_device_set_version_lowest(d,v)	fwupd_device_set_version_lowest(FWUPD_DEVICE(d),v)
 #define fu_device_set_version_bootloader(d,v)	fwupd_device_set_version_bootloader(FWUPD_DEVICE(d),v)
 #define fu_device_set_flashes_left(d,v)		fwupd_device_set_flashes_left(FWUPD_DEVICE(d),v)
+#define fu_device_set_install_duration(d,v)	fwupd_device_set_install_duration(FWUPD_DEVICE(d),v)
 #define fu_device_get_checksums(d)		fwupd_device_get_checksums(FWUPD_DEVICE(d))
 #define fu_device_get_flags(d)			fwupd_device_get_flags(FWUPD_DEVICE(d))
 #define fu_device_get_created(d)		fwupd_device_get_created(FWUPD_DEVICE(d))
@@ -117,6 +118,7 @@ FuDevice	*fu_device_new				(void);
 #define fu_device_get_version_bootloader(d)	fwupd_device_get_version_bootloader(FWUPD_DEVICE(d))
 #define fu_device_get_vendor_id(d)		fwupd_device_get_vendor_id(FWUPD_DEVICE(d))
 #define fu_device_get_flashes_left(d)		fwupd_device_get_flashes_left(FWUPD_DEVICE(d))
+#define fu_device_get_install_duration(d)	fwupd_device_get_install_duration(FWUPD_DEVICE(d))
 
 /* accessors */
 gchar		*fu_device_to_string			(FuDevice	*self);

--- a/src/fu-quirks.h
+++ b/src/fu-quirks.h
@@ -231,6 +231,17 @@ gboolean	 fu_quirks_get_kvs_for_guid		(FuQuirks	*self,
  */
 #define	FU_QUIRKS_FIRMWARE_SIZE_MAX		"FirmwareSizeMax"
 
+/**
+ * FU_QUIRKS_INSTALL_DURATION:
+ * @key: the USB device ID, e.g. `DeviceInstanceId=USB\VID_0763&PID_2806`
+ * @value: the estimated time for flashing the device in seconds
+ *
+ * Sets the estimated time to flash the device
+ *
+ * Since: 1.1.3
+ */
+#define	FU_QUIRKS_INSTALL_DURATION		"InstallDuration"
+
 G_END_DECLS
 
 #endif /* __FU_QUIRKS_H */


### PR DESCRIPTION
This time is provided to frontends to be able to show estimates
before a user would agree to flash the device.