### PR TITLE
fu-progressbar: be more quiet when running non-interactive

### DIFF
--- a/src/fu-progressbar.c
+++ b/src/fu-progressbar.c
@@ -29,6 +29,7 @@ struct _FuProgressbar
 	gint64			 last_animated;		/* monotonic */
 	GTimer			*time_elapsed;
 	gdouble			 last_estimate;
+	gboolean		 interactive;
 };
 
 G_DEFINE_TYPE (FuProgressbar, fu_progressbar, G_TYPE_OBJECT)
@@ -271,6 +272,14 @@ fu_progressbar_update (FuProgressbar *self, FwupdStatus status, guint percentage
 	if (status == FWUPD_STATUS_UNKNOWN)
 		status = self->status;
 
+	if (!self->interactive) {
+		if (self->status != status) {
+			g_print ("%s\n", fu_progressbar_status_to_string (status));
+			self->status = status;
+		}
+		return;
+	}
+
 	/* if the main loop isn't spinning and we've not had a chance to
 	 * execute the callback just do the refresh now manually */
 	if (percentage == 0 &&
@@ -303,6 +312,13 @@ fu_progressbar_update (FuProgressbar *self, FwupdStatus status, guint percentage
 }
 
 void
+fu_progressbar_set_interactive (FuProgressbar *self, gboolean interactive)
+{
+	g_return_if_fail (FU_IS_PROGRESSBAR (self));
+	self->interactive = interactive;
+}
+
+void
 fu_progressbar_set_length_status (FuProgressbar *self, guint len)
 {
 	g_return_if_fail (FU_IS_PROGRESSBAR (self));
@@ -332,6 +348,7 @@ fu_progressbar_init (FuProgressbar *self)
 	self->length_status = 25;
 	self->spinner_count_up = TRUE;
 	self->time_elapsed = g_timer_new ();
+	self->interactive = TRUE;
 }
 
 static void

--- a/src/fu-progressbar.h
+++ b/src/fu-progressbar.h
@@ -26,6 +26,8 @@ void		 fu_progressbar_set_length_percentage	(FuProgressbar	*self,
 							 guint		 len);
 void		 fu_progressbar_set_title		(FuProgressbar	*self,
 							 const gchar	*title);
+void		 fu_progressbar_set_interactive		(FuProgressbar *self,
+							 gboolean interactive);
 
 G_END_DECLS
 

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -1343,8 +1343,10 @@ main (int argc, char *argv[])
 			  (GCompareFunc) fu_sort_command_name_cb);
 
 	/* non-TTY consoles cannot answer questions */
-	if (isatty (fileno (stdout)) == 0)
+	if (isatty (fileno (stdout)) == 0) {
 		priv->no_reboot_check = TRUE;
+		fu_progressbar_set_interactive (priv->progressbar, FALSE);
+	}
 
 	/* get a list of the commands */
 	priv->context = g_option_context_new (NULL);

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -2466,6 +2466,7 @@ main (int argc, char *argv[])
 		priv->no_unreported_check = TRUE;
 		priv->no_metadata_check = TRUE;
 		priv->no_reboot_check = TRUE;
+		fu_progressbar_set_interactive (priv->progressbar, FALSE);
 	}
 
 	/* get a list of the commands */


### PR DESCRIPTION
If fwupdmgr or fwupdtool are scripted all the erasing of lines and
progressbars are much less useful.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Without this fix this is what logs look like:
```
Decompressing?           [-                                      ]Decompressing?           [***************************************]
Loading?                 [ -                                     ]Loading?                 [ -                                     ]Loading?                 [***************************************]
Decompressing?           [  -                                    ]Decompressing?           [  -                                    ]Decompressing?    
```