### PR TITLE
uefi: Correct a boot order creation bug (Fixes: #956)

### DIFF
--- a/plugins/uefi/fu-uefi-bootmgr.c
+++ b/plugins/uefi/fu-uefi-bootmgr.c
@@ -108,7 +108,7 @@ fu_uefi_setup_bootnext_with_dp (const guint8 *dp_buf, guint8 *opt, gssize opt_si
 		efidp found_dp;
 		g_autofree guint8 *var_data_tmp = NULL;
 
-		if (efi_guid_cmp (guid, &efi_guid_global) == 0)
+		if (efi_guid_cmp (guid, &efi_guid_global) != 0)
 			continue;
 		rc = sscanf (name, "Boot%hX%n", &entry, &scanned);
 		if (rc < 0) {


### PR DESCRIPTION
Unfortunately the previous fix (6131f5d) introduced this bug.

The code previously was actually looking for the non-zero case
which was correct, but non-obvious since `efi_guid_cmp` works like
`g_strcmp0` where a match returns zero.

So rather than revert 6131f5d make this completly explicit.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
