### PR TITLE
dell-dock: Prefer to flash VMM5331 via I2C instead of DP aux

### DIFF
--- a/plugins/synapticsmst/fu-plugin-synapticsmst.c
+++ b/plugins/synapticsmst/fu-plugin-synapticsmst.c
@@ -463,7 +463,4 @@ fu_plugin_init (FuPlugin *plugin)
 {
 	/* make sure dell is already coldplugged */
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_RUN_AFTER, "dell");
-
-	/* dell-dock plugin uses a slower bus for flashing */
-	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_BETTER_THAN, "dell_dock");
 }


### PR DESCRIPTION
Although this is (currently) slower to flash with, bad behavior
and corner case scenarios such as these don't occur:

* Flickering during enumeration
* Monitor plugged in during enumeration but not during flash
* Heavy DP traffic slowing down update significantly
* Sandboxes without access to `/dev/drm_dp_auxY` unable to flash
* Exercising existing graphics driver bugs leading to system freezes.

Additionally this removes a lot of code in dell_dock that was put
in place specifically to be able to support waking up the MST hub
to try to use DP aux for flashing.

Now DP aux will only be used to flash when fwupd is compiled
without `dell_dock`.