### PR TITLE
trivial: snap: Use libxmlb subproject instead

### DIFF
--- a/contrib/snap/snapcraft-master.yaml
+++ b/contrib/snap/snapcraft-master.yaml
@@ -80,38 +80,6 @@ parts:
       - -lib
       - -share
       - -usr
-  libxmlb-dev:
-    plugin: meson
-    meson-parameters: [--prefix=/usr, -Dgtk-doc=false, -Dintrospection=false]
-    source: https://github.com/hughsie/libxmlb
-    source-type: git
-    build-packages:
-      - python3-pip
-      - libgirepository1.0-dev
-      - libglib2.0-dev
-      - libgtk-3-dev
-      - libjson-glib-dev
-      - uuid-dev
-    prime:
-      - -usr/bin
-      - -usr/include
-      - -usr/share/doc
-      - -usr/share/bash-completion
-      - -usr/share/aclocal
-      - -usr/lib/*/pkgconfig
-      - -usr/share/installed-tests
-      - -usr/lib/systemd
-      - -usr/lib/glib-networking
-      - -usr/lib/dconf
-      - -usr/share/X11
-      - -usr/share/GConf
-      - -usr/share/dbus-1
-      - -usr/share/glib-2.0/schemas
-      - -usr/share/lintian
-      - -usr/share/man
-      - -usr/lib/*/gdk-pixbuf-2.0
-      - -usr/share/gettext
-    after: [meson]
   gudev:
     plugin: autotools
     source: https://gitlab.gnome.org/GNOME/libgudev.git
@@ -222,6 +190,8 @@ parts:
                        -Dintrospection=false,
                        -Dman=false,
                        -Dudevdir=$SNAPCRAFT_STAGE/lib/udev,
+                       -Dlibxmlb:gtkdoc=false,
+                       -Dlibxmlb:introspection=false,
                        -Dpkcs7=false]
     source: .
     source-type: git
@@ -294,7 +264,7 @@ parts:
       - -usr/share/gir-1.0
       - -usr/share/upstart
       - -usr/lib/*/pkgconfig
-    after: [libxmlb-dev, gudev, gusb, gnu-efi, libefivar-fixpkgconfig, libsmbios, build-introspection, gettext]
+    after: [gudev, gusb, gnu-efi, libefivar-fixpkgconfig, libsmbios, build-introspection, gettext]
   fix-bash-completion:
     plugin: make
     source: contrib/snap/fix-bash-completion

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,37 +77,6 @@ parts:
       - -lib
       - -share
       - -usr
-  libxmlb-dev:
-    plugin: meson
-    meson-parameters: [--prefix=/usr, -Dgtk-doc=false, -Dintrospection=false]
-    source: https://people.freedesktop.org/~hughsient/releases/libxmlb-0.1.2.tar.xz
-    build-packages:
-      - python3-pip
-      - libgirepository1.0-dev
-      - libglib2.0-dev
-      - libgtk-3-dev
-      - libjson-glib-dev
-      - uuid-dev
-    prime:
-      - -usr/bin
-      - -usr/include
-      - -usr/share/doc
-      - -usr/share/bash-completion
-      - -usr/share/aclocal
-      - -usr/lib/*/pkgconfig
-      - -usr/share/installed-tests
-      - -usr/lib/systemd
-      - -usr/lib/glib-networking
-      - -usr/lib/dconf
-      - -usr/share/X11
-      - -usr/share/GConf
-      - -usr/share/dbus-1
-      - -usr/share/glib-2.0/schemas
-      - -usr/share/lintian
-      - -usr/share/man
-      - -usr/lib/*/gdk-pixbuf-2.0
-      - -usr/share/gettext
-    after: [meson]
   gudev:
     plugin: autotools
     source: https://github.com/GNOME/libgudev/archive/232.tar.gz
@@ -217,6 +186,8 @@ parts:
                        -Dintrospection=false,
                        -Dman=false,
                        -Dudevdir=$SNAPCRAFT_STAGE/lib/udev,
+                       "-Dlibxmlb:gtkdoc=false",
+                       "-Dlibxmlb:introspection=false",
                        -Dpkcs7=false]
     source: .
     source-type: git
@@ -289,7 +260,7 @@ parts:
       - -usr/share/gir-1.0
       - -usr/share/upstart
       - -usr/lib/*/pkgconfig
-    after: [libxmlb-dev, gudev, gusb, gnu-efi, libefivar-fixpkgconfig, libsmbios, build-introspection, gettext]
+    after: [gudev, gusb, gnu-efi, libefivar-fixpkgconfig, libsmbios, build-introspection, gettext]
   fix-bash-completion:
     plugin: make
     source: contrib/snap/fix-bash-completion


### PR DESCRIPTION
This avoids having to bump the snap on libxmlb releases.

I tried to do this for flatpak too but failed.