### PR TITLE
dell-dock: Dynamically find MST version offset (Fixes #804)

### DIFF
--- a/plugins/dell-dock/dell-dock.quirk
+++ b/plugins/dell-dock/dell-dock.quirk
@@ -100,9 +100,6 @@ FirmwareSizeMax=524288
 DellDockUnlockTarget = 9
 InstallDuration = 95
 DellDockInstallDurationI2C=360
-DellDockBlobMajorOffset = 0x06F0
-DellDockBlobMinorOffset = 0x06F1
-DellDockBlobBuildOffset = 0x06F2
 
 # Thunderbolt controller
 [Guid=TBT-00d4b070]


### PR DESCRIPTION
Panamera firmware 05.03.05 and less always had it as 0x06F0
Panamera firmware 05.03.06 moved it to 0x06F5.

Looking through the payload I notice that the same header is
found before firmware version each time.

hex:
 24 53 59 4e 41 53 30 10
asci:
 $SYNAS0

Use that as an anchor to find the firmware version offset.

@ryanchang0624 would appreciate your comments if this is a workable approach.  If not please advise if there is something better?