### PR TITLE
trivial: fu-engine: downgrade couldn't find new device message to debug

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1219,8 +1219,8 @@ fu_engine_install_tasks (FuEngine *self,
 						       fu_device_get_id (device),
 						       &error_local);
 		if (device_new == NULL) {
-			g_warning ("failed to find new device: %s",
-				   error_local->message);
+			g_debug ("failed to find new device: %s",
+				 error_local->message);
 			continue;
 		}
 		g_ptr_array_add (devices_new, g_steal_pointer (&device_new));


### PR DESCRIPTION
I've found that this message comes up sometimes due to reprobing order
and it shouldn't be considered important enough to generate a warning.