### PR TITLE
trivial: meson.build: Fix builds with -Ddaemon=false but no other cha…

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -3,8 +3,10 @@ subdir('pki')
 subdir('remotes.d')
 subdir('bash-completion')
 
-if get_option('tests') and get_option('daemon')
+if get_option('tests')
   subdir('tests')
+endif
+if get_option('daemon')
   subdir('installed-tests')
 endif
 


### PR DESCRIPTION
…nges

Without this fix build will fail like below:
```
$ meson build -Ddaemon=false
.
.
.

src/meson.build:21:4: ERROR:  Unknown variable "colorhug_pkcs7_signature".
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
