### PR TITLE
Remove DaemonVersionFormat=quad

### DIFF
--- a/plugins/dell/dell.quirk
+++ b/plugins/dell/dell.quirk
@@ -38,10 +38,3 @@ UefiVersionFormat = quad
 
 [SmbiosManufacturer=Alienware]
 UefiVersionFormat = quad
-
-# DEPRECATED: put this in the AppStream metadata itself using
-# <custom>
-#   <value key="LVFS::VersionFormat">quad</value>
-# </custom>
-[DaemonVersionFormat=quad]
-ComponentIDs = com.dell.uefi*.firmware

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -204,7 +204,6 @@ static gchar *
 fu_engine_get_release_version (FuEngine *self, XbNode *component, XbNode *rel)
 {
 	FuVersionFormat fmt = FU_VERSION_FORMAT_TRIPLET;
-	const gchar *quirk;
 	const gchar *version;
 	const gchar *version_format;
 	guint64 ver_uint32;
@@ -217,21 +216,6 @@ fu_engine_get_release_version (FuEngine *self, XbNode *component, XbNode *rel)
 	/* already dotted notation */
 	if (g_strstr_len (version, -1, ".") != NULL)
 		return g_strdup (version);
-
-	/* fall back to the quirk database until all files have metadata */
-	quirk = fu_quirks_lookup_by_id (self->quirks,
-					"DaemonVersionFormat=quad",
-					FU_QUIRKS_DAEMON_VERSION_FORMAT);
-	if (quirk != NULL) {
-		const gchar *id = xb_node_query_text (component, "id", NULL);
-		g_auto(GStrv) globs = g_strsplit (quirk, ",", -1);
-		for (guint i = 0; globs[i] != NULL; i++) {
-			if (fnmatch (globs[i], id, 0) == 0) {
-				fmt = FU_VERSION_FORMAT_QUAD;
-				break;
-			}
-		}
-	}
 
 	/* specified in metadata */
 	version_format = xb_node_query_text (component,


### PR DESCRIPTION
This metadata key is now unnecessary, as firmwares are expected to set the
version format in the metadata.

If the metadata is missing, the LVFS allows a per-vendor default for non-semver
release versions which is now unconditionally set in metadata.