### PR TITLE
trivial: Speed up daemon startup

### DIFF
--- a/plugins/unifying/fu-plugin-unifying.c
+++ b/plugins/unifying/fu-plugin-unifying.c
@@ -173,5 +173,6 @@ fu_plugin_startup (FuPlugin *plugin, GError **error)
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_REQUIRES_QUIRK, FU_QUIRKS_PLUGIN);
 	fu_plugin_add_udev_subsystem (plugin, "hidraw");
 }


### PR DESCRIPTION
Require a quirk match for Unifying hardware to avoid probing a lot of USB
devices at startup.