### PR TITLE
Check if plugin changed after the device attaches or detaches

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1563,6 +1563,13 @@ fu_engine_install_blob (FuEngine *self,
 		g_prefix_error (error, "failed to get device after detach: ");
 		return FALSE;
 	}
+
+	/* get new plugin after detach */
+	plugin = fu_plugin_list_find_by_name (self->plugin_list,
+					      fu_device_get_plugin (device),
+					      error);
+	if (plugin == NULL)
+		return FALSE;
 	if (!fu_plugin_runner_update (plugin,
 				      device,
 				      blob_cab,
@@ -1629,6 +1636,13 @@ fu_engine_install_blob (FuEngine *self,
 		g_prefix_error (error, "failed to get device after attach: ");
 		return FALSE;
 	}
+
+	/* get new plugin after attach */
+	plugin = fu_plugin_list_find_by_name (self->plugin_list,
+					      fu_device_get_plugin (device),
+					      error);
+	if (plugin == NULL)
+		return FALSE;
 
 	/* get the new version number */
 	if (!fu_plugin_runner_update_reload (plugin, device, error)) {


### PR DESCRIPTION
If the device is rebooted into a different shape, the plugin managing
the device may also be different.

This would be the case for plugins that just subclass the update_detach()
method, and leave to other plugins the actual required update procedure.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
