### PR TITLE
uefi: Do not check the BGRT status before uploading a UX capsule

### DIFF
--- a/plugins/uefi/fu-uefi-bgrt.c
+++ b/plugins/uefi/fu-uefi-bgrt.c
@@ -24,7 +24,6 @@ gboolean
 fu_uefi_bgrt_setup (FuUefiBgrt *self, GError **error)
 {
 	gsize sz = 0;
-	guint64 status;
 	guint64 type;
 	guint64 version;
 	g_autofree gchar *bgrtdir = NULL;
@@ -41,14 +40,6 @@ fu_uefi_bgrt_setup (FuUefiBgrt *self, GError **error)
 				     G_IO_ERROR,
 				     G_IO_ERROR_NOT_SUPPORTED,
 				     "BGRT is not supported");
-		return FALSE;
-	}
-	status = fu_uefi_read_file_as_uint64 (bgrtdir, "status");
-	if (status != 1) {
-		g_set_error (error,
-			     G_IO_ERROR,
-			     G_IO_ERROR_NOT_SUPPORTED,
-			     "BGRT status was %" G_GUINT64_FORMAT, status);
 		return FALSE;
 	}
 	type = fu_uefi_read_file_as_uint64 (bgrtdir, "type");


### PR DESCRIPTION
Microsoft description about the Status is:

    The Status field of the BGRT describes whether the image is currently
    displayed on the screen. This is not applicable to the firmware update
    display capsule.

Many thanks to Steven Chang for identifying this issue.

Fixes: https://github.com/hughsie/fwupd/issues/935

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
