### PR TITLE
Sort the firmware sack by component priority

### DIFF
--- a/contrib/ci/Dockerfile-fedora.in
+++ b/contrib/ci/Dockerfile-fedora.in
@@ -5,7 +5,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 RUN echo fubar > /etc/machine-id
 RUN dnf --enablerepo=updates-testing -y update
-RUN dnf install -y https://kojipkgs.fedoraproject.org//packages/libxmlb/0.1.2/1.fc29/x86_64/libxmlb-0.1.2-1.fc29.x86_64.rpm https://kojipkgs.fedoraproject.org//packages/libxmlb/0.1.2/1.fc29/x86_64/libxmlb-devel-0.1.2-1.fc29.x86_64.rpm
+RUN dnf install -y https://kojipkgs.fedoraproject.org//packages/libxmlb/0.1.3/1.fc29/x86_64/libxmlb-0.1.3-1.fc29.x86_64.rpm https://kojipkgs.fedoraproject.org//packages/libxmlb/0.1.3/1.fc29/x86_64/libxmlb-devel-0.1.3-1.fc29.x86_64.rpm
 RUN echo fubar > /etc/machine-id
 %%%INSTALL_DEPENDENCIES_COMMAND%%%
 RUN mkdir /build

--- a/contrib/ci/Dockerfile-flatpak.in
+++ b/contrib/ci/Dockerfile-flatpak.in
@@ -5,6 +5,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 RUN echo fubar > /etc/machine-id
 %%%INSTALL_DEPENDENCIES_COMMAND%%%
+RUN dnf --enablerepo=updates-testing -y update
 RUN mkdir /build
 WORKDIR /build
 COPY . .

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -555,7 +555,7 @@
     </distro>
     <distro id="debian">
       <control>
-        <version>(>= 0.1.2)</version>
+        <version>(>= 0.1.3)</version>
       </control>
       <package variant="x86_64" />
       <package variant="s390x">libxmlb-dev:s390x</package>
@@ -563,7 +563,7 @@
     </distro>
     <distro id="ubuntu">
       <control>
-        <version>(>= 0.1.2)</version>
+        <version>(>= 0.1.3)</version>
       </control>
       <package variant="x86_64" />
     </distro>

--- a/contrib/ci/flatpak.sh
+++ b/contrib/ci/flatpak.sh
@@ -4,8 +4,8 @@ set -x
 
 # install the runtimes
 flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-flatpak install --assumeyes flathub runtime/org.gnome.Sdk/x86_64/3.28
-flatpak install --assumeyes flathub runtime/org.gnome.Platform/x86_64/3.28
+flatpak install --assumeyes flathub runtime/org.gnome.Sdk/x86_64/3.30
+flatpak install --assumeyes flathub runtime/org.gnome.Platform/x86_64/3.30
 
 # build the repo
 flatpak-builder --repo=repo --force-clean --disable-rofiles-fuse build-dir contrib/org.freedesktop.fwupd.json

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -1,5 +1,5 @@
 %global glib2_version 2.45.8
-%global libxmlb_version 0.1.2
+%global libxmlb_version 0.1.3
 %global libgusb_version 0.2.11
 %global libsoup_version 2.51.92
 %global systemd_version 231

--- a/contrib/org.freedesktop.fwupd.json
+++ b/contrib/org.freedesktop.fwupd.json
@@ -155,8 +155,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "http://superb-dca2.dl.sourceforge.net/project/gnu-efi/gnu-efi-3.0.5.tar.bz2",
-          "sha256": "bd8fcd5914f18fc0e4ba948ab03b00013e528504f529c60739b748f6ef130b22"
+          "url": "http://superb-dca2.dl.sourceforge.net/project/gnu-efi/gnu-efi-3.0.9.tar.bz2",
+          "sha256": "6715ea7eae1c7e4fc5041034bd3f107ec2911962ed284a081e491646b12277f0"
         }
       ]
     },

--- a/contrib/org.freedesktop.fwupd.json
+++ b/contrib/org.freedesktop.fwupd.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.freedesktop.fwupd",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.28",
+  "runtime-version": "3.30",
   "branch": "master",
   "sdk": "org.gnome.Sdk",
   "command": "/app/libexec/fwupd/fwupdtool",
@@ -215,8 +215,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://people.freedesktop.org/~hughsient/releases/libxmlb-0.1.2.tar.xz",
-          "sha256": "20a734895830ae2af82a270b61e4832c6012b1aaf2003e1300d743dbd6aa95cf"
+          "url": "https://people.freedesktop.org/~hughsient/releases/libxmlb-0.1.3.tar.xz",
+          "sha256": "b609a95d078ab956231a43fd082382b386ed2f90e3fe5e8b785c4278a1b4787e"
         }
       ]
     },

--- a/meson.build
+++ b/meson.build
@@ -154,7 +154,7 @@ gudev = dependency('gudev-1.0')
 if gudev.version().version_compare('>= 232')
   conf.set('HAVE_GUDEV_232', '1')
 endif
-libxmlb = dependency('xmlb', version : '>= 0.1.2', fallback : ['libxmlb', 'libxmlb_dep'])
+libxmlb = dependency('xmlb', version : '>= 0.1.3', fallback : ['libxmlb', 'libxmlb_dep'])
 gusb = dependency('gusb', version : '>= 0.2.9')
 sqlite = dependency('sqlite3')
 libarchive = dependency('libarchive')

--- a/subprojects/libxmlb.wrap
+++ b/subprojects/libxmlb.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = libxmlb
 url = https://github.com/hughsie/libxmlb.git
-revision = wip/subproject
+revision = 0.1.3


### PR DESCRIPTION
This allows composite firmware to be ordered in an explicit way. Needs CI fixes, but those depend on a libxmlb 0.1.3 release which I can do Monday.