### PR TITLE
ebitdo: remove clashing SF30/SN30 pro device ids

### DIFF
--- a/plugins/ebitdo/ebitdo.quirk
+++ b/plugins/ebitdo/ebitdo.quirk
@@ -70,7 +70,3 @@ Flags = none
 [DeviceInstanceId=USB\VID_2DC8&PID_6001]
 Plugin = ebitdo
 Flags = none
-## Xinput mode (Start + X)
-[DeviceInstanceId=USB\VID_045E&PID_028E]
-Plugin = ebitdo
-Flags = none


### PR DESCRIPTION
The USB ids clash with the Xbox controller ids. This makes the Xbox controller unusable since fwupd unloads the device just after connecting it and fails to update it not being a 8bitdo device.

This is specially critical since the Xbox controller is one of the most commonly used.

As seen here: https://github.com/paroj/xpad/issues/114