### PR TITLE
Add support for an `UpdateMessage` and display it in tools

### DIFF
--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -380,6 +380,10 @@ fwupd_build_history_report_json_device (JsonBuilder *builder, FwupdDevice *dev)
 		json_builder_set_member_name (builder, "UpdateError");
 		json_builder_add_string_value (builder, fwupd_device_get_update_error (dev));
 	}
+	if (fwupd_release_get_update_message (rel) != NULL) {
+		json_builder_set_member_name (builder, "UpdateMessage");
+		json_builder_add_string_value (builder, fwupd_release_get_update_message (rel));
+	}
 
 	/* map back to the dev type on the LVFS */
 	json_builder_set_member_name (builder, "Guid");

--- a/libfwupd/fwupd-device.h
+++ b/libfwupd/fwupd-device.h
@@ -112,6 +112,9 @@ void		 fwupd_device_set_update_state		(FwupdDevice	*device,
 const gchar	*fwupd_device_get_update_error		(FwupdDevice	*device);
 void		 fwupd_device_set_update_error		(FwupdDevice	*device,
 							 const gchar	*update_error);
+const gchar	*fwupd_device_get_update_message	(FwupdDevice	*device);
+void		 fwupd_device_set_update_message	(FwupdDevice	*device,
+							 const gchar	*update_message);
 void		 fwupd_device_add_release		(FwupdDevice	*device,
 							 FwupdRelease	*release);
 GPtrArray	*fwupd_device_get_releases		(FwupdDevice	*device);

--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -34,6 +34,7 @@
 #define FWUPD_RESULT_KEY_SIZE			"Size"		/* t */
 #define FWUPD_RESULT_KEY_SUMMARY		"Summary"	/* s */
 #define FWUPD_RESULT_KEY_TRUST_FLAGS		"TrustFlags"	/* t */
+#define FWUPD_RESULT_KEY_UPDATE_MESSAGE		"UpdateMessage"	/* s */
 #define FWUPD_RESULT_KEY_UPDATE_ERROR		"UpdateError"	/* s */
 #define FWUPD_RESULT_KEY_UPDATE_STATE		"UpdateState"	/* u */
 #define FWUPD_RESULT_KEY_URI			"Uri"		/* s */

--- a/libfwupd/fwupd-release.h
+++ b/libfwupd/fwupd-release.h
@@ -96,6 +96,9 @@ void		 fwupd_release_set_trust_flags		(FwupdRelease	*release,
 guint32		 fwupd_release_get_install_duration	(FwupdRelease	*release);
 void		 fwupd_release_set_install_duration	(FwupdRelease	*release,
 							 guint32	 duration);
+const gchar	*fwupd_release_get_update_message	(FwupdRelease	*release);
+void		 fwupd_release_set_update_message	(FwupdRelease	*release,
+							 const gchar	*update_message);
 
 G_END_DECLS
 

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -297,9 +297,13 @@ LIBFWUPD_1.2.2 {
 LIBFWUPD_1.2.4 {
   global:
     fwupd_client_get_tainted;
+    fwupd_device_get_update_message;
+    fwupd_device_set_update_message;
     fwupd_release_get_details_url;
     fwupd_release_get_source_url;
+    fwupd_release_get_update_message;
     fwupd_release_set_details_url;
     fwupd_release_set_source_url;
+    fwupd_release_set_update_message;
   local: *;
 } LIBFWUPD_1.2.2;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -341,6 +341,9 @@ fu_engine_set_release_from_appstream (FuEngine *self,
 	tmp = xb_node_query_text (component, "custom/value[@key='LVFS::UpdateProtocol']", NULL);
 	if (tmp != NULL)
 		fwupd_release_set_protocol (rel, tmp);
+	tmp = xb_node_query_text (component, "custom/value[@key='LVFS::UpdateMessage']", NULL);
+	if (tmp != NULL)
+		fwupd_release_set_update_message (rel, tmp);
 }
 
 /* finds the remote-id for the first firmware in the silo that matches this
@@ -2612,6 +2615,7 @@ fu_engine_add_releases_for_device_component (FuEngine *self,
 	}
 	for (guint i = 0; i < releases_tmp->len; i++) {
 		XbNode *release = g_ptr_array_index (releases_tmp, i);
+		const gchar *update_message;
 		GPtrArray *checksums;
 		g_autoptr(FwupdRelease) rel = fwupd_release_new ();
 
@@ -2629,6 +2633,12 @@ fu_engine_add_releases_for_device_component (FuEngine *self,
 		if (checksums->len == 0)
 			continue;
 
+		/* add update message if exists but device doesn't already have one */
+		update_message = fwupd_release_get_update_message (rel);
+		if (fwupd_device_get_update_message (FWUPD_DEVICE (device)) == NULL &&
+		    update_message != NULL) {
+			    fwupd_device_set_update_message (FWUPD_DEVICE (device), update_message);
+		}
 		/* success */
 		g_ptr_array_add (releases, g_steal_pointer (&rel));
 	}


### PR DESCRIPTION
The idea is that if the user should know something about the device update
"after" it's succesfully completed then the plugin can set `UpdateMessage`
for the device and a client can show it.

An example would be a device that doesn't reboot on its own and the user
needs to power cycle it manually.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
