### PR TITLE
trivial: Allow calling fu_device_has_guid() with non-GUID text

### DIFF
--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -771,6 +771,30 @@ fu_device_add_guid_safe (FuDevice *self, const gchar *guid)
 }
 
 /**
+ * fu_device_has_guid:
+ * @self: A #FuDevice
+ * @guid: A GUID, e.g. `WacomAES`
+ *
+ * Finds out if the device has a specific GUID.
+ *
+ * Returns: %TRUE if the GUID is found
+ *
+ * Since: 1.2.2
+ **/
+gboolean
+fu_device_has_guid (FuDevice *self, const gchar *guid)
+{
+	/* make valid */
+	if (!fu_common_guid_is_valid (guid)) {
+		g_autofree gchar *tmp = fu_common_guid_from_string (guid);
+		return fwupd_device_has_guid (FWUPD_DEVICE (self), tmp);
+	}
+
+	/* already valid */
+	return fwupd_device_has_guid (FWUPD_DEVICE (self), guid);
+}
+
+/**
  * fu_device_add_guid:
  * @self: A #FuDevice
  * @guid: A GUID, e.g. `2082b5e0-7a64-478a-b1b2-e3404fab6dad`

--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -85,7 +85,6 @@ FuDevice	*fu_device_new				(void);
 #define fu_device_set_created(d,v)		fwupd_device_set_created(FWUPD_DEVICE(d),v)
 #define fu_device_set_description(d,v)		fwupd_device_set_description(FWUPD_DEVICE(d),v)
 #define fu_device_set_flags(d,v)		fwupd_device_set_flags(FWUPD_DEVICE(d),v)
-#define fu_device_has_guid(d,v)			fwupd_device_has_guid(FWUPD_DEVICE(d),v)
 #define fu_device_set_modified(d,v)		fwupd_device_set_modified(FWUPD_DEVICE(d),v)
 #define fu_device_set_plugin(d,v)		fwupd_device_set_plugin(FWUPD_DEVICE(d),v)
 #define fu_device_set_serial(d,v)		fwupd_device_set_serial(FWUPD_DEVICE(d),v)
@@ -129,6 +128,8 @@ const gchar	*fu_device_get_equivalent_id		(FuDevice	*self);
 void		 fu_device_set_equivalent_id		(FuDevice	*self,
 							 const gchar	*equivalent_id);
 void		 fu_device_add_guid			(FuDevice	*self,
+							 const gchar	*guid);
+gboolean	 fu_device_has_guid			(FuDevice	*self,
 							 const gchar	*guid);
 gchar		*fu_device_get_guids_as_str		(FuDevice	*self);
 FuDevice	*fu_device_get_alternate		(FuDevice	*self);


### PR DESCRIPTION
This matches the behaviour of fu_device_add_guid().