### PR TITLE
uefi: Add a quirk to use the legacy bootmgr description

### DIFF
--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -511,6 +511,12 @@ fu_plugin_uefi_coldplug_device (FuPlugin *plugin, FuUefiDevice *dev, GError **er
 	if (!fu_device_probe (FU_DEVICE (dev), error))
 		return FALSE;
 
+	/* set this flag for all Lenovo hardware */
+	if (fu_plugin_check_hwid (plugin, "6de5d951-d755-576b-bd09-c5cf66b27234")) {
+		fu_device_set_custom_flags (FU_DEVICE (dev), "use-legacy-bootmgr-desc");
+		fu_plugin_add_report_metadata (plugin, "BootMgrDesc", "legacy");
+	}
+
 	/* set fallback name if nothing else is set */
 	if (fu_device_get_name (FU_DEVICE (dev)) == 0) {
 		g_autofree gchar *name = NULL;

--- a/plugins/uefi/fu-uefi-bootmgr.c
+++ b/plugins/uefi/fu-uefi-bootmgr.c
@@ -292,7 +292,10 @@ fu_uefi_copy_asset (const gchar *source, const gchar *target, GError **error)
 }
 
 gboolean
-fu_uefi_bootmgr_bootnext (const gchar *esp_path, FuUefiBootmgrFlags flags, GError **error)
+fu_uefi_bootmgr_bootnext (const gchar *esp_path,
+			  const gchar *description,
+			  FuUefiBootmgrFlags flags,
+			  GError **error)
 {
 	gboolean use_fwup_path = FALSE;
 	gsize loader_sz = 0;
@@ -382,7 +385,7 @@ fu_uefi_bootmgr_bootnext (const gchar *esp_path, FuUefiBootmgrFlags flags, GErro
 		return FALSE;
 	}
 
-	label = g_strdup ("Linux Firmware Updater");
+	label = g_strdup (description);
 	sz = efi_loadopt_create (opt, opt_size, attributes,
 				 (efidp)dp_buf, dp_size,
 				 (guint8 *)label,

--- a/plugins/uefi/fu-uefi-bootmgr.h
+++ b/plugins/uefi/fu-uefi-bootmgr.h
@@ -20,6 +20,7 @@ typedef enum {
 } FuUefiBootmgrFlags;
 
 gboolean	 fu_uefi_bootmgr_bootnext	(const gchar		*esp_path,
+						 const gchar		*description,
 						 FuUefiBootmgrFlags	 flags,
 						 GError			**error);
 

--- a/plugins/uefi/fu-uefi-device.c
+++ b/plugins/uefi/fu-uefi-device.c
@@ -353,6 +353,7 @@ fu_uefi_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
 {
 	FuUefiDevice *self = FU_UEFI_DEVICE (device);
 	FuUefiBootmgrFlags flags = FU_UEFI_BOOTMGR_FLAG_NONE;
+	const gchar *bootmgr_desc = "Linux Firmware Updater";
 	const gchar *esp_path = fu_device_get_metadata (device, "EspPath");
 	efi_guid_t guid;
 	efi_update_info_t info;
@@ -423,7 +424,11 @@ fu_uefi_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
 	/* update the firmware before the bootloader runs */
 	if (fu_device_get_metadata_boolean (device, "RequireShimForSecureBoot"))
 		flags |= FU_UEFI_BOOTMGR_FLAG_USE_SHIM_FOR_SB;
-	if (!fu_uefi_bootmgr_bootnext (esp_path, flags, error))
+
+	/* some legacy devices use the old name to deduplicate boot entries */
+	if (fu_device_has_custom_flag (device, "use-legacy-bootmgr-desc"))
+		bootmgr_desc = "Linux-Firmware-Updater";
+	if (!fu_uefi_bootmgr_bootnext (esp_path, bootmgr_desc, flags, error))
 		return FALSE;
 
 	/* success! */


### PR DESCRIPTION
Some hardware from Lenovo deduplicates UEFI Boot entries, and uses the old
string 'Linux-Firmware-Updater' to avoid removing the firmware update entry.
Although this is forbidden in the UEFI specification we shouldn't break
firmware updates from old firmware versions.

Provide a quirk for this, and automatically whitelist anything with the LENOVO
SMBIOS Manufacturer.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
