### PR TITLE
trivial: allow using python2.x instead

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -193,7 +193,10 @@ if libgcab.version().version_compare('>= 1.0')
 endif
 gcab = find_program('gcab', required : true)
 bashcomp = dependency('bash-completion', required: false)
-python3 = find_program('python3')
+python = find_program('python3', required: false)
+if not python.found()
+  python = find_program('python2')
+endif
 
 if valgrind.found()
   conf.set('HAVE_VALGRIND', '1')
@@ -238,7 +241,7 @@ if get_option('plugin_uefi')
           gnu_efi_arch = ''
   endif
   conf.set_quoted('EFI_MACHINE_TYPE_NAME', EFI_MACHINE_TYPE_NAME)
-  r = run_command([python3, 'po/test-deps'])
+  r = run_command([python, 'po/test-deps'])
   if r.returncode() != 0
     error(r.stdout())
   endif

--- a/po/meson.build
+++ b/po/meson.build
@@ -6,5 +6,5 @@ i18n.gettext(meson.project_name(),
 )
 
 if get_option('plugin_uefi')
-meson.add_install_script('make-images.sh', localedir, python3.path())
+meson.add_install_script('make-images.sh', localedir, python.path())
 endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -111,7 +111,7 @@ fu_hash = custom_target(
   'fu-hash.h',
   input : libfwupdprivate,
   output : 'fu-hash.h',
-  command : [python3.path(),
+  command : [python.path(),
              join_paths(meson.current_source_dir(), 'fu-hash.py'),
              '@INPUT@', '@OUTPUT@']
 )


### PR DESCRIPTION
Some environments such as ChromeOS SDK don't have python3.x available.

Allow using python2.x in such environments to generate the hash for
fu-hash.py.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
