### PR TITLE
contrib: Add information on how to use debugging scripts

### DIFF
--- a/contrib/vscode/README.md
+++ b/contrib/vscode/README.md
@@ -1,0 +1,39 @@
+# Using Visual Studio Code to debug
+
+This directory contains a collection of scripts and assets to make debugging using Visual Studio Code easier.
+
+## Preparing
+First install the following applications locally:
+* GDB Server
+* GDB
+* Visual Studio Code
+
+In Visual Studio code, visit the extension store and install *C/C++* which is an extension provided by Microsoft.
+Configure Visual Studio code to open the folder representing the root of the fwupd checkout.
+
+## Building
+Run `./contrib/debugging/build.sh` to build fwupd with all default options and create helper scripts pre-configured for debugger use.
+The application will be placed into `./dist` and helper scripts will be created for `fwupdtool`, `fwupdmgr`, and `fwupd`.
+
+## Running
+To run any of the applications, execute the appropriate helper script in `./dist`.
+
+## Debugging
+To debug any of the applications, launch the helper script with the environment variable `DEBUG` set.
+For example to debug `fwupdtool get-devices` the command to launch would be:
+
+```
+sudo DEBUG=1 ./dist/fwupdtool.sh get-devices
+```
+
+This will configure `gdbserver` to listen on a local port waiting for a debugger to connect.
+
+## Using Visual Studio code
+During build time a set of launch targets will have been created for use with Visual Studio Code.
+
+Press the debugging button on the left and 3 targets will be listed at the top.
+* gdbserver (fwupdtool)
+* gdbserver (fwupd)
+* gdbserver (fwupdmgr)
+
+Select the appropriate target and press the green arrow to connect to `gdbserver` and start debugging.

--- a/contrib/vscode/build.sh
+++ b/contrib/vscode/build.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Copyright (C) 2018 Dell, Inc.
+
+SOURCE=$(dirname $0)
+ROOT=$1
+if [ -z "$ROOT" ]; then
+        ROOT=`pwd`
+fi
+
+# build in tree
+rm -rf build ${ROOT}/dist
+meson build --prefix=${ROOT}/dist -Dsystemd=false -Dudevdir=${ROOT}/dist
+ninja -C build install
+
+#create helper scripts
+TEMPLATE=${SOURCE}/launcher.sh
+sed "s,#ROOT#,${ROOT},; s,#EXECUTABLE#,libexec/fwupd/fwupd," \
+        ${TEMPLATE} > ${ROOT}/dist/fwupd.sh
+sed "s,#ROOT#,${ROOT},; s,#EXECUTABLE#,libexec/fwupd/fwupdtool," \
+        ${TEMPLATE} > ${ROOT}/dist/fwupdtool.sh
+sed "s,#ROOT#,${ROOT},; s,#EXECUTABLE#,bin/fwupdmgr," \
+        ${TEMPLATE} > ${ROOT}/dist/fwupdmgr.sh
+chmod +x ${ROOT}/dist/*.sh
+
+#create debugging targets
+TARGET=${ROOT}/.vscode
+mkdir -p ${TARGET}
+if [ -f ${TARGET}/launch.json ]; then
+        echo "${TARGET}/launch.json already exists, not overwriting"
+else
+        cp ${SOURCE}/launch.json ${TARGET}
+fi

--- a/contrib/vscode/launch.json
+++ b/contrib/vscode/launch.json
@@ -1,0 +1,68 @@
+{
+        // Use IntelliSense to learn about possible attributes.
+        // Hover to view descriptions of existing attributes.
+        // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+        "version": "0.2.0",
+        "configurations": [
+                {
+                        "name": "gdbserver (fwupdtool)",
+                        "type": "cppdbg",
+                        "request": "launch",
+                        "program": "${workspaceFolder}/dist/libexec/fwupd/fwupdtool",
+                        "args": [],
+                        "stopAtEntry": false,
+                        "cwd": "${workspaceFolder}",
+                        "environment": [],
+                        "miDebuggerServerAddress": "localhost:9091",
+                        "externalConsole": false,
+                        "MIMode": "gdb",
+                        "setupCommands": [
+                            {
+                                "description": "Enable pretty-printing for gdb",
+                                "text": "-enable-pretty-printing",
+                                "ignoreFailures": true
+                            }
+                        ]
+                },
+                {
+                        "name": "gdbserver (fwupd)",
+                        "type": "cppdbg",
+                        "request": "launch",
+                        "program": "${workspaceFolder}/dist/libexec/fwupd/fwupd",
+                        "args": [],
+                        "stopAtEntry": false,
+                        "cwd": "${workspaceFolder}",
+                        "environment": [],
+                        "miDebuggerServerAddress": "localhost:9091",
+                        "externalConsole": false,
+                        "MIMode": "gdb",
+                        "setupCommands": [
+                            {
+                                "description": "Enable pretty-printing for gdb",
+                                "text": "-enable-pretty-printing",
+                                "ignoreFailures": true
+                            }
+                        ]
+                },
+                {
+                        "name": "gdbserver (fwupdmgr)",
+                        "type": "cppdbg",
+                        "request": "launch",
+                        "program": "${workspaceFolder}/dist/bin/fwupdmgr",
+                        "args": [],
+                        "stopAtEntry": false,
+                        "cwd": "${workspaceFolder}",
+                        "environment": [],
+                        "miDebuggerServerAddress": "localhost:9091",
+                        "externalConsole": false,
+                        "MIMode": "gdb",
+                        "setupCommands": [
+                            {
+                                "description": "Enable pretty-printing for gdb",
+                                "text": "-enable-pretty-printing",
+                                "ignoreFailures": true
+                            }
+                        ]
+                },
+        ]
+}

--- a/contrib/vscode/launcher.sh
+++ b/contrib/vscode/launcher.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+export ROOT=#ROOT#
+export FWUPD_LOCALSTATEDIR=${ROOT}/dist
+export FWUPD_SYSCONFDIR=${ROOT}/dist/etc
+if [ -n "${DEBUG}" ]; then
+        DEBUG="gdbserver localhost:9091"
+fi
+${DEBUG} ${ROOT}/dist/#EXECUTABLE# "$@"


### PR DESCRIPTION
At least for me it was a challenge to get the debugger properly
configured to allow debugging fwupd when built in tree.

This should allow very simple debugging.