### PR TITLE
Create a silo index to speed up GUID queries

### DIFF
--- a/contrib/ci/Dockerfile-fedora.in
+++ b/contrib/ci/Dockerfile-fedora.in
@@ -5,7 +5,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 RUN echo fubar > /etc/machine-id
 RUN dnf --enablerepo=updates-testing -y update
-RUN dnf install -y https://kojipkgs.fedoraproject.org//packages/libxmlb/0.1.3/1.fc29/x86_64/libxmlb-0.1.3-1.fc29.x86_64.rpm https://kojipkgs.fedoraproject.org//packages/libxmlb/0.1.3/1.fc29/x86_64/libxmlb-devel-0.1.3-1.fc29.x86_64.rpm
+RUN dnf install -y https://kojipkgs.fedoraproject.org//packages/libxmlb/0.1.5/1.fc29/x86_64/libxmlb-0.1.5-1.fc29.x86_64.rpm https://kojipkgs.fedoraproject.org//packages/libxmlb/0.1.5/1.fc29/x86_64/libxmlb-devel-0.1.5-1.fc29.x86_64.rpm
 RUN echo fubar > /etc/machine-id
 %%%INSTALL_DEPENDENCIES_COMMAND%%%
 RUN mkdir /build

--- a/meson.build
+++ b/meson.build
@@ -154,7 +154,7 @@ gudev = dependency('gudev-1.0')
 if gudev.version().version_compare('>= 232')
   conf.set('HAVE_GUDEV_232', '1')
 endif
-libxmlb = dependency('xmlb', version : '>= 0.1.3', fallback : ['libxmlb', 'libxmlb_dep'])
+libxmlb = dependency('xmlb', version : '>= 0.1.5', fallback : ['libxmlb', 'libxmlb_dep'])
 gusb = dependency('gusb', version : '>= 0.2.9')
 sqlite = dependency('sqlite3')
 libarchive = dependency('libarchive')

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1860,6 +1860,16 @@ fu_engine_load_metadata_store (FuEngine *self, GError **error)
 	if (components != NULL)
 		g_debug ("%u components now in silo", components->len);
 
+	/* build the index */
+	if (!xb_silo_query_build_index (self->silo,
+					"components/component/provides/firmware",
+					"type", error))
+		return FALSE;
+	if (!xb_silo_query_build_index (self->silo,
+					"components/component/provides/firmware",
+					NULL, error))
+		return FALSE;
+
 	/* did any devices SUPPORTED state change? */
 	devices = fu_device_list_get_all (self->device_list);
 	for (guint i = 0; i < devices->len; i++) {
@@ -2076,7 +2086,7 @@ fu_engine_get_result_from_component (FuEngine *self, XbNode *component, GError *
 
 	dev = fwupd_device_new ();
 	provides = xb_node_query (component,
-				  "provides/firmware[@type='flashed']",
+				  "provides/firmware[@type=$'flashed']",
 				  0, &error_local);
 	if (provides == NULL) {
 		g_set_error (error,
@@ -2480,7 +2490,7 @@ fu_engine_get_releases_for_device (FuEngine *self, FuDevice *device, GError **er
 		const gchar *guid = g_ptr_array_index (device_guids, i);
 		xb_string_append_union (xpath,
 					"components/component/"
-					"provides/firmware[@type='flashed'][text()='%s']/"
+					"provides/firmware[@type=$'flashed'][text()=$'%s']/"
 					"../..", guid);
 	}
 	components = xb_silo_query (self->silo, xpath->str, 0, &error_local);

--- a/subprojects/libxmlb.wrap
+++ b/subprojects/libxmlb.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = libxmlb
 url = https://github.com/hughsie/libxmlb.git
-revision = 0.1.3
+revision = 0.1.5


### PR DESCRIPTION
This speeds up matching for GUIDs by about 90%, taking the query from 3.17ms to
about 0.33ms on my Thinkpad. This is more important for slow ARM hardware,
where strcmp() is more expensive than on x64.