### PR TITLE
fu-tool: Show UpdateMessage if applicable for install command

### DIFF
--- a/src/fu-device-private.h
+++ b/src/fu-device-private.h
@@ -8,6 +8,7 @@
 #define __FU_DEVICE_PRIVATE_H
 
 #include <fu-device.h>
+#include <xmlb.h>
 
 G_BEGIN_DECLS
 
@@ -26,6 +27,8 @@ void		 fu_device_set_alternate		(FuDevice	*self,
 							 FuDevice	*alternate);
 gboolean	 fu_device_ensure_id			(FuDevice	*self,
 							 GError		**error);
+void		 fu_device_incorporate_from_component	(FuDevice	*device,
+							 XbNode		*component);
 
 G_END_DECLS
 

--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -2089,6 +2089,24 @@ fu_device_incorporate (FuDevice *self, FuDevice *donor)
 		klass->incorporate (self, donor);
 }
 
+/**
+ * fu_device_incorporate_from_component:
+ * @self: A #FuDevice
+ * @component: A #XbNode
+ *
+ * Copy all properties from the donor AppStream component.
+ *
+ * Since: 1.2.4
+ **/
+void
+fu_device_incorporate_from_component (FuDevice *device, XbNode *component)
+{
+	const gchar *tmp;
+	tmp = xb_node_query_text (component, "custom/value[@key='LVFS::UpdateMessage']", NULL);
+	if (tmp != NULL)
+		fwupd_device_set_update_message (FWUPD_DEVICE (device), tmp);
+}
+
 static void
 fu_device_class_init (FuDeviceClass *klass)
 {

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -629,6 +629,9 @@ fu_main_install_with_helper (FuMainAuthHelper *helper_ref, GError **error)
 				continue;
 			}
 
+			/* if component should have an update message from CAB */
+			fu_device_incorporate_from_component (device, component);
+
 			/* get the action IDs for the valid device */
 			action_id = fu_install_task_get_action_id (task);
 			if (!g_ptr_array_find (helper->action_ids, action_id, NULL))

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -17,6 +17,7 @@
 #include <unistd.h>
 #include <libsoup/soup.h>
 
+#include "fu-device-private.h"
 #include "fu-engine.h"
 #include "fu-plugin-private.h"
 #include "fu-progressbar.h"
@@ -822,6 +823,9 @@ fu_util_install (FuUtilPrivate *priv, gchar **values, GError **error)
 				g_ptr_array_add (errors, g_steal_pointer (&error_local));
 				continue;
 			}
+
+			/* if component should have an update message from CAB */
+			fu_device_incorporate_from_component (device, component);
 
 			/* success */
 			g_ptr_array_add (install_tasks, g_steal_pointer (&task));


### PR DESCRIPTION
When calling with a CAB as an install argument, this needs to be
manually populated since the release won't be built.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
