### PR TITLE
Make policykit optional (Fixes #920)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -163,9 +163,12 @@ libjsonglib = dependency('json-glib-1.0', version : '>= 1.1.1')
 valgrind = dependency('valgrind', required: false)
 soup = dependency('libsoup-2.4', version : '>= 2.51.92')
 if get_option('daemon')
-  polkit = dependency('polkit-gobject-1', version : '>= 0.103')
-  if polkit.version().version_compare('>= 0.114')
-    conf.set('HAVE_POLKIT_0_114', '1')
+  if get_option ('policykit')
+    polkit = dependency('polkit-gobject-1', version : '>= 0.103')
+    conf.set('HAVE_POLKIT', '1')
+    if polkit.version().version_compare('>= 0.114')
+      conf.set('HAVE_POLKIT_0_114', '1')
+    endif
   endif
   udevdir = get_option('udevdir')
   if udevdir == ''
@@ -322,7 +325,7 @@ if get_option('gtkdoc')
 endif
 subdir('libfwupd')
 subdir('po')
-if get_option('daemon')
+if get_option('daemon') and get_option ('policykit')
   subdir('policy')
 endif
 subdir('src')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,6 +6,7 @@ option('introspection', type : 'boolean', value : true, description : 'generate 
 option('lvfs', type : 'boolean', value : true, description : 'enable LVFS remotes')
 option('man', type : 'boolean', value : true, description : 'enable man pages')
 option('pkcs7', type : 'boolean', value : true, description : 'enable the PKCS7 verification support')
+option('policykit', type: 'boolean', value : true, description: 'enable policykit support')
 option('plugin_altos', type : 'boolean', value : true, description : 'enable altos support')
 option('plugin_amt', type : 'boolean', value : true, description : 'enable Intel AMT support')
 option('plugin_dell', type : 'boolean', value : true, description : 'enable Dell-specific support')

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,6 +7,7 @@ endif
 keyring_deps = []
 keyring_src = []
 test_deps = []
+daemon_deps = []
 
 if get_option('gpg')
   keyring_src += 'fu-keyring-gpg.c'
@@ -68,6 +69,11 @@ libfwupdprivate = static_library(
 )
 
 if get_option('daemon')
+
+if get_option ('policykit')
+  daemon_deps += polkit
+endif
+
 fwupdmgr = executable(
   'fwupdmgr',
   sources : [
@@ -231,13 +237,13 @@ executable(
   ],
   dependencies : [
     keyring_deps,
+    daemon_deps,
     libxmlb,
     libgcab,
     giounix,
     gmodule,
     gudev,
     gusb,
-    polkit,
     soup,
     sqlite,
     valgrind,


### PR DESCRIPTION
This causes all requests to be allowed.  It shouldn't be used in most
general purpose distributions.  It's intended for ChromeOS systems where
PolicyKit will not be used.

Type of pull request:
- [X] Feature

After more discussion in https://chromium-review.googlesource.com/c/chromiumos/overlays/portage-stable/+/1396829/ there are strong views that policy kit should not be used in ChromeOS.

ChromeOS will not be using any web remotes such as LVFS.  GPG verification or PKCS7 verification will also not be used.  CAB files corresponding to supported updates for the system will be preloaded into the ChromeOS filesystem when the OS image is generated.