### PR TITLE
Add TB18DC to the synapticmst plugin list

### DIFF
--- a/plugins/synapticsmst/README.md
+++ b/plugins/synapticsmst/README.md
@@ -57,18 +57,19 @@ Payloads can be flashed just like any other plugin from LVFS.
 ## Supported devices
 Not all Dell systems or accessories contain MST hubs.
 Here is a sample list of systems known to support them however:
-1. Dell WD15 dock
-2. Dell TB16 dock
-3. Latitude E5570
-4. Latitude E5470
-5. Latitude E5270
-6. Latitude E7470
-7. Latitude E7270
-8. Latitude E7450
-9. Latitude E7250
-10. Latitude E5550
-11. Latitude E5450
-12. Latitude E5250
-13. Latitude Rugged 5414
-14. Latitude Rugged 7214
-15. Latitude Rugged 7414
+ *  Dell WD15 dock
+ *  Dell TB16 dock
+ *  Dell TB18DC
+ *  Latitude E5570
+ *  Latitude E5470
+ *  Latitude E5270
+ *  Latitude E7470
+ *  Latitude E7270
+ *  Latitude E7450
+ *  Latitude E7250
+ *  Latitude E5550
+ *  Latitude E5450
+ *  Latitude E5250
+ *  Latitude Rugged 5414
+ *  Latitude Rugged 7214
+ *  Latitude Rugged 7414


### PR DESCRIPTION
Hi fwupd developers,

First of all many thanks for your all efforts and work put into this project!

This PR adds the Dell TB18DC docking station to the readme of the synapticsmst plugin which might be helpful to others in the future. 

I have a Dell Precision 7530 with a TB18DC dock. Upgrading the Synaptics MST chips failed with the official tools on Windows, but the fwupd lists them properly so it turned out that they have the latest (3.12.0.2) firmware so all of my unsuccessful efforts of the upgrade was pointless on Windows. 
