### PR TITLE
Fix building with -Wl,-z,defs

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -111,6 +111,7 @@ add_project_arguments(cc.get_supported_arguments(warning_flags), language : 'c')
 global_link_args = []
 test_link_args = [
   '-Wl,-z,relro',
+  '-Wl,-z,defs',
   '-Wl,-z,now',
 ]
 foreach arg: test_link_args

--- a/plugins/altos/meson.build
+++ b/plugins/altos/meson.build
@@ -17,6 +17,9 @@ shared_module('fu_plugin_altos',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     libelf,

--- a/plugins/amt/meson.build
+++ b/plugins/amt/meson.build
@@ -11,6 +11,9 @@ shared_module('fu_plugin_amt',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     plugin_deps,

--- a/plugins/colorhug/meson.build
+++ b/plugins/colorhug/meson.build
@@ -19,6 +19,9 @@ shared_module('fu_plugin_colorhug',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     plugin_deps,

--- a/plugins/csr/meson.build
+++ b/plugins/csr/meson.build
@@ -22,6 +22,7 @@ shared_module('fu_plugin_csr',
     plugin_deps,
   ],
   link_with : [
+    libfwupdprivate,
     dfu,
   ],
 )

--- a/plugins/dell-dock/meson.build
+++ b/plugins/dell-dock/meson.build
@@ -21,6 +21,9 @@ shared_module('fu_plugin_dell_dock',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     plugin_deps,

--- a/plugins/dell-esrt/meson.build
+++ b/plugins/dell-esrt/meson.build
@@ -12,8 +12,11 @@ shared_module('fu_plugin_dell_esrt',
   install : true,
   install_dir: plugin_dir,
   c_args : [
-      cargs,
-    ],
+    cargs,
+  ],
+  link_with : [
+    libfwupdprivate,
+  ],
   dependencies : [
     plugin_deps,
     libsmbios_c,

--- a/plugins/dell/meson.build
+++ b/plugins/dell/meson.build
@@ -16,9 +16,12 @@ shared_module('fu_plugin_dell',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : [
-      cargs,
-    ],
+    cargs,
+  ],
   dependencies : [
     plugin_deps,
     efivar,
@@ -51,7 +54,6 @@ if get_option('tests')
       valgrind,
     ],
     link_with : [
-      fwupd,
       libfwupdprivate,
     ],
     c_args : [

--- a/plugins/dfu/meson.build
+++ b/plugins/dfu/meson.build
@@ -31,6 +31,9 @@ dfu = static_library(
     gusb,
     gudev,
   ],
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   include_directories : [
     include_directories('../..'),
@@ -55,6 +58,7 @@ shared_module('fu_plugin_dfu',
     plugin_deps,
   ],
   link_with : [
+    libfwupdprivate,
     dfu,
   ],
 )
@@ -79,7 +83,6 @@ dfu_tool = executable(
   ],
   link_with : [
     dfu,
-    fwupd,
     libfwupdprivate,
   ],
   c_args : cargs,
@@ -130,7 +133,6 @@ if get_option('tests')
     ],
     link_with : [
       dfu,
-      fwupd,
       libfwupdprivate,
     ],
     c_args : cargs

--- a/plugins/ebitdo/meson.build
+++ b/plugins/ebitdo/meson.build
@@ -17,6 +17,9 @@ shared_module('fu_plugin_ebitdo',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     plugin_deps,

--- a/plugins/fastboot/meson.build
+++ b/plugins/fastboot/meson.build
@@ -16,6 +16,9 @@ shared_module('fu_plugin_fastboot',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     plugin_deps,

--- a/plugins/flashrom/meson.build
+++ b/plugins/flashrom/meson.build
@@ -15,6 +15,9 @@ shared_module('fu_plugin_flashrom',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : [
     cargs,
     '-DLOCALSTATEDIR="' + localstatedir + '"',

--- a/plugins/nitrokey/meson.build
+++ b/plugins/nitrokey/meson.build
@@ -17,6 +17,9 @@ shared_module('fu_plugin_nitrokey',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     plugin_deps,

--- a/plugins/nvme/meson.build
+++ b/plugins/nvme/meson.build
@@ -16,6 +16,9 @@ shared_module('fu_plugin_nvme',
     cargs,
     '-DLOCALSTATEDIR="' + localstatedir + '"',
   ],
+  link_with : [
+    libfwupdprivate,
+  ],
   dependencies : [
     plugin_deps,
     efivar,
@@ -42,7 +45,6 @@ if get_option('tests')
       efivar,
     ],
     link_with : [
-      fwupd,
       libfwupdprivate,
     ],
     c_args : cargs

--- a/plugins/redfish/meson.build
+++ b/plugins/redfish/meson.build
@@ -13,6 +13,9 @@ shared_module('fu_plugin_redfish',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     plugin_deps,
@@ -44,7 +47,6 @@ if get_option('tests')
       libjsonglib,
     ],
     link_with : [
-      fwupd,
       libfwupdprivate,
     ],
     c_args : cargs

--- a/plugins/rts54hid/meson.build
+++ b/plugins/rts54hid/meson.build
@@ -19,6 +19,9 @@ shared_module('fu_plugin_rts54hid',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     plugin_deps,

--- a/plugins/rts54hub/meson.build
+++ b/plugins/rts54hub/meson.build
@@ -18,6 +18,9 @@ shared_module('fu_plugin_rts54hub',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     plugin_deps,

--- a/plugins/steelseries/meson.build
+++ b/plugins/steelseries/meson.build
@@ -16,6 +16,9 @@ shared_module('fu_plugin_steelseries',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     plugin_deps,

--- a/plugins/superio/meson.build
+++ b/plugins/superio/meson.build
@@ -16,6 +16,9 @@ shared_module('fu_plugin_superio',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     plugin_deps,

--- a/plugins/synapticsmst/meson.build
+++ b/plugins/synapticsmst/meson.build
@@ -18,8 +18,11 @@ shared_module('fu_plugin_synapticsmst',
   install : true,
   install_dir: plugin_dir,
   c_args : [
-      cargs,
-    ],
+    cargs,
+  ],
+  link_with : [
+    libfwupdprivate,
+  ],
   dependencies : [
     plugin_deps,
   ],
@@ -47,7 +50,6 @@ if get_option('tests')
       valgrind,
     ],
     link_with : [
-      fwupd,
       libfwupdprivate,
     ],
     c_args : [

--- a/plugins/test/meson.build
+++ b/plugins/test/meson.build
@@ -16,6 +16,9 @@ shared_module('fu_plugin_test',
   ],
   install : install_dummy,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     plugin_deps,

--- a/plugins/thunderbolt-power/meson.build
+++ b/plugins/thunderbolt-power/meson.build
@@ -11,6 +11,9 @@ fu_plugin_thunderbolt_power = shared_module('fu_plugin_thunderbolt_power',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     plugin_deps,

--- a/plugins/thunderbolt/meson.build
+++ b/plugins/thunderbolt/meson.build
@@ -12,6 +12,9 @@ fu_plugin_thunderbolt = shared_module('fu_plugin_thunderbolt',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     plugin_deps,
@@ -33,7 +36,6 @@ executable('tbtfwucli',
   c_args : cargs,
   link_with : [
     fu_plugin_thunderbolt,
-    fwupd,
     libfwupdprivate,
   ],
   dependencies : [
@@ -62,7 +64,6 @@ if get_option('tests') and umockdev.found() and gio.version().version_compare('>
       umockdev,
     ],
     link_with : [
-      fwupd,
       libfwupdprivate,
     ],
     c_args : cargs

--- a/plugins/udev/meson.build
+++ b/plugins/udev/meson.build
@@ -12,6 +12,9 @@ shared_module('fu_plugin_udev',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     plugin_deps,
@@ -33,7 +36,6 @@ executable(
     plugin_deps,
   ],
   link_with : [
-    fwupd,
     libfwupdprivate,
   ],
   c_args : cargs,
@@ -59,7 +61,6 @@ if get_option('tests')
       plugin_deps,
     ],
     link_with : [
-      fwupd,
       libfwupdprivate,
     ],
     c_args : cargs

--- a/plugins/uefi/meson.build
+++ b/plugins/uefi/meson.build
@@ -26,6 +26,9 @@ shared_module('fu_plugin_uefi',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     plugin_deps,
@@ -62,7 +65,6 @@ executable(
     efiboot,
   ],
   link_with : [
-    fwupd,
     libfwupdprivate,
   ],
   install : true,
@@ -101,7 +103,6 @@ if get_option('tests')
       efiboot,
     ],
     link_with : [
-      fwupd,
       libfwupdprivate,
     ],
     c_args : cargs

--- a/plugins/unifying/meson.build
+++ b/plugins/unifying/meson.build
@@ -26,6 +26,9 @@ shared_module('fu_plugin_unifying',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     plugin_deps,
@@ -47,7 +50,7 @@ if get_option('tests')
       plugin_deps,
     ],
     link_with : [
-      fwupd,
+      libfwupdprivate,
     ],
     c_args : cargs,
   )

--- a/plugins/upower/meson.build
+++ b/plugins/upower/meson.build
@@ -11,6 +11,9 @@ shared_module('fu_plugin_upower',
   ],
   install : true,
   install_dir: plugin_dir,
+  link_with : [
+    libfwupdprivate,
+  ],
   c_args : cargs,
   dependencies : [
     plugin_deps,

--- a/plugins/wacom-usb/meson.build
+++ b/plugins/wacom-usb/meson.build
@@ -27,6 +27,7 @@ shared_module('fu_plugin_wacom_usb',
     plugin_deps,
   ],
   link_with : [
+    libfwupdprivate,
     dfu,
   ],
 )
@@ -57,7 +58,6 @@ if get_option('tests')
     ],
     link_with : [
       dfu,
-      fwupd,
       libfwupdprivate,
     ],
     c_args : cargs

--- a/src/meson.build
+++ b/src/meson.build
@@ -59,6 +59,9 @@ libfwupdprivate = static_library(
     valgrind,
     uuid,
   ],
+  link_with : [
+    fwupd,
+  ],
   c_args : [
     '-DFU_OFFLINE_DESTDIR=""',
   ],


### PR DESCRIPTION
This allows us to find undefined references at compile time, not runtime.