### PR TITLE
Add support for a per-release source and details URL

### DIFF
--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -20,6 +20,8 @@
 #define FWUPD_RESULT_KEY_INSTALL_DURATION	"InstallDuration"	/* u */
 #define FWUPD_RESULT_KEY_GUID			"Guid"		/* as */
 #define FWUPD_RESULT_KEY_HOMEPAGE		"Homepage"	/* s */
+#define FWUPD_RESULT_KEY_DETAILS_URL		"DetailsUrl"	/* s */
+#define FWUPD_RESULT_KEY_SOURCE_URL		"SourceUrl"	/* s */
 #define FWUPD_RESULT_KEY_ICON			"Icon"		/* as */
 #define FWUPD_RESULT_KEY_LICENSE		"License"	/* s */
 #define FWUPD_RESULT_KEY_MODIFIED		"Modified"	/* t */

--- a/libfwupd/fwupd-release.c
+++ b/libfwupd/fwupd-release.c
@@ -35,6 +35,8 @@ typedef struct {
 	gchar				*filename;
 	gchar				*protocol;
 	gchar				*homepage;
+	gchar				*details_url;
+	gchar				*source_url;
 	gchar				*appstream_id;
 	gchar				*license;
 	gchar				*name;
@@ -391,6 +393,78 @@ fwupd_release_set_homepage (FwupdRelease *release, const gchar *homepage)
 	g_return_if_fail (FWUPD_IS_RELEASE (release));
 	g_free (priv->homepage);
 	priv->homepage = g_strdup (homepage);
+}
+
+/**
+ * fwupd_release_get_details_url:
+ * @release: A #FwupdRelease
+ *
+ * Gets the URL for the online update notes.
+ *
+ * Returns: the update URL, or %NULL if unset
+ *
+ * Since: 1.2.4
+ **/
+const gchar *
+fwupd_release_get_details_url (FwupdRelease *release)
+{
+	FwupdReleasePrivate *priv = GET_PRIVATE (release);
+	g_return_val_if_fail (FWUPD_IS_RELEASE (release), NULL);
+	return priv->details_url;
+}
+
+/**
+ * fwupd_release_set_details_url:
+ * @release: A #FwupdRelease
+ * @details_url: the URL
+ *
+ * Sets the URL for the online update notes.
+ *
+ * Since: 1.2.4
+ **/
+void
+fwupd_release_set_details_url (FwupdRelease *release, const gchar *details_url)
+{
+	FwupdReleasePrivate *priv = GET_PRIVATE (release);
+	g_return_if_fail (FWUPD_IS_RELEASE (release));
+	g_free (priv->details_url);
+	priv->details_url = g_strdup (details_url);
+}
+
+/**
+ * fwupd_release_get_source_url:
+ * @release: A #FwupdRelease
+ *
+ * Gets the URL of the source code used to build this release.
+ *
+ * Returns: the update source_url, or %NULL if unset
+ *
+ * Since: 1.2.4
+ **/
+const gchar *
+fwupd_release_get_source_url (FwupdRelease *release)
+{
+	FwupdReleasePrivate *priv = GET_PRIVATE (release);
+	g_return_val_if_fail (FWUPD_IS_RELEASE (release), NULL);
+	return priv->source_url;
+}
+
+/**
+ * fwupd_release_set_source_url:
+ * @release: A #FwupdRelease
+ * @source_url: the URL
+ *
+ * Sets the URL of the source code used to build this release.
+ *
+ * Since: 1.2.4
+ **/
+void
+fwupd_release_set_source_url (FwupdRelease *release, const gchar *source_url)
+{
+	FwupdReleasePrivate *priv = GET_PRIVATE (release);
+	g_return_if_fail (FWUPD_IS_RELEASE (release));
+	g_free (priv->source_url);
+	priv->source_url = g_strdup (source_url);
 }
 
 /**
@@ -828,6 +902,16 @@ fwupd_release_to_variant (FwupdRelease *release)
 				       FWUPD_RESULT_KEY_HOMEPAGE,
 				       g_variant_new_string (priv->homepage));
 	}
+	if (priv->details_url != NULL) {
+		g_variant_builder_add (&builder, "{sv}",
+				       FWUPD_RESULT_KEY_DETAILS_URL,
+				       g_variant_new_string (priv->details_url));
+	}
+	if (priv->source_url != NULL) {
+		g_variant_builder_add (&builder, "{sv}",
+				       FWUPD_RESULT_KEY_SOURCE_URL,
+				       g_variant_new_string (priv->source_url));
+	}
 	if (priv->version != NULL) {
 		g_variant_builder_add (&builder, "{sv}",
 				       FWUPD_RESULT_KEY_VERSION,
@@ -909,6 +993,14 @@ fwupd_release_from_key_value (FwupdRelease *release, const gchar *key, GVariant 
 	}
 	if (g_strcmp0 (key, FWUPD_RESULT_KEY_HOMEPAGE) == 0) {
 		fwupd_release_set_homepage (release, g_variant_get_string (value, NULL));
+		return;
+	}
+	if (g_strcmp0 (key, FWUPD_RESULT_KEY_DETAILS_URL) == 0) {
+		fwupd_release_set_details_url (release, g_variant_get_string (value, NULL));
+		return;
+	}
+	if (g_strcmp0 (key, FWUPD_RESULT_KEY_SOURCE_URL) == 0) {
+		fwupd_release_set_source_url (release, g_variant_get_string (value, NULL));
 		return;
 	}
 	if (g_strcmp0 (key, FWUPD_RESULT_KEY_VERSION) == 0) {
@@ -1024,6 +1116,8 @@ fwupd_release_to_string (FwupdRelease *release)
 	fwupd_pad_kv_siz (str, FWUPD_RESULT_KEY_SIZE, priv->size);
 	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_URI, priv->uri);
 	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_HOMEPAGE, priv->homepage);
+	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_DETAILS_URL, priv->details_url);
+	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_SOURCE_URL, priv->source_url);
 	fwupd_pad_kv_str (str, FWUPD_RESULT_KEY_VENDOR, priv->vendor);
 	fwupd_pad_kv_tfl (str, FWUPD_RESULT_KEY_TRUST_FLAGS, priv->trust_flags);
 	fwupd_pad_kv_int (str, FWUPD_RESULT_KEY_INSTALL_DURATION, priv->install_duration);
@@ -1069,6 +1163,8 @@ fwupd_release_finalize (GObject *object)
 	g_free (priv->summary);
 	g_free (priv->uri);
 	g_free (priv->homepage);
+	g_free (priv->details_url);
+	g_free (priv->source_url);
 	g_free (priv->vendor);
 	g_free (priv->version);
 	g_free (priv->remote_id);

--- a/libfwupd/fwupd-release.h
+++ b/libfwupd/fwupd-release.h
@@ -78,6 +78,12 @@ void		 fwupd_release_set_description		(FwupdRelease	*release,
 const gchar	*fwupd_release_get_homepage		(FwupdRelease	*release);
 void		 fwupd_release_set_homepage		(FwupdRelease	*release,
 							 const gchar	*homepage);
+const gchar	*fwupd_release_get_details_url		(FwupdRelease	*release);
+void		 fwupd_release_set_details_url		(FwupdRelease	*release,
+							 const gchar	*details_url);
+const gchar	*fwupd_release_get_source_url		(FwupdRelease	*release);
+void		 fwupd_release_set_source_url		(FwupdRelease	*release,
+							 const gchar	*source_url);
 guint64		 fwupd_release_get_size			(FwupdRelease	*release);
 void		 fwupd_release_set_size			(FwupdRelease	*release,
 							 guint64	 size);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -297,5 +297,9 @@ LIBFWUPD_1.2.2 {
 LIBFWUPD_1.2.4 {
   global:
     fwupd_client_get_tainted;
+    fwupd_release_get_details_url;
+    fwupd_release_get_source_url;
+    fwupd_release_set_details_url;
+    fwupd_release_set_source_url;
   local: *;
 } LIBFWUPD_1.2.2;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -308,6 +308,12 @@ fu_engine_set_release_from_appstream (FuEngine *self,
 	tmp = xb_node_query_text (release, "checksum[@target='content']", NULL);
 	if (tmp != NULL)
 		fwupd_release_set_filename (rel, tmp);
+	tmp = xb_node_query_text (release, "url[@type='details']", NULL);
+	if (tmp != NULL)
+		fwupd_release_set_details_url (rel, tmp);
+	tmp = xb_node_query_text (release, "url[@type='source']", NULL);
+	if (tmp != NULL)
+		fwupd_release_set_source_url (rel, tmp);
 	tmp = xb_node_query_text (release, "checksum[@target='container']", NULL);
 	if (tmp != NULL)
 		fwupd_release_add_checksum (rel, tmp);


### PR DESCRIPTION
The source URL allows us to comply with our various obligations when shipping
firmware built from GPL licensed sources. The details URL allows vendors to
include a link to a full HTML details page about the specific release.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
