### PR TITLE
meson: Bump dependency to 0.44 and adjust sysconfdir handling

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -38,7 +38,7 @@ if get_option('systemd')
 
   rw_directories = []
   rw_directories += join_paths (localstatedir, 'lib', 'fwupd')
-  rw_directories += join_paths (default_sysconfdir, 'fwupd', 'remotes.d')
+  rw_directories += join_paths (sysconfdir, 'fwupd', 'remotes.d')
   if get_option('plugin_uefi')
     rw_directories += ['-/boot/efi', '-/efi/EFI', '-/boot/EFI']
   endif

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('fwupd', 'c',
   version : '1.2.0',
   license : 'LGPL-2.1+',
-  meson_version : '>=0.43.0',
+  meson_version : '>=0.44.0',
   default_options : ['warning_level=2', 'c_std=c99'],
 )
 
@@ -309,12 +309,6 @@ configure_file(
   output : 'config.h',
   configuration : conf
 )
-
-default_sysconfdir = get_option('sysconfdir')
-if default_sysconfdir == 'etc'
-  message('sysconfdir of etc makes no sense, using /etc')
-  default_sysconfdir = '/etc'
-endif
 
 plugin_deps = []
 plugin_deps += appstream_glib


### PR DESCRIPTION
Some code was put in place to workaround sysconfdir behavior of meson
0.43 and less.  This is no longer needed.