### PR TITLE
dfu: Require a specific USB class and subclass for DFU mode

### DIFF
--- a/plugins/dfu/dfu.quirk
+++ b/plugins/dfu/dfu.quirk
@@ -1,3 +1,7 @@
+# All DFU devices
+[DeviceInstanceId=USB\CLASS_FE&SUBCLASS_01]
+Plugin = dfu
+
 # on PC platforms the DW1820A firmware is loaded at runtime and can't
 # be stored on the device itself as the flash chip is unpopulated
 [DeviceInstanceId=USB\VID_0A5C&PID_6412]
@@ -130,6 +134,7 @@ DfuFlags = use-any-interface,legacy-protocol,force-dfu-mode
 Plugin = dfu
 DfuFlags = use-any-interface,legacy-protocol,force-dfu-mode
 [DeviceInstanceId=USB\VID_03EB&PID_2FF4]
+Plugin = dfu
 DfuFlags = use-any-interface,legacy-protocol,force-dfu-mode
 
 # Atmel XMEGA Bootloader

--- a/plugins/dfu/fu-plugin-dfu.c
+++ b/plugins/dfu/fu-plugin-dfu.c
@@ -10,6 +10,12 @@
 
 #include "dfu-device.h"
 
+void
+fu_plugin_init (FuPlugin *plugin)
+{
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_REQUIRES_QUIRK, FU_QUIRKS_PLUGIN);
+}
+
 static void
 fu_plugin_dfu_state_changed_cb (DfuDevice *device,
 				DfuState state,


### PR DESCRIPTION
This makes startup quicker as we no longer have to probe every USB device, and
is now possible with the new GUIDs we added. Devices not using the
specification-provided values can (and already are) worked around with quirks.