### PR TITLE
Fix Storage invalid firmware version read #960

### DIFF
--- a/plugins/nitrokey/fu-nitrokey-common.h
+++ b/plugins/nitrokey/fu-nitrokey-common.h
@@ -23,20 +23,20 @@ guint32		 fu_nitrokey_perform_crc32	(const guint8	*data,
 #define NITROKEY_CMD_GET_DEVICE_STATUS		(0x20 + 14)
 
 typedef struct __attribute__((packed)) {
-    guint8		command;
-    guint8		payload[NITROKEY_REQUEST_DATA_LENGTH];
-    guint32		crc;
+        guint8		command;
+        guint8		payload[NITROKEY_REQUEST_DATA_LENGTH];
+        guint32		crc;
 } NitrokeyHidRequest;
 
 
 
 typedef struct __attribute__((packed)) {
-    guint8		device_status;
-    guint8		command_id;
-    guint32		last_command_crc;
-    guint8		last_command_status;
-    guint8		payload[NITROKEY_REPLY_DATA_LENGTH];
-    guint32		crc;
+        guint8		device_status;
+        guint8		command_id;
+        guint32		last_command_crc;
+        guint8		last_command_status;
+        guint8		payload[NITROKEY_REPLY_DATA_LENGTH];
+        guint32		crc;
 } NitrokeyHidResponse;
 
 
@@ -44,29 +44,29 @@ typedef struct __attribute__((packed)) {
  * libnitrokey v3.4.1
  * */
 typedef struct __attribute__((packed)) {
-    guint8		_padding[18]; /* stick20_commands.h:132 // 26 - 8 = 18 */
-    guint8		SendCounter;
-    guint8		SendDataType;
-    guint8		FollowBytesFlag;
-    guint8		SendSize;
-    guint16		MagicNumber_StickConfig;
-    guint8		ReadWriteFlagUncryptedVolume;
-    guint8		ReadWriteFlagCryptedVolume;
-    guint8		VersionMajor;
-    guint8		VersionMinor;
-    guint8		VersionReservedByte;
-    guint8		VersionBuildIteration;
-    guint8		ReadWriteFlagHiddenVolume;
-    guint8		FirmwareLocked;
-    guint8		NewSDCardFound;
-    guint8		SDFillWithRandomChars;
-    guint32		ActiveSD_CardID;
-    guint8		VolumeActiceFlag;
-    guint8		NewSmartCardFound;
-    guint8		UserPwRetryCount;
-    guint8		AdminPwRetryCount;
-    guint32		ActiveSmartCardID;
-    guint8		StickKeysNotInitiated;
+        guint8		_padding[18]; /* stick20_commands.h:132 // 26 - 8 = 18 */
+        guint8		SendCounter;
+        guint8		SendDataType;
+        guint8		FollowBytesFlag;
+        guint8		SendSize;
+        guint16		MagicNumber_StickConfig;
+        guint8		ReadWriteFlagUncryptedVolume;
+        guint8		ReadWriteFlagCryptedVolume;
+        guint8		VersionMajor;
+        guint8		VersionMinor;
+        guint8		VersionReservedByte;
+        guint8		VersionBuildIteration;
+        guint8		ReadWriteFlagHiddenVolume;
+        guint8		FirmwareLocked;
+        guint8		NewSDCardFound;
+        guint8		SDFillWithRandomChars;
+        guint32		ActiveSD_CardID;
+        guint8		VolumeActiceFlag;
+        guint8		NewSmartCardFound;
+        guint8		UserPwRetryCount;
+        guint8		AdminPwRetryCount;
+        guint32		ActiveSmartCardID;
+        guint8		StickKeysNotInitiated;
 } NitrokeyGetDeviceStatusPayload;
 
 G_END_DECLS

--- a/plugins/nitrokey/fu-nitrokey-common.h
+++ b/plugins/nitrokey/fu-nitrokey-common.h
@@ -14,6 +14,61 @@ G_BEGIN_DECLS
 guint32		 fu_nitrokey_perform_crc32	(const guint8	*data,
 						 gsize		 size);
 
+#define NITROKEY_TRANSACTION_TIMEOUT		100 /* ms */
+#define NITROKEY_NR_RETRIES			5
+
+#define NITROKEY_REQUEST_DATA_LENGTH		59
+#define NITROKEY_REPLY_DATA_LENGTH		53
+
+#define NITROKEY_CMD_GET_DEVICE_STATUS		(0x20 + 14)
+
+typedef struct __attribute__((packed)) {
+    guint8		command;
+    guint8		payload[NITROKEY_REQUEST_DATA_LENGTH];
+    guint32		crc;
+} NitrokeyHidRequest;
+
+
+
+typedef struct __attribute__((packed)) {
+    guint8		device_status;
+    guint8		command_id;
+    guint32		last_command_crc;
+    guint8		last_command_status;
+    guint8		payload[NITROKEY_REPLY_DATA_LENGTH];
+    guint32		crc;
+} NitrokeyHidResponse;
+
+
+/* based from libnitrokey/stick20_commands.h
+ * libnitrokey v3.4.1
+ * */
+typedef struct __attribute__((packed)) {
+    guint8		_padding[18]; /* stick20_commands.h:132 // 26 - 8 = 18 */
+    guint8		SendCounter;
+    guint8		SendDataType;
+    guint8		FollowBytesFlag;
+    guint8		SendSize;
+    guint16		MagicNumber_StickConfig;
+    guint8		ReadWriteFlagUncryptedVolume;
+    guint8		ReadWriteFlagCryptedVolume;
+    guint8		VersionMajor;
+    guint8		VersionMinor;
+    guint8		VersionReservedByte;
+    guint8		VersionBuildIteration;
+    guint8		ReadWriteFlagHiddenVolume;
+    guint8		FirmwareLocked;
+    guint8		NewSDCardFound;
+    guint8		SDFillWithRandomChars;
+    guint32		ActiveSD_CardID;
+    guint8		VolumeActiceFlag;
+    guint8		NewSmartCardFound;
+    guint8		UserPwRetryCount;
+    guint8		AdminPwRetryCount;
+    guint32		ActiveSmartCardID;
+    guint8		StickKeysNotInitiated;
+} NitrokeyGetDeviceStatusPayload;
+
 G_END_DECLS
 
 #endif /* __FU_NITROKEY_COMMON_H */

--- a/plugins/nitrokey/fu-nitrokey-device.c
+++ b/plugins/nitrokey/fu-nitrokey-device.c
@@ -13,55 +13,6 @@
 
 G_DEFINE_TYPE (FuNitrokeyDevice, fu_nitrokey_device, FU_TYPE_USB_DEVICE)
 
-#define NITROKEY_TRANSACTION_TIMEOUT		100 /* ms */
-#define NITROKEY_NR_RETRIES			5
-
-#define NITROKEY_REQUEST_DATA_LENGTH		59
-#define NITROKEY_REPLY_DATA_LENGTH		53
-
-#define NITROKEY_CMD_GET_DEVICE_STATUS		(0x20 + 14)
-
-typedef struct __attribute__((packed)) {
-	guint8		command;
-	guint8		payload[NITROKEY_REQUEST_DATA_LENGTH];
-	guint32		crc;
-} NitrokeyHidRequest;
-
-typedef struct __attribute__((packed)) {
-	guint8		_padding; /* always zero */
-	guint8		device_status;
-	guint32		last_command_crc;
-	guint8		last_command_status;
-	guint8		payload[NITROKEY_REPLY_DATA_LENGTH];
-	guint32		crc;
-} NitrokeyHidResponse;
-
-/* based from libnitrokey/stick20_commands.h */
-typedef struct __attribute__((packed)) {
-	guint8		_padding[24];
-	guint8		SendCounter;
-	guint8		SendDataType;
-	guint8		FollowBytesFlag;
-	guint8		SendSize;
-	guint16		MagicNumber_StickConfig;
-	guint8		ReadWriteFlagUncryptedVolume;
-	guint8		ReadWriteFlagCryptedVolume;
-	guint8		VersionReserved1;
-	guint8		VersionMinor;
-	guint8		VersionReserved2;
-	guint8		VersionMajor;
-	guint8		ReadWriteFlagHiddenVolume;
-	guint8		FirmwareLocked;
-	guint8		NewSDCardFound;
-	guint8		SDFillWithRandomChars;
-	guint32		ActiveSD_CardID;
-	guint8		VolumeActiceFlag;
-	guint8		NewSmartCardFound;
-	guint8		UserPwRetryCount;
-	guint8		AdminPwRetryCount;
-	guint32		ActiveSmartCardID;
-	guint8		StickKeysNotInitiated;
-} NitrokeyGetDeviceStatusPayload;
 
 static void
 _dump_to_console (const gchar *title, const guint8 *buf, gsize buf_sz)
@@ -240,8 +191,8 @@ fu_nitrokey_device_setup (FuDevice *device, GError **error)
 		return FALSE;
 	}
 	_dump_to_console ("payload", buf_reply, sizeof(buf_reply));
-	memcpy (&payload, buf_reply, sizeof(buf_reply));
-	version = g_strdup_printf ("%u.%u", payload.VersionMinor, payload.VersionMajor);
+	memcpy (&payload, buf_reply, sizeof(payload));
+	version = g_strdup_printf ("%u.%u", payload.VersionMajor, payload.VersionMinor);
 	fu_device_set_version (FU_DEVICE (device), version);
 
 	/* success */

--- a/plugins/nitrokey/fu-self-test.c
+++ b/plugins/nitrokey/fu-self-test.c
@@ -16,8 +16,7 @@ fu_nitrokey_version_test (void)
         /* use the Nitrokey Storage v0.53 status response for test, CRC 0xa2762d14 */
         NitrokeyGetDeviceStatusPayload payload;
         NitrokeyHidResponse res;
-        guint32
-        crc_tmp;
+        guint32 crc_tmp;
         /* 65 bytes of response from HIDAPI; first byte is always 0*/
         const guint8 buf[] = {
                     /*0x00,*/

--- a/plugins/nitrokey/fu-self-test.c
+++ b/plugins/nitrokey/fu-self-test.c
@@ -11,79 +11,80 @@
 #include "fu-nitrokey-common.h"
 
 static void
-fu_nitrokey_version_test(void)
+fu_nitrokey_version_test (void)
 {
-    /* use the Nitrokey Storage v0.53 status response for test, CRC 0xa2762d14 */
-    NitrokeyGetDeviceStatusPayload payload;
-    NitrokeyHidResponse res;
-    guint32 crc_tmp;
-    /* 65 bytes of response from HIDAPI; first byte is always 0*/
-    const guint8 buf[] =  {
-                /*0x00,*/
-                0x00,0x2e,0xef,0xc4,0x9b,0x84,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
-                0x00,0x00,0x00,0x00,0x00,0x0c,0x2e,0x01,0x00,0x00,0x00,0x03,0x00,0x1c,0x18,0x33,
-                0x00,0x00,0x00,0x35,0x00,0x00,0x00,0x00,0x00,0x01,0x45,0x24,0xf1,0x4c,0x01,0x00,
-                0x03,0x03,0xc7,0x37,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x14,0x2d,0x76,
-                0xa2 };
+        /* use the Nitrokey Storage v0.53 status response for test, CRC 0xa2762d14 */
+        NitrokeyGetDeviceStatusPayload payload;
+        NitrokeyHidResponse res;
+        guint32
+        crc_tmp;
+        /* 65 bytes of response from HIDAPI; first byte is always 0*/
+        const guint8 buf[] = {
+                    /*0x00,*/
+                    0x00, 0x2e, 0xef, 0xc4, 0x9b, 0x84, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x0c, 0x2e, 0x01, 0x00, 0x00, 0x00, 0x03, 0x00, 0x1c, 0x18, 0x33,
+                    0x00, 0x00, 0x00, 0x35, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x45, 0x24, 0xf1, 0x4c, 0x01, 0x00,
+                    0x03, 0x03, 0xc7, 0x37, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x14, 0x2d, 0x76,
+                    0xa2};
 
-    /* testing the whole path, as in fu_nitrokey_device_setup()*/
-    memcpy (&res, buf, sizeof(buf));
-    memcpy (&payload, &res.payload, sizeof(payload));
+        /* testing the whole path, as in fu_nitrokey_device_setup()*/
+        memcpy (&res, buf, sizeof (buf));
+        memcpy (&payload, &res.payload, sizeof (payload));
 
-    /* verify the version number */
-    g_assert_cmpint (payload.VersionMajor, ==, 0);
-    g_assert_cmpint (payload.VersionMinor, ==, 53);
-    g_assert_cmpint (buf[34], ==, payload.VersionMinor);
-    g_assert_cmpint (payload.VersionBuildIteration, ==, 0);
+        /* verify the version number */
+        g_assert_cmpint (payload.VersionMajor, == , 0);
+        g_assert_cmpint (payload.VersionMinor, == , 53);
+        g_assert_cmpint (buf[34], == , payload.VersionMinor);
+        g_assert_cmpint (payload.VersionBuildIteration, == , 0);
 
-    /* verify the response checksum */
-    crc_tmp = fu_nitrokey_perform_crc32 (buf, sizeof(res) - 4);
-    g_assert_cmpint ( GUINT32_FROM_LE (res.crc), ==, crc_tmp);
+        /* verify the response checksum */
+        crc_tmp = fu_nitrokey_perform_crc32 (buf, sizeof (res) - 4);
+        g_assert_cmpint (GUINT32_FROM_LE (res.crc), == , crc_tmp);
 
 }
 
 static void
-fu_nitrokey_version_test_static(void)
+fu_nitrokey_version_test_static (void)
 {
-    /* Use static response from numbered bytes, to make sure fields occupy expected bytes */
-    NitrokeyGetDeviceStatusPayload payload;
-    NitrokeyHidResponse res;
+        /* Use static response from numbered bytes, to make sure fields occupy expected bytes */
+        NitrokeyGetDeviceStatusPayload payload;
+        NitrokeyHidResponse res;
 
-    const guint8 buf[] =  {
-                0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F,
-                0x10,0x11,0x12,0x13,0x14,0x15,0x16,0x17,0x18,0x19,0x1A,0x1B,0x1C,0x1D,0x1E,0x1F,
-                0x20,0x21,0x22,0x23,0x24,0x25,0x26,0x27,0x28,0x29,0x2A,0x2B,0x2C,0x2D,0x2E,0x2F,
-                0x30,0x31,0x32,0x33,0x34,0x35,0x36,0x37,0x38,0x39,0x3A,0x3B,0x3C,0x3D,0x3E,0x3F,
-                };
-    memcpy (&res, buf, sizeof(buf));
-    memcpy (&payload, &res.payload, sizeof(payload));
-    g_assert_cmpint (payload.VersionMajor, ==, 33); /*0x1A*/
-    g_assert_cmpint (payload.VersionMinor, ==, 34); /*0x1B*/
-    g_assert_cmpint (buf[34], ==, 34);
+        const guint8 buf[] = {
+                    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
+                    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F,
+                    0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B, 0x2C, 0x2D, 0x2E, 0x2F,
+                    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3A, 0x3B, 0x3C, 0x3D, 0x3E, 0x3F,
+        };
+        memcpy (&res, buf, sizeof (buf));
+        memcpy (&payload, &res.payload, sizeof (payload));
+        g_assert_cmpint (payload.VersionMajor, == , 33); /*0x1A*/
+        g_assert_cmpint (payload.VersionMinor, == , 34); /*0x1B*/
+        g_assert_cmpint (buf[34], == , 34);
 }
 
 static void
 fu_nitrokey_func (void)
 {
-    const guint8 buf[] =  { 0x00, 0x01, 0x02, 0x03,
-                0x04, 0x05, 0x06, 0x07,
-                0x08, 0x09, 0x0a, 0x0b,
-                0x0c, 0x0d, 0x0e, 0x0f };
-    g_assert_cmpint (fu_nitrokey_perform_crc32 (buf, 16), ==, 0x081B46CA);
-    g_assert_cmpint (fu_nitrokey_perform_crc32 (buf, 15), ==, 0xED7320AB);
+        const guint8 buf[] = {0x00, 0x01, 0x02, 0x03,
+                              0x04, 0x05, 0x06, 0x07,
+                              0x08, 0x09, 0x0a, 0x0b,
+                              0x0c, 0x0d, 0x0e, 0x0f};
+        g_assert_cmpint (fu_nitrokey_perform_crc32 (buf, 16), == , 0x081B46CA);
+        g_assert_cmpint (fu_nitrokey_perform_crc32 (buf, 15), == , 0xED7320AB);
 }
 
 int
 main (int argc, char **argv)
 {
-    g_test_init (&argc, &argv, NULL);
+        g_test_init (&argc, &argv, NULL);
 
-    /* only critical and error are fatal */
-    g_log_set_fatal_mask (NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
+        /* only critical and error are fatal */
+        g_log_set_fatal_mask (NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
 
-    /* tests go here */
-    g_test_add_func ("/fwupd/nitrokey", fu_nitrokey_func);
-    g_test_add_func ("/fwupd/nitrokey-version-static", fu_nitrokey_version_test_static);
-    g_test_add_func ("/fwupd/nitrokey-version", fu_nitrokey_version_test);
-    return g_test_run ();
+        /* tests go here */
+        g_test_add_func ("/fwupd/nitrokey", fu_nitrokey_func);
+        g_test_add_func ("/fwupd/nitrokey-version-static", fu_nitrokey_version_test_static);
+        g_test_add_func ("/fwupd/nitrokey-version", fu_nitrokey_version_test);
+        return g_test_run ();
 }

--- a/plugins/nitrokey/fu-self-test.c
+++ b/plugins/nitrokey/fu-self-test.c
@@ -11,25 +11,79 @@
 #include "fu-nitrokey-common.h"
 
 static void
+fu_nitrokey_version_test(void)
+{
+    /* use the Nitrokey Storage v0.53 status response for test, CRC 0xa2762d14 */
+    NitrokeyGetDeviceStatusPayload payload;
+    NitrokeyHidResponse res;
+    guint32 crc_tmp;
+    /* 65 bytes of response from HIDAPI; first byte is always 0*/
+    const guint8 buf[] =  {
+                /*0x00,*/
+                0x00,0x2e,0xef,0xc4,0x9b,0x84,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                0x00,0x00,0x00,0x00,0x00,0x0c,0x2e,0x01,0x00,0x00,0x00,0x03,0x00,0x1c,0x18,0x33,
+                0x00,0x00,0x00,0x35,0x00,0x00,0x00,0x00,0x00,0x01,0x45,0x24,0xf1,0x4c,0x01,0x00,
+                0x03,0x03,0xc7,0x37,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x14,0x2d,0x76,
+                0xa2 };
+
+    /* testing the whole path, as in fu_nitrokey_device_setup()*/
+    memcpy (&res, buf, sizeof(buf));
+    memcpy (&payload, &res.payload, sizeof(payload));
+
+    /* verify the version number */
+    g_assert_cmpint (payload.VersionMajor, ==, 0);
+    g_assert_cmpint (payload.VersionMinor, ==, 53);
+    g_assert_cmpint (buf[34], ==, payload.VersionMinor);
+    g_assert_cmpint (payload.VersionBuildIteration, ==, 0);
+
+    /* verify the response checksum */
+    crc_tmp = fu_nitrokey_perform_crc32 (buf, sizeof(res) - 4);
+    g_assert_cmpint ( GUINT32_FROM_LE (res.crc), ==, crc_tmp);
+
+}
+
+static void
+fu_nitrokey_version_test_static(void)
+{
+    /* Use static response from numbered bytes, to make sure fields occupy expected bytes */
+    NitrokeyGetDeviceStatusPayload payload;
+    NitrokeyHidResponse res;
+
+    const guint8 buf[] =  {
+                0x00,0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0A,0x0B,0x0C,0x0D,0x0E,0x0F,
+                0x10,0x11,0x12,0x13,0x14,0x15,0x16,0x17,0x18,0x19,0x1A,0x1B,0x1C,0x1D,0x1E,0x1F,
+                0x20,0x21,0x22,0x23,0x24,0x25,0x26,0x27,0x28,0x29,0x2A,0x2B,0x2C,0x2D,0x2E,0x2F,
+                0x30,0x31,0x32,0x33,0x34,0x35,0x36,0x37,0x38,0x39,0x3A,0x3B,0x3C,0x3D,0x3E,0x3F,
+                };
+    memcpy (&res, buf, sizeof(buf));
+    memcpy (&payload, &res.payload, sizeof(payload));
+    g_assert_cmpint (payload.VersionMajor, ==, 33); /*0x1A*/
+    g_assert_cmpint (payload.VersionMinor, ==, 34); /*0x1B*/
+    g_assert_cmpint (buf[34], ==, 34);
+}
+
+static void
 fu_nitrokey_func (void)
 {
-	const guint8 buf[] =  { 0x00, 0x01, 0x02, 0x03,
-				0x04, 0x05, 0x06, 0x07,
-				0x08, 0x09, 0x0a, 0x0b,
-				0x0c, 0x0d, 0x0e, 0x0f };
-	g_assert_cmpint (fu_nitrokey_perform_crc32 (buf, 16), ==, 0x081B46CA);
-	g_assert_cmpint (fu_nitrokey_perform_crc32 (buf, 15), ==, 0xED7320AB);
+    const guint8 buf[] =  { 0x00, 0x01, 0x02, 0x03,
+                0x04, 0x05, 0x06, 0x07,
+                0x08, 0x09, 0x0a, 0x0b,
+                0x0c, 0x0d, 0x0e, 0x0f };
+    g_assert_cmpint (fu_nitrokey_perform_crc32 (buf, 16), ==, 0x081B46CA);
+    g_assert_cmpint (fu_nitrokey_perform_crc32 (buf, 15), ==, 0xED7320AB);
 }
 
 int
 main (int argc, char **argv)
 {
-	g_test_init (&argc, &argv, NULL);
+    g_test_init (&argc, &argv, NULL);
 
-	/* only critical and error are fatal */
-	g_log_set_fatal_mask (NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
+    /* only critical and error are fatal */
+    g_log_set_fatal_mask (NULL, G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL);
 
-	/* tests go here */
-	g_test_add_func ("/fwupd/nitrokey", fu_nitrokey_func);
-	return g_test_run ();
+    /* tests go here */
+    g_test_add_func ("/fwupd/nitrokey", fu_nitrokey_func);
+    g_test_add_func ("/fwupd/nitrokey-version-static", fu_nitrokey_version_test_static);
+    g_test_add_func ("/fwupd/nitrokey-version", fu_nitrokey_version_test);
+    return g_test_run ();
 }


### PR DESCRIPTION
This patch corrects the Nitrokey Storage firmware version getter plugin. 
Commit message:
>  Correct Nitrokey Storage invalid firmware version read
Currently used structures were based on early libnitrokey definitions
(which were broken for some time). Corrected their sizes and elements,
and added tests.

> Tested live on Fedora 29, with Nitrokey Storage v0.53.
Bundled tests pass on my build.

Fixes #960



Type of pull request:
- [ ] New plugin 
- [x] Code fix
- [ ] Feature
- [ ] Documentation
