### PR TITLE
uefi: Append the header on capsules without headers from Linux

### DIFF
--- a/plugins/dell/fu-self-test.c
+++ b/plugins/dell/fu-self-test.c
@@ -69,7 +69,7 @@ fu_plugin_dell_tpm_func (void)
 	struct tpm_status tpm_out;
 	g_autoptr(FuPlugin) plugin_dell = NULL;
 	g_autoptr(FuPlugin) plugin_uefi = NULL;
-	g_autoptr(GBytes) blob_fw = g_bytes_new_static ("fw", 2);
+	g_autoptr(GBytes) blob_fw = g_bytes_new_static ("fw", 30);
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GPtrArray) devices = NULL;
 
@@ -244,8 +244,11 @@ fu_plugin_dell_tpm_func (void)
 	g_clear_error (&error);
 
 	/* test override */
+	g_test_expect_message ("FuPluginUefi", G_LOG_LEVEL_WARNING,
+			       "missing or invalid embedded capsule header");
 	ret = fu_plugin_runner_update (plugin_uefi, device_v20, NULL, blob_fw,
 				       FWUPD_INSTALL_FLAG_FORCE, &error);
+	g_test_assert_expected_messages ();
 	g_assert_no_error (error);
 	g_assert (ret);
 }

--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -377,6 +377,10 @@ fu_plugin_update (FuPlugin *plugin,
 	if (!fu_device_write_firmware (device, blob_fw, error))
 		return FALSE;
 
+	/* record if we had an invalid header during update */
+	str = fu_uefi_missing_capsule_header (device) ? "True" : "False";
+	fu_plugin_add_report_metadata (plugin, "MissingCapsuleHeader", str);
+
 	/* record boot information to system log for future debugging */
 	efibootmgr_path = fu_common_find_program_in_path ("efibootmgr", NULL);
 	if (efibootmgr_path != NULL) {

--- a/plugins/uefi/fu-uefi-bootmgr.c
+++ b/plugins/uefi/fu-uefi-bootmgr.c
@@ -108,7 +108,7 @@ fu_uefi_setup_bootnext_with_dp (const guint8 *dp_buf, guint8 *opt, gssize opt_si
 		efidp found_dp;
 		g_autofree guint8 *var_data_tmp = NULL;
 
-		if (efi_guid_cmp (guid, &efi_guid_global))
+		if (efi_guid_cmp (guid, &efi_guid_global) == 0)
 			continue;
 		rc = sscanf (name, "Boot%hX%n", &entry, &scanned);
 		if (rc < 0) {

--- a/plugins/uefi/fu-uefi-device.c
+++ b/plugins/uefi/fu-uefi-device.c
@@ -323,7 +323,7 @@ fu_uefi_device_fixup_firmware (FuDevice *device, GBytes *fw, GError **error)
 		return g_bytes_new_from_bytes (fw, 0, fw_length);
 	/* Missing, add a header */
 	} else {
-		guint header_size = sizeof(efi_capsule_header_t);
+		guint header_size = getpagesize();
 		guint8 *new_data = g_malloc (fw_length + header_size);
 		guint8 *capsule = new_data + header_size;
 		efi_capsule_header_t *header = (efi_capsule_header_t *) new_data;

--- a/plugins/uefi/fu-uefi-device.h
+++ b/plugins/uefi/fu-uefi-device.h
@@ -57,6 +57,7 @@ const gchar	*fu_uefi_device_kind_to_string		(FuUefiDeviceKind kind);
 const gchar	*fu_uefi_device_status_to_string	(FuUefiDeviceStatus status);
 FuUefiUpdateInfo *fu_uefi_device_load_update_info	(FuUefiDevice	*self,
 							 GError		**error);
+gboolean	 fu_uefi_missing_capsule_header		(FuDevice *device);
 
 G_END_DECLS
 


### PR DESCRIPTION
This allows using better heuristics and potentially phasing this out in the future.

This idea was mentioned in #889 .

It's not yet tested. @hughsie can you arrange for one of the affected machines that need header added to be tested against it?