### PR TITLE
trivial: upower: correct a logic error from ed021ab

### DIFF
--- a/plugins/upower/fu-plugin-upower.c
+++ b/plugins/upower/fu-plugin-upower.c
@@ -108,7 +108,7 @@ fu_plugin_upower_check_on_battery (FuPlugin *plugin)
 	value = g_dbus_proxy_get_cached_property (data->upower_proxy, "OnBattery");
 	if (value == NULL) {
 		g_warning ("failed to get OnBattery value, assume on AC power");
-		return TRUE;
+		return FALSE;
 	}
 	return g_variant_get_boolean (value);
 }


### PR DESCRIPTION
When unable to read battery value this should return FALSE to indicate
AC power.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

This was the error showing up otherwise:
```
20:36:34:0982 FuPluginUpower       failed to get OnBattery value, assume on AC power
20:36:34:0982 FuPlugin             performing composite_cleanup() on dell_dock
20:36:34:0982 FuIdle               uninhibiting: performing update
failed to update_prepare using upower: Cannot install update when not on AC power unless forced
```