### PR TITLE
trivial: Update FU_DEVICE_REMOVE_DELAY_USER_REPLUG from 20s to 40s (Fixes: #758)

### DIFF
--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -70,7 +70,7 @@ struct _FuDeviceClass
  * being slow and clumsy. This should be used when the user has to do something,
  * e.g. unplug, press a magic button and then replug.
  */
-#define FU_DEVICE_REMOVE_DELAY_USER_REPLUG		20000
+#define FU_DEVICE_REMOVE_DELAY_USER_REPLUG		40000
 
 FuDevice	*fu_device_new				(void);
 


### PR DESCRIPTION
Sometimes it's difficult to get 8bitdo controllers to turn off, so
give users more time to do it.