### PR TITLE
Sanitize the version if the version format has been specified

### DIFF
--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -1071,6 +1071,16 @@ fu_device_set_id (FuDevice *self, const gchar *id)
 	fwupd_device_set_id (FWUPD_DEVICE (self), id_hash);
 }
 
+static gboolean
+fu_device_is_valid_semver_char (gchar c)
+{
+	if (g_ascii_isdigit (c))
+		return TRUE;
+	if (c == '.')
+		return TRUE;
+	return FALSE;
+}
+
 /**
  * fu_device_set_version:
  * @self: A #FuDevice
@@ -1084,14 +1094,31 @@ void
 fu_device_set_version (FuDevice *self, const gchar *version)
 {
 	FuDevicePrivate *priv = GET_PRIVATE (self);
+	g_autoptr(GString) version_safe = NULL;
 
 	g_return_if_fail (FU_IS_DEVICE (self));
 	g_return_if_fail (version != NULL);
 
+	/* sanitize if required */
+	if (priv->version_format != FU_VERSION_FORMAT_UNKNOWN &&
+	    priv->version_format != FU_VERSION_FORMAT_PLAIN) {
+		version_safe = g_string_new (NULL);
+		for (guint i = 0; version[i] != '\0'; i++) {
+			if (fu_device_is_valid_semver_char (version[i]))
+				g_string_append_c (version_safe, version[i]);
+		}
+		if (g_strcmp0 (version, version_safe->str) != 0) {
+			g_debug ("converted '%s' to '%s'",
+				 version, version_safe->str);
+		}
+	} else {
+		version_safe = g_string_new (version);
+	}
+
 	/* try to autodetect the version-format */
 	if (priv->version_format == FU_VERSION_FORMAT_UNKNOWN)
-		priv->version_format = fu_common_version_guess_format (version);
-	fwupd_device_set_version (FWUPD_DEVICE (self), version);
+		priv->version_format = fu_common_version_guess_format (version_safe->str);
+	fwupd_device_set_version (FWUPD_DEVICE (self), version_safe->str);
 }
 
 /**

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -1459,6 +1459,15 @@ fu_device_list_func (void)
 }
 
 static void
+fu_device_version_format_func (void)
+{
+	g_autoptr(FuDevice) device = fu_device_new ();
+	fu_device_set_version_format (device, FU_VERSION_FORMAT_TRIPLET);
+	fu_device_set_version (device, "Ver1.2.3 RELEASE");
+	g_assert_cmpstr (fu_device_get_version (device), ==, "1.2.3");
+}
+
+static void
 fu_device_open_refcount_func (void)
 {
 	gboolean ret;
@@ -3255,6 +3264,7 @@ main (int argc, char **argv)
 	g_test_add_func ("/fwupd/device-locker{fail}", fu_device_locker_fail_func);
 	g_test_add_func ("/fwupd/device{metadata}", fu_device_metadata_func);
 	g_test_add_func ("/fwupd/device{open-refcount}", fu_device_open_refcount_func);
+	g_test_add_func ("/fwupd/device{version-format}", fu_device_version_format_func);
 	g_test_add_func ("/fwupd/device-list", fu_device_list_func);
 	g_test_add_func ("/fwupd/device-list{delay}", fu_device_list_delay_func);
 	g_test_add_func ("/fwupd/device-list{compatible}", fu_device_list_compatible_func);


### PR DESCRIPTION
This converts versions like 'v1.2.3' into a valid semver of '1.2.3' if the
version format has been set.

Fixes https://github.com/hughsie/fwupd/issues/884