### PR TITLE
Add missing unlock call for MST via dell_dock plugin

### DIFF
--- a/plugins/dell-dock/dell-dock.quirk
+++ b/plugins/dell-dock/dell-dock.quirk
@@ -100,9 +100,9 @@ FirmwareSizeMax=524288
 DellDockUnlockTarget = 9
 InstallDuration = 95
 DellDockInstallDurationI2C=360
-DellDockBlobMajorOffset = 0x06F0
-DellDockBlobMinorOffset = 0x06F1
-DellDockBlobBuildOffset = 0x06F2
+DellDockBlobMajorOffset = 0x18400
+DellDockBlobMinorOffset = 0x18401
+DellDockBlobBuildOffset = 0x18402
 
 # Thunderbolt controller
 [Guid=TBT-00d4b070]

--- a/plugins/dell-dock/fu-dell-dock-i2c-mst.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-mst.c
@@ -787,6 +787,10 @@ fu_dell_dock_mst_write_fw (FuDevice *device,
 		self->relock_id = 0;
 	}
 
+	/* power up controller in case it's asleep */
+	if (!fu_dell_dock_set_power (device, self->unlock_target, TRUE, error))
+		return FALSE;
+
 	dynamic_version = g_strdup_printf ("%02x.%02x.%02x",
 					   data[self->blob_major_offset],
 					   data[self->blob_minor_offset],


### PR DESCRIPTION
When updating over I2C instead of DP aux one of the calls for unlock isn't happening anymore, fix that.