### PR TITLE
dell-dock: Fixes for board 4

### DIFF
--- a/plugins/dell-dock/dell-dock.quirk
+++ b/plugins/dell-dock/dell-dock.quirk
@@ -70,8 +70,8 @@ FirmwareSizeMax = 0x20000
 Flags = require-ac
 Children = FuDellDockStatus|USB\VID_413C&PID_B06E&hub&status,FuDellDockMst|MST-panamera-vmm5331-259
 DellDockUnlockTarget = 1
-DellDockBoardMin = 2
-DellDockVersionLowest = 00.00.00.09
+DellDockBoardMin = 4
+DellDockVersionLowest = 00.00.00.17
 DellDockBlobVersionOffset = 0x1AFC0
 InstallDuration = 60
 
@@ -114,14 +114,3 @@ FirmwareSizeMin=0x40000
 FirmwareSizeMax=0x80000
 Flags = require-ac
 InstallDuration = 22
-
-# Thunderbolt controller (old ID)
-# TODO: This should be dropped when DellDockBoardMin is 3+
-[Guid=TBT-00d40012]
-Name = Thunderbolt controller in Dell dock
-Summary = Thunderbolt controller
-Vendor = Dell Inc
-ParentGuid = USB\VID_413C&PID_B06E&hub&embedded
-FirmwareSizeMin=0x40000
-FirmwareSizeMax=0x80000
-Flags = require-ac,ignore-validation

--- a/plugins/dell-dock/fu-dell-dock-common.c
+++ b/plugins/dell-dock/fu-dell-dock-common.c
@@ -47,10 +47,12 @@ fu_dell_dock_set_power (FuDevice *device, guint8 target,
 void
 fu_dell_dock_will_replug (FuDevice *device)
 {
+	guint64 timeout = fu_device_get_install_duration (device);
+
 	g_return_if_fail (FU_IS_DEVICE (device));
 
-	g_debug ("Activated %ds replug delay for %s",
-		 REPLUG_TIMEOUT, fu_device_get_name (device));
-	fu_device_set_remove_delay (device, REPLUG_TIMEOUT * 1000);
+	g_debug ("Activated %" G_GUINT64_FORMAT "s replug delay for %s",
+		 timeout, fu_device_get_name (device));
+	fu_device_set_remove_delay (device, timeout * 1000);
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
 }

--- a/plugins/dell-dock/fu-dell-dock-common.h
+++ b/plugins/dell-dock/fu-dell-dock-common.h
@@ -27,7 +27,6 @@
 
 #define 	DELL_DOCK_EC_GUID		"USB\\VID_413C&PID_B06E&hub&embedded"
 #define 	DELL_DOCK_TBT_GUID		"TBT-00d4b070"
-#define		REPLUG_TIMEOUT			60 /* s */
 
 gboolean	fu_dell_dock_set_power		(FuDevice *device,
 						 guint8 target,

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -593,6 +593,16 @@ guint32
 fu_dell_dock_ec_get_status_version (FuDevice *device)
 {
 	FuDellDockEc *self = FU_DELL_DOCK_EC (device);
+
+	/* TODO: drop if setting minimum board to 5+
+	 * this board was manufactured with 89.16.01.00 and won't upgrade
+	 */
+	if (self->data->board_id == 4 &&
+	    self->raw_versions->pkg_version == 71305) {
+		g_printerr ("Dock manufactured w/ invalid package %u\n",
+			    self->raw_versions->pkg_version);
+		self->raw_versions->pkg_version = 0;
+	}
 	return self->raw_versions->pkg_version;
 }
 

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -369,6 +369,12 @@ fu_dell_dock_ec_get_dock_info (FuDevice *device,
 		}
 	}
 
+	/* Thunderbolt SKU takes a little longer */
+	if (self->data->module_type == MODULE_TYPE_TBT) {
+		guint64 tmp = fu_device_get_install_duration (device);
+		fu_device_set_install_duration (device, tmp + 20);
+	}
+
 	/* minimum EC version this code will support */
 	if (fu_common_vercmp (self->ec_version, self->ec_minimum_version) < 0) {
 		g_set_error (error, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED,

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -529,7 +529,6 @@ fu_dell_dock_ec_reset (FuDevice *device, GError **error)
 gboolean
 fu_dell_dock_ec_reboot_dock (FuDevice *device, GError **error)
 {
-	FuDellDockEc *self = FU_DELL_DOCK_EC (device);
 	guint16 cmd = EC_CMD_REBOOT;
 
 	g_return_val_if_fail (device != NULL, FALSE);
@@ -539,10 +538,6 @@ fu_dell_dock_ec_reboot_dock (FuDevice *device, GError **error)
 		return TRUE;
 	}
 
-	/* TODO: Drop when bumping minimum EC version to 13+ */
-	if (fu_common_vercmp (self->ec_version, "00.00.00.13") < 0)
-		g_print ("\nEC Reboot API may fail on EC %s.  Please manually power cycle dock.\n",
-			   self->ec_version);
 	g_debug ("Rebooting %s", fu_device_get_name (device));
 
 	return fu_dell_dock_ec_write (device, 2, (guint8 *) &cmd, error);
@@ -633,13 +628,6 @@ fu_dell_dock_ec_commit_package (FuDevice *device, GBytes *blob_fw,
 	g_debug ("\thub2_version: %x", self->raw_versions->hub2_version);
 	g_debug ("\ttbt_version: %x", self->raw_versions->tbt_version);
 	g_debug ("\tpkg_version: %x", self->raw_versions->pkg_version);
-
-	/* TODO: Drop when updating minimum EC to 11+ */
-	if (fu_common_vercmp (self->ec_version, "00.00.00.11") < 0) {
-		g_debug ("EC %s doesn't support package version, ignoring",
-			 self->ec_version);
-		return TRUE;
-	}
 
 	payload [0] = EC_CMD_SET_DOCK_PKG;
 	payload [1] = length;

--- a/plugins/dell-dock/fu-dell-dock-i2c-mst.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-mst.c
@@ -425,35 +425,6 @@ fu_d19_mst_check_fw (FuDevice *symbiote, GError **error)
 }
 
 static gboolean
-fu_dell_dock_mst_get_version_direct (FuDevice *symbiote, gchar **version_out,
-				     GError **error)
-{
-	g_autoptr(GBytes) bytes = NULL;
-	const guint8 *data;
-	gsize length = 4;
-
-	g_return_val_if_fail (version_out != NULL, FALSE);
-
-	/* Try to read core MCU FW version */
-	if (!fu_dell_dock_mst_read_register (symbiote,
-					     MST_CORE_MCU_FW_VERSION,
-					     length, &bytes,
-					     error))
-		return FALSE;
-	data = g_bytes_get_data (bytes, &length);
-	if (length < 4) {
-		g_set_error (error, G_IO_ERROR, G_IO_ERROR_FAILED,
-			     "Invalid MST result %" G_GSIZE_FORMAT, length);
-		return FALSE;
-	}
-	*version_out = g_strdup_printf ("%02x.%02x.%02x",
-					data[1],    /* major */
-					data[0],    /* minor */
-					data[2]);   /* build */
-	return TRUE;
-}
-
-static gboolean
 fu_dell_dock_mst_checksum_bank (FuDevice *symbiote,
 				GBytes *blob_fw,
 				MSTBank bank,
@@ -923,7 +894,6 @@ fu_dell_dock_mst_setup (FuDevice *device, GError **error)
 	FuDellDockMst *self = FU_DELL_DOCK_MST (device);
 	FuDevice *parent;
 	const gchar *version;
-	g_autofree gchar *dynamic_version = NULL;
 
 	/* sanity check that we can talk to MST */
 	if (!fu_d19_mst_check_fw (self->symbiote, error))
@@ -933,14 +903,6 @@ fu_dell_dock_mst_setup (FuDevice *device, GError **error)
 	parent = fu_device_get_parent (device);
 	version = fu_dell_dock_ec_get_mst_version (parent);
 
-	/* TODO: Drop when we can guarantee EC 15+ */
-	if (version == NULL) {
-		if (!fu_dell_dock_mst_get_version_direct (self->symbiote,
-							  &dynamic_version,
-							  error))
-			return FALSE;
-		version = dynamic_version;
-	}
 	if (version != NULL)
 		fu_device_set_version (device, version);
 


### PR DESCRIPTION
Type of pull request:
- [X] Code fix

This resets the minimum requirement in fwupd to board ID #4.  Really it's still all API compatible, but cleans up the code for stuff that will never be seen in production.