### PR TITLE
upower: Add support for checking battery percentage

### DIFF
--- a/plugins/upower/fu-plugin-upower.c
+++ b/plugins/upower/fu-plugin-upower.c
@@ -8,8 +8,11 @@
 
 #include "fu-plugin-vfuncs.h"
 
+#define MINIMUM_BATTERY_PERCENTAGE	30
+
 struct FuPluginData {
-	GDBusProxy		*proxy;
+	GDBusProxy		*upower_proxy;
+	GDBusProxy		*display_proxy;
 };
 
 void
@@ -22,15 +25,17 @@ void
 fu_plugin_destroy (FuPlugin *plugin)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
-	if (data->proxy != NULL)
-		g_object_unref (data->proxy);
+	if (data->upower_proxy != NULL)
+		g_object_unref (data->upower_proxy);
+	if (data->display_proxy != NULL)
+		g_object_unref (data->display_proxy);
 }
 
 gboolean
 fu_plugin_startup (FuPlugin *plugin, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
-	data->proxy =
+	data->upower_proxy =
 		g_dbus_proxy_new_for_bus_sync (G_BUS_TYPE_SYSTEM,
 					       G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS,
 					       NULL,
@@ -39,11 +44,72 @@ fu_plugin_startup (FuPlugin *plugin, GError **error)
 					       "org.freedesktop.UPower",
 					       NULL,
 					       error);
-	if (data->proxy == NULL) {
+	if (data->upower_proxy == NULL) {
 		g_prefix_error (error, "failed to connect to upower: ");
 		return FALSE;
 	}
+	data->display_proxy =
+		g_dbus_proxy_new_for_bus_sync (G_BUS_TYPE_SYSTEM,
+					       G_DBUS_PROXY_FLAGS_DO_NOT_CONNECT_SIGNALS,
+					       NULL,
+					       "org.freedesktop.UPower",
+					       "/org/freedesktop/UPower/devices/DisplayDevice",
+					       "org.freedesktop.UPower.Device",
+					       NULL,
+					       error);
+	if (data->display_proxy == NULL) {
+		g_prefix_error (error, "failed to connect to upower: ");
+		return FALSE;
+	}
+
 	return TRUE;
+}
+
+static gboolean
+fu_plugin_upower_check_percentage_level (FuPlugin *plugin)
+{
+	FuPluginData *data = fu_plugin_get_data (plugin);
+	gdouble level;
+	guint power_type;
+	g_autoptr(GVariant) percentage_val = NULL;
+	g_autoptr(GVariant) type_val = NULL;
+
+	/* check that we "have" a battery */
+	type_val = g_dbus_proxy_get_cached_property (data->display_proxy, "Type");
+	if (type_val == NULL) {
+		g_warning ("Failed to query power type, assume AC power");
+		return TRUE;
+	}
+	power_type = g_variant_get_uint32 (type_val);
+	if (power_type != 2) {
+		g_debug ("Not running on battery (Type: %u)", power_type);
+		return TRUE;
+	}
+
+	/* check percentage high enough */
+	percentage_val = g_dbus_proxy_get_cached_property (data->display_proxy, "Percentage");
+	if (percentage_val == NULL) {
+		g_warning ("Failed to query power percentage level, assume enough charge");
+		return TRUE;
+	}
+	level = g_variant_get_double (percentage_val);
+	g_debug ("System power source is %.1f%%", level);
+
+	return level >= MINIMUM_BATTERY_PERCENTAGE;
+}
+
+static gboolean
+fu_plugin_upower_check_on_battery (FuPlugin *plugin)
+{
+	FuPluginData *data = fu_plugin_get_data (plugin);
+	g_autoptr(GVariant) value = NULL;
+
+	value = g_dbus_proxy_get_cached_property (data->upower_proxy, "OnBattery");
+	if (value == NULL) {
+		g_warning ("failed to get OnBattery value, assume on AC power");
+		return TRUE;
+	}
+	return g_variant_get_boolean (value);
 }
 
 gboolean
@@ -52,23 +118,30 @@ fu_plugin_update_prepare (FuPlugin *plugin,
 			  FuDevice *device,
 			  GError **error)
 {
-	FuPluginData *data = fu_plugin_get_data (plugin);
-	g_autoptr(GVariant) value = NULL;
-
-	/* can we only do this on AC power */
+	/* not all devices need this */
 	if (!fu_device_has_flag (device, FWUPD_DEVICE_FLAG_REQUIRE_AC))
 		return TRUE;
-	value = g_dbus_proxy_get_cached_property (data->proxy, "OnBattery");
-	if (value == NULL) {
-		g_warning ("failed to get OnBattery value, assume on AC power");
-		return TRUE;
-	}
-	if (g_variant_get_boolean (value) && (flags & FWUPD_INSTALL_FLAG_FORCE) == 0) {
+
+	/* determine if operating on AC or battery */
+	if (fu_plugin_upower_check_on_battery (plugin) &&
+	    (flags & FWUPD_INSTALL_FLAG_FORCE) == 0) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_AC_POWER_REQUIRED,
 				     "Cannot install update "
 				     "when not on AC power unless forced");
+		return FALSE;
+	}
+
+	/* deteremine if battery high enough */
+	if (!fu_plugin_upower_check_percentage_level (plugin) &&
+	   (flags & FWUPD_INSTALL_FLAG_FORCE) == 0) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_AC_POWER_REQUIRED,
+			     "Cannot install update when battery "
+			     "is not at least %d%% unless forced",
+			      MINIMUM_BATTERY_PERCENTAGE);
 		return FALSE;
 	}
 	return TRUE;


### PR DESCRIPTION
On any devices that normally would require checking for AC also
check that at least one battery on the system has at least 30% to
perform an update.

Fixes: #925

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
