### PR TITLE
Allow plugins to define support for a 'well-known' protocol

### DIFF
--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2016-2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */
@@ -14,6 +14,7 @@
 #define FWUPD_RESULT_KEY_DEVICE_ID		"DeviceId"	/* s */
 #define FWUPD_RESULT_KEY_PARENT_DEVICE_ID	"ParentDeviceId"/* s */
 #define FWUPD_RESULT_KEY_FILENAME		"Filename"	/* s */
+#define FWUPD_RESULT_KEY_PROTOCOL		"Protocol"	/* s */
 #define FWUPD_RESULT_KEY_FLAGS			"Flags"		/* t */
 #define FWUPD_RESULT_KEY_FLASHES_LEFT		"FlashesLeft"	/* u */
 #define FWUPD_RESULT_KEY_INSTALL_DURATION	"InstallDuration"	/* u */

--- a/libfwupd/fwupd-release.h
+++ b/libfwupd/fwupd-release.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2015-2018 Richard Hughes <richard@hughsie.com>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */
@@ -54,6 +54,9 @@ const gchar	*fwupd_release_get_metadata_item	(FwupdRelease	*release,
 const gchar	*fwupd_release_get_filename		(FwupdRelease	*release);
 void		 fwupd_release_set_filename		(FwupdRelease	*release,
 							 const gchar	*filename);
+const gchar	*fwupd_release_get_protocol		(FwupdRelease	*release);
+void		 fwupd_release_set_protocol		(FwupdRelease	*release,
+							 const gchar	*protocol);
 const gchar	*fwupd_release_get_appstream_id		(FwupdRelease	*release);
 void		 fwupd_release_set_appstream_id		(FwupdRelease	*release,
 							 const gchar	*appstream_id);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -286,3 +286,10 @@ LIBFWUPD_1.2.1 {
     fwupd_release_set_install_duration;
   local: *;
 } LIBFWUPD_1.1.3;
+
+LIBFWUPD_1.2.2 {
+  global:
+    fwupd_release_get_protocol;
+    fwupd_release_set_protocol;
+  local: *;
+} LIBFWUPD_1.2.1;

--- a/plugins/altos/fu-plugin-altos.c
+++ b/plugins/altos/fu-plugin-altos.c
@@ -14,6 +14,7 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_REQUIRES_QUIRK, FU_QUIRKS_PLUGIN);
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "org.altusmetrum.altos");
 }
 
 gboolean

--- a/plugins/colorhug/fu-plugin-colorhug.c
+++ b/plugins/colorhug/fu-plugin-colorhug.c
@@ -14,6 +14,7 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_REQUIRES_QUIRK, FU_QUIRKS_PLUGIN);
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.hughski.colorhug");
 }
 
 gboolean

--- a/plugins/csr/fu-plugin-csr.c
+++ b/plugins/csr/fu-plugin-csr.c
@@ -14,6 +14,7 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_REQUIRES_QUIRK, FU_QUIRKS_PLUGIN);
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.qualcomm.dfu");
 }
 
 gboolean

--- a/plugins/dell-dock/fu-plugin-dell-dock.c
+++ b/plugins/dell-dock/fu-plugin-dell-dock.c
@@ -30,6 +30,8 @@ void fu_plugin_init (FuPlugin *plugin)
 
 	/* currently slower performance, but more reliable in corner cases */
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_BETTER_THAN, "synapticsmst");
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.dell.dock");
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.synaptics.mst");
 }
 
 static gboolean

--- a/plugins/dfu/fu-plugin-dfu.c
+++ b/plugins/dfu/fu-plugin-dfu.c
@@ -14,6 +14,8 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_REQUIRES_QUIRK, FU_QUIRKS_PLUGIN);
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "org.usb.dfu");
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.st.dfuse");
 }
 
 static void

--- a/plugins/ebitdo/fu-plugin-ebitdo.c
+++ b/plugins/ebitdo/fu-plugin-ebitdo.c
@@ -14,6 +14,7 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_REQUIRES_QUIRK, FU_QUIRKS_PLUGIN);
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.8bitdo");
 }
 
 gboolean

--- a/plugins/fastboot/fu-plugin-fastboot.c
+++ b/plugins/fastboot/fu-plugin-fastboot.c
@@ -14,6 +14,7 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_REQUIRES_QUIRK, FU_QUIRKS_PLUGIN);
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.google.fastboot");
 }
 
 gboolean

--- a/plugins/flashrom/fu-plugin-flashrom.c
+++ b/plugins/flashrom/fu-plugin-flashrom.c
@@ -33,6 +33,7 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "org.flashrom");
 }
 
 void

--- a/plugins/nvme/fu-plugin-nvme.c
+++ b/plugins/nvme/fu-plugin-nvme.c
@@ -32,6 +32,7 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_add_udev_subsystem (plugin, "nvme");
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "org.nvmexpress");
 }
 
 gboolean

--- a/plugins/redfish/fu-plugin-redfish.c
+++ b/plugins/redfish/fu-plugin-redfish.c
@@ -117,6 +117,7 @@ fu_plugin_init (FuPlugin *plugin)
 {
 	FuPluginData *data = fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	data->client = fu_redfish_client_new ();
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "org.dmtf.redfish");
 }
 
 void

--- a/plugins/rts54hid/fu-plugin-rts54hid.c
+++ b/plugins/rts54hid/fu-plugin-rts54hid.c
@@ -15,6 +15,7 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_REQUIRES_QUIRK, FU_QUIRKS_PLUGIN);
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.realtek.rts54");
 
 	/* register the custom types */
 	g_type_ensure (FU_TYPE_RTS54HID_MODULE);

--- a/plugins/rts54hub/fu-plugin-rts54hub.c
+++ b/plugins/rts54hub/fu-plugin-rts54hub.c
@@ -14,6 +14,7 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_REQUIRES_QUIRK, FU_QUIRKS_PLUGIN);
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.realtek.rts54");
 }
 
 gboolean

--- a/plugins/synapticsmst/fu-plugin-synapticsmst.c
+++ b/plugins/synapticsmst/fu-plugin-synapticsmst.c
@@ -471,4 +471,5 @@ fu_plugin_init (FuPlugin *plugin)
 {
 	/* make sure dell is already coldplugged */
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_RUN_AFTER, "dell");
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.synaptics.mst");
 }

--- a/plugins/test/fu-plugin-test.c
+++ b/plugins/test/fu-plugin-test.c
@@ -15,6 +15,7 @@ struct FuPluginData {
 void
 fu_plugin_init (FuPlugin *plugin)
 {
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.acme.test");
 	fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	g_debug ("init");
 }

--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -562,6 +562,7 @@ fu_plugin_init (FuPlugin *plugin)
 	FuPluginData *data = fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	const gchar *subsystems[] = { "thunderbolt", NULL };
 
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.intel.thunderbolt");
 	data->udev = g_udev_client_new (subsystems);
 	g_signal_connect (data->udev, "uevent",
 			  G_CALLBACK (udev_uevent_cb), plugin);

--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -38,6 +38,7 @@ fu_plugin_init (FuPlugin *plugin)
 	FuPluginData *data = fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
 	data->bgrt = fu_uefi_bgrt_new ();
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_RUN_AFTER, "upower");
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "org.uefi.capsule");
 	fu_plugin_add_compile_version (plugin, "com.redhat.efivar", EFIVAR_LIBRARY_VERSION);
 }
 

--- a/plugins/unifying/fu-plugin-unifying.c
+++ b/plugins/unifying/fu-plugin-unifying.c
@@ -174,5 +174,7 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_REQUIRES_QUIRK, FU_QUIRKS_PLUGIN);
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.logitech.unifying");
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.logitech.unifyingsigned");
 	fu_plugin_add_udev_subsystem (plugin, "hidraw");
 }

--- a/plugins/wacom-usb/fu-plugin-wacom-usb.c
+++ b/plugins/wacom-usb/fu-plugin-wacom-usb.c
@@ -14,6 +14,7 @@ void
 fu_plugin_init (FuPlugin *plugin)
 {
 	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_REQUIRES_QUIRK, FU_QUIRKS_PLUGIN);
+	fu_plugin_add_rule (plugin, FU_PLUGIN_RULE_SUPPORTS_PROTOCOL, "com.wacom.usb");
 }
 
 gboolean

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -321,6 +321,9 @@ fu_engine_set_release_from_appstream (FuEngine *self,
 	tmp64 = xb_node_get_attr_as_uint (release, "install_duration");
 	if (tmp64 != 0)
 		fwupd_release_set_install_duration (rel, tmp64);
+	tmp = xb_node_query_text (component, "custom/value[@key='LVFS::UpdateProtocol']", NULL);
+	if (tmp != NULL)
+		fwupd_release_set_protocol (rel, tmp);
 }
 
 /* finds the remote-id for the first firmware in the silo that matches this

--- a/src/fu-plugin.h
+++ b/src/fu-plugin.h
@@ -70,6 +70,7 @@ typedef enum {
  * @FU_PLUGIN_RULE_REQUIRES_QUIRK:	Requires a specific quirk
  * @FU_PLUGIN_RULE_BETTER_THAN:		Is better than another plugin
  * @FU_PLUGIN_RULE_INHIBITS_IDLE:	The plugin inhibits the idle shutdown
+ * @FU_PLUGIN_RULE_SUPPORTS_PROTOCOL:	The plugin supports a well known protocol
  *
  * The rules used for ordering plugins.
  * Plugins are expected to add rules in fu_plugin_initialize().
@@ -81,6 +82,7 @@ typedef enum {
 	FU_PLUGIN_RULE_REQUIRES_QUIRK,
 	FU_PLUGIN_RULE_BETTER_THAN,
 	FU_PLUGIN_RULE_INHIBITS_IDLE,
+	FU_PLUGIN_RULE_SUPPORTS_PROTOCOL,
 	/*< private >*/
 	FU_PLUGIN_RULE_LAST
 } FuPluginRule;


### PR DESCRIPTION
Future metadata from the LVFS will set the protocol the firmware is expected to
use. As vendors love to re-use common terms like DFU for incompatible protocols,
namespace them with the controlling company ID with an approximate reverse DNS
namespace.

This also allows more than one plugin to define support for the same protocol,
for instance rts54hid+rts54hub and synapticsmst+dell-dock.