### PR TITLE
ebitdo: Fix the reported version number if the daemon locale is not C…

### DIFF
--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -215,7 +215,7 @@ static void
 fu_ebitdo_device_set_version (FuEbitdoDevice *self, guint32 version)
 {
 	g_autofree gchar *tmp = NULL;
-	tmp = g_strdup_printf ("%.2f", version / 100.f);
+	tmp = g_strdup_printf ("%u.%02u", version / 100, version % 100);
 	fu_device_set_version (FU_DEVICE (self), tmp);
 }
 


### PR DESCRIPTION
….UTF-8

Always use a dot as the delimiter of a semver rather than treating it as a
floating point number.

Related to https://github.com/hughsie/lvfs-website/issues/216