### PR TITLE
QMI PDC support for MCFG file downloading in the MM plugin

### DIFF
--- a/contrib/PKGBUILD
+++ b/contrib/PKGBUILD
@@ -8,7 +8,7 @@ pkgdesc='A simple daemon to allow session software to update firmware'
 arch=('i686' 'x86_64')
 url='https://github.com/hughsie/fwupd'
 license=('GPL2')
-depends=('libgusb')
+depends=('libgusb' 'modemmanager')
 optdepends=('tpm2-abrmd' 'tpm2-tools')
 makedepends=('meson' 'valgrind' 'gobject-introspection' 'gtk-doc' 'python-pillow' 'git'
              'python-cairo' 'noto-fonts' 'noto-fonts-cjk' 'python-gobject' 'vala'

--- a/contrib/ci/centos.sh
+++ b/contrib/ci/centos.sh
@@ -9,6 +9,7 @@ meson .. \
 	--werror \
 	-Dplugin_uefi=false \
 	-Dplugin_dell=false \
+	-Dplugin_modem_manager=false \
 	-Dplugin_synaptics=true \
 	-Dintrospection=true \
 	-Dgtkdoc=true \

--- a/contrib/ci/debian_s390x.sh
+++ b/contrib/ci/debian_s390x.sh
@@ -18,6 +18,7 @@ meson .. \
 	--werror \
 	-Dplugin_uefi=false \
 	-Dplugin_dell=false \
+	-Dplugin_modem_manager=false \
 	-Dplugin_redfish=false \
 	-Dintrospection=false \
 	-Dgtkdoc=false \

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -921,6 +921,27 @@
       <package variant="x86_64" />
     </distro>
   </dependency>
+  <dependency type="build" id="libqmi-glib-dev">
+    <distro id="centos">
+      <package>libqmi-devel</package>
+    </distro>
+    <distro id="fedora">
+      <package>libqmi-devel</package>
+    </distro>
+    <distro id="arch">
+      <package>libqmi</package>
+    </distro>
+    <distro id="debian">
+      <control />
+      <package variant="x86_64" />
+      <package variant="s390x">libqmi-glib-dev:s390x</package>
+      <package variant="i386" />
+    </distro>
+    <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+  </dependency>
   <dependency type="build" id="libpolkit-gobject-1-dev">
     <distro id="centos">
       <package>polkit-devel</package>

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -900,6 +900,27 @@
       <package variant="x86_64" />
     </distro>
   </dependency>
+  <dependency type="build" id="libmm-glib-dev">
+    <distro id="centos">
+      <package>ModemManager-glib-devel</package>
+    </distro>
+    <distro id="fedora">
+      <package>ModemManager-glib-devel</package>
+    </distro>
+    <distro id="arch">
+      <package>modemmanager</package>
+    </distro>
+    <distro id="debian">
+      <control />
+      <package variant="x86_64" />
+      <package variant="s390x">libmm-glib-dev:s390x</package>
+      <package variant="i386" />
+    </distro>
+    <distro id="ubuntu">
+      <control />
+      <package variant="x86_64" />
+    </distro>
+  </dependency>
   <dependency type="build" id="libpolkit-gobject-1-dev">
     <distro id="centos">
       <package>polkit-devel</package>

--- a/contrib/ci/fedora.sh
+++ b/contrib/ci/fedora.sh
@@ -12,6 +12,7 @@ meson .. \
     -Dman=true \
     -Dtests=true \
     -Dplugin_dummy=true \
+    -Dplugin_modem_manager=true \
     -Dplugin_thunderbolt=true \
     -Dplugin_uefi=true \
     -Dplugin_dell=true \

--- a/contrib/debian/lintian/fwupd
+++ b/contrib/debian/lintian/fwupd
@@ -6,3 +6,4 @@ fwupd binary: systemd-service-file-missing-install-key lib/systemd/system/system
 fwupd: library-not-linked-against-libc usr/lib/*/fwupd-plugins-3/libfu_plugin_upower.so
 #EFI applications are PE executables
 fwupd: executable-not-elf-or-script usr/lib/fwupd/efi/*.efi
+fwupd: library-not-linked-against-libc usr/lib/*/fwupd-plugins-3/libfu_plugin_modem_manager.so

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -61,6 +61,7 @@ BuildRequires: help2man
 BuildRequires: json-glib-devel >= %{json_glib_version}
 BuildRequires: vala
 BuildRequires: bash-completion
+#BuildRequires: ModemManager-glib-devel >= 1.9.1
 
 %if 0%{?have_redfish}
 BuildRequires: efivar-devel >= 33
@@ -269,6 +270,7 @@ mkdir -p --mode=0700 $RPM_BUILD_ROOT%{_localstatedir}/lib/fwupd/gnupg
 %{_libdir}/fwupd-plugins-3/libfu_plugin_ebitdo.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_fastboot.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_flashrom.so
+#%{_libdir}/fwupd-plugins-3/libfu_plugin_modem_manager.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_nitrokey.so
 %if 0%{?have_uefi}
 %{_libdir}/fwupd-plugins-3/libfu_plugin_nvme.so

--- a/meson.build
+++ b/meson.build
@@ -252,6 +252,11 @@ if get_option('plugin_dell')
   endif
 endif
 
+if get_option('plugin_modem_manager')
+  libmm_glib = dependency('mm-glib', version : '>= 1.9.1')
+  add_project_arguments('-DMM_REQUIRED_VERSION="1.9.1"', language : 'c')
+endif
+
 if get_option('plugin_nvme')
   if not cc.has_header('linux/nvme_ioctl.h')
     error('NVMe support requires kernel >= 4.4')

--- a/meson.build
+++ b/meson.build
@@ -255,6 +255,8 @@ endif
 if get_option('plugin_modem_manager')
   libmm_glib = dependency('mm-glib', version : '>= 1.9.1')
   add_project_arguments('-DMM_REQUIRED_VERSION="1.9.1"', language : 'c')
+  libqmi_glib = dependency('qmi-glib', version : '>= 1.22.0')
+  add_project_arguments('-DQMI_REQUIRED_VERSION="1.22.0"', language : 'c')
 endif
 
 if get_option('plugin_nvme')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -15,6 +15,7 @@ option('plugin_thunderbolt', type : 'boolean', value : true, description : 'enab
 option('plugin_redfish', type : 'boolean', value : true, description : 'enable Redfish support')
 option('plugin_uefi', type : 'boolean', value : true, description : 'enable UEFI support')
 option('plugin_nvme', type : 'boolean', value : true, description : 'enable NVMe support')
+option('plugin_modem_manager', type : 'boolean', value : false, description : 'enable ModemManager support')
 option('systemd', type : 'boolean', value : true, description : 'enable systemd support')
 option('systemdunitdir', type: 'string', value: '', description: 'Directory for systemd units')
 option('tests', type : 'boolean', value : true, description : 'enable tests')

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -24,6 +24,10 @@ if get_option('plugin_nvme')
 subdir('nvme')
 endif
 
+if get_option('plugin_modem_manager')
+subdir('modem-manager')
+endif
+
 if get_option('plugin_altos')
 subdir('altos')
 endif

--- a/plugins/modem-manager/README.md
+++ b/plugins/modem-manager/README.md
@@ -1,0 +1,17 @@
+ModemManager
+============
+
+Introduction
+------------
+
+This plugin adds support for devices managed by ModemManager.
+
+GUID Generation
+---------------
+
+These device use the ModemManager "Firmware Device IDs" as the GUID, e.g.
+
+ * `USB\VID_413C&PID_81D7&REV_0318&CARRIER_VODAFONE`
+ * `USB\VID_413C&PID_81D7&REV_0318`
+ * `USB\VID_413C&PID_81D7`
+ * `USB\VID_413C`

--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -1,0 +1,338 @@
+/*
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include <string.h>
+
+#include "fu-io-channel.h"
+#include "fu-mm-device.h"
+
+struct _FuMmDevice {
+	FuDevice			 parent_instance;
+	FuIOChannel			*io_channel;
+	MMManager			*manager;
+	MMObject			*omodem;
+	MMModemFirmwareUpdateMethod	 update_method;
+	gchar				*detach_fastboot_at;
+	gchar				*detach_port_at;
+};
+
+G_DEFINE_TYPE (FuMmDevice, fu_mm_device, FU_TYPE_DEVICE)
+
+static void
+fu_mm_device_to_string (FuDevice *device, GString *str)
+{
+	FuMmDevice *self = FU_MM_DEVICE (device);
+	g_string_append (str, "  FuMmDevice:\n");
+	g_string_append_printf (str, "    path:\t\t\t%s\n",
+				mm_object_get_path (self->omodem));
+	if (self->update_method != MM_MODEM_FIRMWARE_UPDATE_METHOD_NONE) {
+		g_autofree gchar *tmp = NULL;
+		tmp = mm_modem_firmware_update_method_build_string_from_mask (self->update_method);
+		g_string_append_printf (str, "    detach-kind:\t\t%s\n", tmp);
+	}
+	if (self->detach_port_at != NULL) {
+		g_string_append_printf (str, "    at-port:\t\t\t%s\n",
+					self->detach_port_at);
+	}
+}
+
+static gboolean
+fu_mm_device_probe (FuDevice *device, GError **error)
+{
+	FuMmDevice *self = FU_MM_DEVICE (device);
+	MMModemFirmware *modem_fw;
+	MMModem *modem = mm_object_peek_modem (self->omodem);
+	MMModemPortInfo *ports = NULL;
+	const gchar **device_ids;
+	const gchar *version;
+	guint n_ports = 0;
+	g_autoptr(MMFirmwareUpdateSettings) update_settings = NULL;
+
+	/* find out what detach method we should use */
+	modem_fw = mm_object_peek_modem_firmware (self->omodem);
+	update_settings = mm_modem_firmware_get_update_settings (modem_fw);
+	self->update_method = mm_firmware_update_settings_get_method (update_settings);
+	if (self->update_method == MM_MODEM_FIRMWARE_UPDATE_METHOD_NONE) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED,
+				     "modem cannot be put in programming mode");
+		return FALSE;
+	}
+
+	/* various fastboot commands */
+	if (self->update_method & MM_MODEM_FIRMWARE_UPDATE_METHOD_FASTBOOT) {
+		const gchar *tmp;
+		tmp = mm_firmware_update_settings_get_fastboot_at (update_settings);
+		if (tmp == NULL) {
+			g_set_error_literal (error,
+					     FWUPD_ERROR,
+					     FWUPD_ERROR_NOT_SUPPORTED,
+					     "modem does not set fastboot command");
+			return FALSE;
+		}
+		self->detach_fastboot_at = g_strdup (tmp);
+	} else {
+		g_autofree gchar *str = NULL;
+		str = mm_modem_firmware_update_method_build_string_from_mask (self->update_method);
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_NOT_SUPPORTED,
+			     "modem detach method %s not supported", str);
+		return FALSE;
+	}
+
+	/* get GUIDs */
+	device_ids = mm_firmware_update_settings_get_device_ids (update_settings);
+	if (device_ids == NULL || device_ids[0] == NULL) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED,
+				     "modem did not specify any device IDs");
+		return FALSE;
+	}
+
+	/* get version string, which is fw_ver+config_ver */
+	version = mm_firmware_update_settings_get_version (update_settings);
+	if (version == NULL) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED,
+				     "modem did not specify a firmware version");
+		return FALSE;
+	}
+
+	/* add properties to fwupd device */
+	fu_device_set_physical_id (device, mm_modem_get_device (modem));
+	fu_device_set_vendor (device, mm_modem_get_manufacturer (modem));
+	fu_device_set_name (device, mm_modem_get_model (modem));
+	fu_device_set_version (device, version);
+	for (guint i = 0; device_ids[i] != NULL; i++)
+		fu_device_add_guid (device, device_ids[i]);
+
+	/* look for the AT port */
+	if (!mm_modem_get_ports (modem, &ports, &n_ports)) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED,
+				     "failed to get port information");
+		return FALSE;
+	}
+	for (guint i = 0; i < n_ports; i++) {
+		if (ports[i].type == MM_MODEM_PORT_TYPE_AT) {
+			self->detach_port_at = g_strdup_printf ("/dev/%s", ports[i].name);
+			break;
+		}
+	}
+	mm_modem_port_info_array_free (ports, n_ports);
+
+	/* this is required for detaching */
+	if (self->detach_port_at == NULL) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOT_SUPPORTED,
+				     "failed to find AT port");
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_mm_device_at_cmd (FuMmDevice *self, const gchar *cmd, GError **error)
+{
+	const gchar *buf;
+	gsize bufsz = 0;
+	g_autoptr(GBytes) at_req  = NULL;
+	g_autoptr(GBytes) at_res  = NULL;
+	g_autofree gchar *cmd_cr = g_strdup_printf ("%s\r\n", cmd);
+
+	/* command */
+	at_req = g_bytes_new (cmd_cr, strlen (cmd_cr));
+	if (g_getenv ("FWUPD_MODEM_MANAGER_VERBOSE") != NULL)
+		fu_common_dump_bytes (G_LOG_DOMAIN, "writing", at_req);
+	if (!fu_io_channel_write_bytes (self->io_channel, at_req, 1500,
+					FU_IO_CHANNEL_FLAG_FLUSH_INPUT, error)) {
+		g_prefix_error (error, "failed to write %s: ", cmd);
+		return FALSE;
+	}
+
+	/* response */
+	at_res = fu_io_channel_read_bytes (self->io_channel, -1, 1500,
+					   FU_IO_CHANNEL_FLAG_SINGLE_SHOT, error);
+	if (at_res == NULL) {
+		g_prefix_error (error, "failed to read response for %s: ", cmd);
+		return FALSE;
+	}
+	if (g_getenv ("FWUPD_MODEM_MANAGER_VERBOSE") != NULL)
+		fu_common_dump_bytes (G_LOG_DOMAIN, "read", at_res);
+	buf = g_bytes_get_data (at_res, &bufsz);
+	if (bufsz < 6) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_NOT_SUPPORTED,
+			     "failed to read valid response for %s", cmd);
+		return FALSE;
+	}
+	if (memcmp (buf, "\r\nOK\r\n", 6) != 0) {
+		g_autofree gchar *tmp = g_strndup (buf + 2, bufsz - 4);
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_NOT_SUPPORTED,
+			     "failed to read valid response for %s: %s",
+			     cmd, tmp);
+		return FALSE;
+	}
+	return TRUE;
+}
+
+static gboolean
+fu_mm_device_io_open (FuMmDevice *self, GError **error)
+{
+	/* open device */
+	self->io_channel = fu_io_channel_new_file (self->detach_port_at, error);
+	if (self->io_channel == NULL)
+		return FALSE;
+
+	/* success */
+	return TRUE;
+}
+
+static gboolean
+fu_mm_device_io_close (FuMmDevice *self, GError **error)
+{
+	if (!fu_io_channel_shutdown (self->io_channel, error))
+		return FALSE;
+	g_clear_object (&self->io_channel);
+	return TRUE;
+}
+
+static gboolean
+fu_mm_device_detach_fastboot (FuDevice *device, GError **error)
+{
+	FuMmDevice *self = FU_MM_DEVICE (device);
+	g_autoptr(FuDeviceLocker) locker  = NULL;
+
+	/* boot to fastboot mode */
+	locker = fu_device_locker_new_full (device,
+					    (FuDeviceLockerFunc) fu_mm_device_io_open,
+					    (FuDeviceLockerFunc) fu_mm_device_io_close,
+					    error);
+	if (locker == NULL)
+		return FALSE;
+	if (!fu_mm_device_at_cmd (self, "AT", error))
+		return FALSE;
+	if (!fu_mm_device_at_cmd (self, self->detach_fastboot_at, error)) {
+		g_prefix_error (error, "rebooting into fastboot not supported: ");
+		return FALSE;
+	}
+
+	/* success */
+	fu_device_set_remove_delay (device, FU_DEVICE_REMOVE_DELAY_RE_ENUMERATE);
+	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+	return TRUE;
+}
+
+static gboolean
+fu_mm_device_inhibit (FuMmDevice *self, GError **error)
+{
+	MMModem *modem = mm_object_peek_modem (self->omodem);
+
+	/* prevent NM from activating the modem */
+	g_debug ("inhibit %s", mm_modem_get_device (modem));
+	if (!mm_manager_inhibit_device_sync (self->manager,
+					     mm_modem_get_device (modem),
+					     NULL, error))
+		return FALSE;
+
+	/* success: the device will disappear */
+	return TRUE;
+}
+
+static gboolean
+fu_mm_device_uninhibit (FuMmDevice *self, GError **error)
+{
+	MMModem *modem = mm_object_peek_modem (self->omodem);
+
+	/* allow NM to activate the modem */
+	g_debug ("uninhibit %s", mm_modem_get_device (modem));
+	if (!mm_manager_uninhibit_device_sync (self->manager,
+					       mm_modem_get_device (modem),
+					       NULL, error))
+		return FALSE;
+
+	/* success: the device will re-appear in a few seconds */
+	return TRUE;
+}
+
+static gboolean
+fu_mm_device_detach (FuDevice *device, GError **error)
+{
+	FuMmDevice *self = FU_MM_DEVICE (device);
+	g_autoptr(FuDeviceLocker) locker  = NULL;
+
+	/* boot to fastboot mode */
+	locker = fu_device_locker_new_full (device,
+					    (FuDeviceLockerFunc) fu_mm_device_inhibit,
+					    (FuDeviceLockerFunc) fu_mm_device_uninhibit,
+					    error);
+	if (locker == NULL)
+		return FALSE;
+
+	/* fastboot */
+	if (self->update_method & MM_MODEM_FIRMWARE_UPDATE_METHOD_FASTBOOT)
+		return fu_mm_device_detach_fastboot (device, error);
+
+	/* should not get here */
+	g_set_error_literal (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_NOT_SUPPORTED,
+			     "modem does not support detach");
+	return FALSE;
+}
+
+static void
+fu_mm_device_init (FuMmDevice *self)
+{
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_USE_RUNTIME_VERSION);
+	fu_device_set_summary (FU_DEVICE (self), "Mobile broadband device");
+	fu_device_add_icon (FU_DEVICE (self), "network-modem");
+}
+
+static void
+fu_mm_device_finalize (GObject *object)
+{
+	FuMmDevice *self = FU_MM_DEVICE (object);
+	g_object_unref (self->manager);
+	g_object_unref (self->omodem);
+	g_free (self->detach_fastboot_at);
+	g_free (self->detach_port_at);
+	G_OBJECT_CLASS (fu_mm_device_parent_class)->finalize (object);
+}
+
+static void
+fu_mm_device_class_init (FuMmDeviceClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+	FuDeviceClass *klass_device = FU_DEVICE_CLASS (klass);
+	object_class->finalize = fu_mm_device_finalize;
+	klass_device->to_string = fu_mm_device_to_string;
+	klass_device->probe = fu_mm_device_probe;
+	klass_device->detach = fu_mm_device_detach;
+}
+
+FuMmDevice *
+fu_mm_device_new (MMManager *manager, MMObject *omodem)
+{
+	FuMmDevice *self = g_object_new (FU_TYPE_MM_DEVICE, NULL);
+	self->manager = g_object_ref (manager);
+	self->omodem = g_object_ref (omodem);
+	return self;
+}

--- a/plugins/modem-manager/fu-mm-device.h
+++ b/plugins/modem-manager/fu-mm-device.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#ifndef __FU_MM_DEVICE_H
+#define __FU_MM_DEVICE_H
+
+#include <libmm-glib.h>
+
+#include "fu-plugin.h"
+
+G_BEGIN_DECLS
+
+#define FU_TYPE_MM_DEVICE (fu_mm_device_get_type ())
+G_DECLARE_FINAL_TYPE (FuMmDevice, fu_mm_device, FU, MM_DEVICE, FuDevice)
+
+FuMmDevice	*fu_mm_device_new		(MMManager	*manager,
+						 MMObject	*omodem);
+
+G_END_DECLS
+
+#endif /* __FU_MM_DEVICE_H */

--- a/plugins/modem-manager/fu-mm-device.h
+++ b/plugins/modem-manager/fu-mm-device.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+ * Copyright (C) 2019 Aleksander Morgado <aleksander@aleksander.es>
  *
  * SPDX-License-Identifier: LGPL-2.1+
  */
@@ -16,8 +17,26 @@ G_BEGIN_DECLS
 #define FU_TYPE_MM_DEVICE (fu_mm_device_get_type ())
 G_DECLARE_FINAL_TYPE (FuMmDevice, fu_mm_device, FU, MM_DEVICE, FuDevice)
 
-FuMmDevice	*fu_mm_device_new		(MMManager	*manager,
-						 MMObject	*omodem);
+FuMmDevice			*fu_mm_device_new			(MMManager	*manager,
+									 MMObject	*omodem);
+const gchar			*fu_mm_device_get_inhibition_uid	(FuMmDevice	*device);
+const gchar			*fu_mm_device_get_detach_fastboot_at	(FuMmDevice	*device);
+gint				 fu_mm_device_get_port_at_ifnum		(FuMmDevice	*device);
+MMModemFirmwareUpdateMethod	 fu_mm_device_get_update_methods	(FuMmDevice	*device);
+
+FuMmDevice			*fu_mm_device_udev_new			(MMManager	*manager,
+									 const gchar	*physical_id,
+									 const gchar	*vendor,
+									 const gchar	*name,
+									 const gchar	*version,
+									 const gchar	**device_ids,
+									 MMModemFirmwareUpdateMethod update_methods,
+									 const gchar	*detach_fastboot_at,
+									 gint		 port_at_ifnum);
+void			       fu_mm_device_udev_add_port		(FuMmDevice	*device,
+									 const gchar	*subsystem,
+									 const gchar	*path,
+									 gint		 ifnum);
 
 G_END_DECLS
 

--- a/plugins/modem-manager/fu-mm-utils.c
+++ b/plugins/modem-manager/fu-mm-utils.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2019 Aleksander Morgado <aleksander@aleksander.es>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include <gio/gio.h>
+#include "fu-mm-utils.h"
+
+gboolean
+fu_mm_utils_get_udev_port_info (GUdevDevice  *device,
+				gchar	    **out_device_sysfs_path,
+				gint	     *out_port_ifnum,
+				GError	    **error)
+{
+	g_autoptr(GUdevDevice) parent = NULL;
+	g_autofree gchar *device_sysfs_path = NULL;
+	gint port_ifnum = -1;
+	const gchar *aux;
+
+	/* ID_USB_INTERFACE_NUM is set on the port device itself */
+	aux = g_udev_device_get_property (device, "ID_USB_INTERFACE_NUM");
+	if (aux != NULL)
+		port_ifnum = (guint16) g_ascii_strtoull (aux, NULL, 16);
+
+	/* we need to traverse all parents of the give udev device until we find
+	 * the first 'usb_device' reported, which is the GUdevDevice associated with
+	 * the full USB device (i.e. all ports of the same device).
+	 */
+	parent = g_udev_device_get_parent (device);
+	while (parent != NULL) {
+		g_autoptr(GUdevDevice) next = NULL;
+
+		if (g_strcmp0 (g_udev_device_get_devtype (parent), "usb_device") == 0) {
+			device_sysfs_path = g_strdup (g_udev_device_get_sysfs_path (parent));
+			break;
+		}
+
+		/* Check next parent */
+		next = g_udev_device_get_parent (parent);
+		g_set_object (&parent, next);
+	}
+
+	if (parent == NULL) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_NOT_FOUND,
+			     "failed to lookup device info: parent usb_device not found");
+		return FALSE;
+	}
+
+	if (out_port_ifnum != NULL)
+		*out_port_ifnum = port_ifnum;
+	if (out_device_sysfs_path != NULL)
+		*out_device_sysfs_path = g_steal_pointer (&device_sysfs_path);
+	return TRUE;
+}
+
+gboolean
+fu_mm_utils_get_port_info (const gchar	*path,
+			   gchar       **out_device_sysfs_path,
+			   gint		*out_port_ifnum,
+			   GError      **error)
+{
+	g_autoptr(GUdevClient) client = NULL;
+	g_autoptr(GUdevDevice) dev = NULL;
+
+	client = g_udev_client_new (NULL);
+	dev = g_udev_client_query_by_device_file (client, path);
+	if (dev == NULL) {
+		g_set_error (error,
+			     G_IO_ERROR,
+			     G_IO_ERROR_NOT_FOUND,
+			     "failed to lookup device by path");
+		return FALSE;
+	}
+
+	return fu_mm_utils_get_udev_port_info (dev, out_device_sysfs_path, out_port_ifnum, error);
+}

--- a/plugins/modem-manager/fu-mm-utils.h
+++ b/plugins/modem-manager/fu-mm-utils.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2019 Aleksander Morgado <aleksander@aleksander.es>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#ifndef __FU_MM_UTILS_H
+#define __FU_MM_UTILS_H
+
+#include "config.h"
+#include <gudev/gudev.h>
+
+G_BEGIN_DECLS
+
+#ifndef HAVE_GUDEV_232
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevClient, g_object_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(GUdevDevice, g_object_unref)
+#pragma clang diagnostic pop
+#endif
+
+gboolean	fu_mm_utils_get_udev_port_info	(GUdevDevice  *dev,
+						 gchar	     **device_sysfs_path,
+						 gint	      *port_ifnum,
+						 GError	     **error);
+gboolean	fu_mm_utils_get_port_info	(const gchar  *path,
+						 gchar	     **device_sysfs_path,
+						 gint	      *port_ifnum,
+						 GError	     **error);
+
+G_END_DECLS
+
+#endif /* __FU_MM_UTILS_H */

--- a/plugins/modem-manager/fu-plugin-modem-manager.c
+++ b/plugins/modem-manager/fu-plugin-modem-manager.c
@@ -12,11 +12,250 @@
 #include "fu-plugin-vfuncs.h"
 
 #include "fu-mm-device.h"
+#include "fu-mm-utils.h"
+
+/* amount of time to wait for ports of the same device	being exposed by kernel */
+#define FU_MM_UDEV_DEVICE_PORTS_TIMEOUT		3	/* s */
+
+typedef struct FuPluginMmInhibitedDevice FuPluginMmInhibitedDevice;
 
 struct FuPluginData {
 	MMManager	*manager;
 	gboolean	manager_ready;
+
+	/* when a device is inhibited from MM, we store all relevant details
+	 * ourselves to recreate a functional device object even without MM
+	 */
+	FuPluginMmInhibitedDevice *inhibited;
 };
+
+struct FuPluginMmInhibitedDevice {
+	gchar	 *inhibited_uid;
+	gchar	 *physical_id;
+	gchar	 *vendor;
+	gchar	 *name;
+	gchar	 *version;
+	gchar	**guids;
+	MMModemFirmwareUpdateMethod update_methods;
+	gchar	 *detach_fastboot_at;
+	gint	  port_at_ifnum;
+
+	GUdevClient	*udev_client;
+	guint		 udev_timeout_id;
+};
+
+static void
+fu_plugin_mm_inhibited_device_free (FuPluginMmInhibitedDevice *info)
+{
+	if (info->udev_timeout_id)
+		g_source_remove (info->udev_timeout_id);
+	if (info->udev_client)
+		g_object_unref (info->udev_client);
+	g_free (info->inhibited_uid);
+	g_free (info->physical_id);
+	g_free (info->vendor);
+	g_free (info->name);
+	g_free (info->version);
+	g_strfreev (info->guids);
+	g_free (info->detach_fastboot_at);
+	g_free (info);
+}
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (FuPluginMmInhibitedDevice, fu_plugin_mm_inhibited_device_free);
+
+static void
+fu_plugin_mm_udev_device_removed (FuPlugin *plugin)
+{
+	FuPluginData *priv = fu_plugin_get_data (plugin);
+	FuMmDevice *dev;
+
+	if (priv->inhibited == NULL)
+		return;
+
+	dev = fu_plugin_cache_lookup (plugin, priv->inhibited->physical_id);
+	if (dev == NULL)
+		return;
+
+	/* once the first port is gone, consider device is gone */
+	fu_plugin_cache_remove (plugin, priv->inhibited->physical_id);
+	fu_plugin_device_remove (plugin, FU_DEVICE (dev));
+
+	/* no need to wait for more ports, cancel that right away */
+	if (priv->inhibited->udev_timeout_id != 0) {
+		g_source_remove (priv->inhibited->udev_timeout_id);
+		priv->inhibited->udev_timeout_id = 0;
+	}
+}
+
+static void
+fu_plugin_mm_uninhibit_device (FuPlugin *plugin)
+{
+	FuPluginData *priv = fu_plugin_get_data (plugin);
+	g_autoptr(FuPluginMmInhibitedDevice) info = NULL;
+
+	/* get the device removed from the plugin cache before uninhibiting */
+	fu_plugin_mm_udev_device_removed (plugin);
+
+	info = g_steal_pointer (&priv->inhibited);
+	if ((priv->manager != NULL) && (info != NULL)) {
+		g_debug ("uninhibit modemmanager device with uid %s", info->inhibited_uid);
+		mm_manager_uninhibit_device_sync (priv->manager, info->inhibited_uid, NULL, NULL);
+	}
+}
+
+static gboolean
+fu_plugin_mm_udev_device_ports_timeout (gpointer user_data)
+{
+	FuPlugin *plugin = user_data;
+	FuPluginData *priv = fu_plugin_get_data (plugin);
+	FuMmDevice *dev;
+	g_autoptr(GError) error = NULL;
+
+	g_assert (priv->inhibited != NULL);
+	priv->inhibited->udev_timeout_id = 0;
+
+	dev = fu_plugin_cache_lookup (plugin, priv->inhibited->physical_id);
+
+	if (dev != NULL) {
+		if (!fu_device_probe (FU_DEVICE (dev), &error)) {
+			g_debug ("failed to probe MM device: %s", error->message);
+		} else {
+			fu_plugin_device_add (plugin, FU_DEVICE (dev));
+		}
+	}
+
+	return G_SOURCE_REMOVE;
+}
+
+static void
+fu_plugin_mm_udev_device_ports_timeout_reset (FuPlugin *plugin)
+{
+	FuPluginData *priv = fu_plugin_get_data (plugin);
+
+	g_assert (priv->inhibited != NULL);
+	if (priv->inhibited->udev_timeout_id != 0)
+		g_source_remove (priv->inhibited->udev_timeout_id);
+	priv->inhibited->udev_timeout_id = g_timeout_add_seconds (FU_MM_UDEV_DEVICE_PORTS_TIMEOUT,
+								  fu_plugin_mm_udev_device_ports_timeout,
+								  plugin);
+}
+
+static void
+fu_plugin_mm_udev_device_port_added (FuPlugin		*plugin,
+				     const gchar	*subsystem,
+				     const gchar	*path,
+				     gint		 ifnum)
+{
+	FuPluginData *priv = fu_plugin_get_data (plugin);
+	FuMmDevice *existing;
+	g_autoptr(FuMmDevice) dev = NULL;
+	g_autoptr(GError) error = NULL;
+
+	g_assert (priv->inhibited != NULL);
+	existing = fu_plugin_cache_lookup (plugin, priv->inhibited->physical_id);
+	if (existing != NULL) {
+		/* add port to existing device */
+		fu_mm_device_udev_add_port (existing, subsystem, path, ifnum);
+		fu_plugin_mm_udev_device_ports_timeout_reset (plugin);
+		return;
+	}
+	/* create device and add to cache */
+	dev = fu_mm_device_udev_new (priv->manager,
+				     priv->inhibited->physical_id,
+				     priv->inhibited->vendor,
+				     priv->inhibited->name,
+				     priv->inhibited->version,
+				     (const gchar **) priv->inhibited->guids,
+				     priv->inhibited->update_methods,
+				     priv->inhibited->detach_fastboot_at,
+				     priv->inhibited->port_at_ifnum);
+	fu_mm_device_udev_add_port (dev, subsystem, path, ifnum);
+	fu_plugin_cache_add (plugin, priv->inhibited->physical_id, dev);
+
+	/* wait a bit before probing, in case more ports get added */
+	fu_plugin_mm_udev_device_ports_timeout_reset (plugin);
+}
+
+static gboolean
+fu_plugin_mm_udev_uevent_cb (GUdevClient	*udev,
+			     const gchar	*action,
+			     GUdevDevice	*device,
+			     gpointer		 user_data)
+{
+	FuPlugin *plugin = FU_PLUGIN (user_data);
+	FuPluginData *priv = fu_plugin_get_data (plugin);
+	const gchar *subsystem = g_udev_device_get_subsystem (device);
+	const gchar *name = g_udev_device_get_name (device);
+	g_autofree gchar *path = NULL;
+	g_autofree gchar *device_sysfs_path = NULL;
+	gint ifnum = -1;
+
+	if ((action == NULL) || (subsystem == NULL) || (priv->inhibited == NULL) || (name == NULL))
+		return TRUE;
+
+	/* ignore if loading port info fails */
+	if (!fu_mm_utils_get_udev_port_info (device, &device_sysfs_path, &ifnum, NULL))
+		return TRUE;
+
+	/* ignore all events for ports not owned by our device */
+	if (g_strcmp0 (device_sysfs_path, priv->inhibited->physical_id) != 0)
+		return TRUE;
+
+	/* ignore non-cdc-wdm usbmisc ports */
+	if (g_str_equal (subsystem, "usbmisc") && !g_str_has_prefix (name, "cdc-wdm"))
+		return TRUE;
+
+	path = g_strdup_printf ("/dev/%s", name);
+
+	if ((g_str_equal (action, "add")) || (g_str_equal (action, "change"))) {
+		g_debug ("added port to inhibited modem: %s (ifnum %d)", path, ifnum);
+		fu_plugin_mm_udev_device_port_added (plugin, subsystem, path, ifnum);
+	} else if (g_str_equal (action, "remove")) {
+		g_debug ("removed port from inhibited modem: %s", path);
+		fu_plugin_mm_udev_device_removed (plugin);
+	}
+
+	return TRUE;
+}
+
+static gboolean
+fu_plugin_mm_inhibit_device (FuPlugin *plugin, FuDevice *device, GError **error)
+{
+	static const gchar *subsystems[] = { "tty", "usbmisc", NULL };
+	FuPluginData *priv = fu_plugin_get_data (plugin);
+	g_autofree gchar *guids_str = NULL;
+	g_autoptr(FuPluginMmInhibitedDevice) info = NULL;
+	const gchar *inhibition_uid;
+
+	fu_plugin_mm_uninhibit_device (plugin);
+
+	info = g_new0 (FuPluginMmInhibitedDevice, 1);
+	info->physical_id = g_strdup (fu_device_get_physical_id (device));
+	info->vendor = g_strdup (fu_device_get_vendor (device));
+	info->name = g_strdup (fu_device_get_name (device));
+	info->version = g_strdup (fu_device_get_version (device));
+	guids_str = fu_device_get_guids_as_str (device);
+	info->guids = g_strsplit (guids_str, ",", -1);
+	info->update_methods = fu_mm_device_get_update_methods (FU_MM_DEVICE (device));
+	info->detach_fastboot_at = g_strdup (fu_mm_device_get_detach_fastboot_at (FU_MM_DEVICE (device)));
+	info->port_at_ifnum = fu_mm_device_get_port_at_ifnum (FU_MM_DEVICE (device));
+
+	inhibition_uid = fu_mm_device_get_inhibition_uid (FU_MM_DEVICE (device));
+	g_debug ("inhibit modemmanager device with uid %s", inhibition_uid);
+	if (!mm_manager_inhibit_device_sync (priv->manager, inhibition_uid, NULL, error))
+		return FALSE;
+
+	/* setup inhibited device info */
+	info->inhibited_uid = g_strdup (inhibition_uid);
+	priv->inhibited = g_steal_pointer (&info);
+
+	/* as soon as inhibition is place, we need to do modem device monitoring based
+	 * on the udev client, as MM no longer reports devices */
+	priv->inhibited->udev_client = g_udev_client_new (subsystems);
+	g_signal_connect (priv->inhibited->udev_client, "uevent", G_CALLBACK (fu_plugin_mm_udev_uevent_cb), plugin);
+
+	return TRUE;
+}
 
 static void
 fu_plugin_mm_device_add (FuPlugin *plugin, MMObject *modem)
@@ -156,12 +395,66 @@ void
 fu_plugin_destroy (FuPlugin *plugin)
 {
 	FuPluginData *priv = fu_plugin_get_data (plugin);
+
+	fu_plugin_mm_uninhibit_device (plugin);
+
 	if (priv->manager != NULL)
 		g_object_unref (priv->manager);
 }
 
 gboolean
 fu_plugin_update_detach (FuPlugin *plugin, FuDevice *device, GError **error)
+{
+	FuPluginData *priv = fu_plugin_get_data (plugin);
+	g_autoptr(FuDeviceLocker) locker = NULL;
+
+	/* open device */
+	locker = fu_device_locker_new (device, error);
+	if (locker == NULL)
+		return FALSE;
+
+	/* inhibit device and track it inside the plugin, not bound to the
+	 * lifetime of the FuMmDevice, because that object will only exist for
+	 * as long as the ModemManager device exists, and inhibiting will
+	 * implicitly remove the device from ModemManager. */
+	if (priv->inhibited == NULL) {
+		if (!fu_plugin_mm_inhibit_device (plugin, device, error))
+			return FALSE;
+	}
+
+	/* reset */
+	if (!fu_device_detach (device, error)) {
+		fu_plugin_mm_uninhibit_device (plugin);
+		return FALSE;
+	}
+
+	/* note: wait for replug set by device if it really needs it */
+	return TRUE;
+}
+
+gboolean
+fu_plugin_update (FuPlugin *plugin,
+		  FuDevice *device,
+		  GBytes *blob_fw,
+		  FwupdInstallFlags flags,
+		  GError **error)
+{
+	g_autoptr(FuDeviceLocker) locker = fu_device_locker_new (device, error);
+	if (locker == NULL)
+		return FALSE;
+	return fu_device_write_firmware (device, blob_fw, error);
+}
+
+static gboolean
+fu_plugin_mm_uninhibit_device_idle (gpointer user_data)
+{
+	FuPlugin *plugin = FU_PLUGIN (user_data);
+	fu_plugin_mm_uninhibit_device (plugin);
+	return G_SOURCE_REMOVE;
+}
+
+gboolean
+fu_plugin_update_attach (FuPlugin *plugin, FuDevice *device, GError **error)
 {
 	g_autoptr(FuDeviceLocker) locker = NULL;
 
@@ -170,11 +463,10 @@ fu_plugin_update_detach (FuPlugin *plugin, FuDevice *device, GError **error)
 	if (locker == NULL)
 		return FALSE;
 
-	/* reset */
-	if (!fu_device_detach (FU_DEVICE (device), error))
-		return FALSE;
+	/* must be done in idle so that the engine explicitly
+	 * waits for the device to be redetected */
+	g_idle_add (fu_plugin_mm_uninhibit_device_idle, plugin);
 
-	/* wait for replug */
-	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
-	return TRUE;
+	/* reset */
+	return fu_device_attach (FU_DEVICE (device), error);
 }

--- a/plugins/modem-manager/fu-plugin-modem-manager.c
+++ b/plugins/modem-manager/fu-plugin-modem-manager.c
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <libmm-glib.h>
+
+#include "fu-plugin-vfuncs.h"
+
+#include "fu-mm-device.h"
+
+struct FuPluginData {
+	MMManager	*manager;
+	gboolean	manager_ready;
+};
+
+static void
+fu_plugin_mm_device_add (FuPlugin *plugin, MMObject *modem)
+{
+	FuPluginData *priv = fu_plugin_get_data (plugin);
+	const gchar *object_path = mm_object_get_path (modem);
+	g_autoptr(FuMmDevice) dev = NULL;
+	g_autoptr(GError) error = NULL;
+	if (fu_plugin_cache_lookup (plugin, object_path) != NULL) {
+		g_warning ("MM device already added, ignoring");
+		return;
+	}
+	dev = fu_mm_device_new (priv->manager, modem);
+	if (!fu_device_probe (FU_DEVICE (dev), &error)) {
+		g_debug ("failed to probe MM device: %s", error->message);
+		return;
+	}
+	fu_plugin_device_add (plugin, FU_DEVICE (dev));
+	fu_plugin_cache_add (plugin, object_path, dev);
+}
+
+static void
+fu_plugin_mm_device_added_cb (MMManager *manager, MMObject *modem, FuPlugin *plugin)
+{
+	fu_plugin_mm_device_add (plugin, modem);
+}
+
+static void
+fu_plugin_mm_device_removed_cb (MMManager *manager, MMObject *modem, FuPlugin *plugin)
+{
+	const gchar *object_path = mm_object_get_path (modem);
+	FuMmDevice *dev = fu_plugin_cache_lookup (plugin, object_path);
+	if (dev == NULL)
+		return;
+	g_debug ("removed modem: %s", mm_object_get_path (modem));
+	fu_plugin_cache_remove (plugin, object_path);
+	fu_plugin_device_remove (plugin, FU_DEVICE (dev));
+}
+
+static void
+fu_plugin_mm_teardown_manager (FuPlugin *plugin)
+{
+	FuPluginData *priv = fu_plugin_get_data (plugin);
+
+	if (priv->manager_ready) {
+		g_debug ("ModemManager no longer available");
+		g_signal_handlers_disconnect_by_func (priv->manager,
+						      G_CALLBACK (fu_plugin_mm_device_added_cb),
+						      plugin);
+		g_signal_handlers_disconnect_by_func (priv->manager,
+						      G_CALLBACK (fu_plugin_mm_device_removed_cb),
+						      plugin);
+		priv->manager_ready = FALSE;
+	}
+}
+
+static void
+fu_plugin_mm_setup_manager (FuPlugin *plugin)
+{
+	FuPluginData *priv = fu_plugin_get_data (plugin);
+	const gchar *version = mm_manager_get_version (priv->manager);
+	GList *list;
+
+	if (fu_common_vercmp (version, MM_REQUIRED_VERSION) < 0) {
+		g_warning ("ModemManager %s is available, but need at least %s",
+			   version, MM_REQUIRED_VERSION);
+		return;
+	}
+
+	g_debug ("ModemManager %s is available", version);
+
+	g_signal_connect (priv->manager, "object-added",
+			  G_CALLBACK (fu_plugin_mm_device_added_cb), plugin);
+	g_signal_connect (priv->manager, "object-removed",
+			  G_CALLBACK (fu_plugin_mm_device_removed_cb), plugin);
+
+	list = g_dbus_object_manager_get_objects (G_DBUS_OBJECT_MANAGER (priv->manager));
+	for (GList *l = list; l != NULL; l = g_list_next (l)) {
+		MMObject *modem = MM_OBJECT (l->data);
+		fu_plugin_mm_device_add (plugin, modem);
+		g_object_unref (modem);
+	}
+	g_list_free (list);
+
+	priv->manager_ready = TRUE;
+}
+
+static void
+fu_plugin_mm_name_owner_updated (FuPlugin *plugin)
+{
+	FuPluginData *priv = fu_plugin_get_data (plugin);
+	const gchar *name_owner;
+	name_owner = g_dbus_object_manager_client_get_name_owner (G_DBUS_OBJECT_MANAGER_CLIENT (priv->manager));
+	if (name_owner != NULL)
+		fu_plugin_mm_setup_manager (plugin);
+	else
+		fu_plugin_mm_teardown_manager (plugin);
+}
+
+gboolean
+fu_plugin_coldplug (FuPlugin *plugin, GError **error)
+{
+	FuPluginData *priv = fu_plugin_get_data (plugin);
+	g_signal_connect_swapped (priv->manager, "notify::name-owner",
+				  G_CALLBACK (fu_plugin_mm_name_owner_updated),
+				  plugin);
+	fu_plugin_mm_name_owner_updated (plugin);
+	return TRUE;
+}
+
+gboolean
+fu_plugin_startup (FuPlugin *plugin, GError **error)
+{
+	FuPluginData *priv = fu_plugin_get_data (plugin);
+	g_autoptr(GDBusConnection) connection = NULL;
+
+	connection = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, error);
+	if (connection == NULL)
+		return FALSE;
+	priv->manager = mm_manager_new_sync (connection,
+					     G_DBUS_OBJECT_MANAGER_CLIENT_FLAGS_DO_NOT_AUTO_START,
+					     NULL, error);
+	if (priv->manager == NULL)
+		return FALSE;
+
+	return TRUE;
+}
+
+void
+fu_plugin_init (FuPlugin *plugin)
+{
+	fu_plugin_set_build_hash (plugin, FU_BUILD_HASH);
+	fu_plugin_alloc_data (plugin, sizeof (FuPluginData));
+}
+
+void
+fu_plugin_destroy (FuPlugin *plugin)
+{
+	FuPluginData *priv = fu_plugin_get_data (plugin);
+	if (priv->manager != NULL)
+		g_object_unref (priv->manager);
+}
+
+gboolean
+fu_plugin_update_detach (FuPlugin *plugin, FuDevice *device, GError **error)
+{
+	g_autoptr(FuDeviceLocker) locker = NULL;
+
+	/* open device */
+	locker = fu_device_locker_new (device, error);
+	if (locker == NULL)
+		return FALSE;
+
+	/* reset */
+	if (!fu_device_detach (FU_DEVICE (device), error))
+		return FALSE;
+
+	/* wait for replug */
+	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_WAIT_FOR_REPLUG);
+	return TRUE;
+}

--- a/plugins/modem-manager/fu-qmi-pdc-updater.c
+++ b/plugins/modem-manager/fu-qmi-pdc-updater.c
@@ -1,0 +1,432 @@
+/*
+ * Copyright (C) 2019 Aleksander Morgado <aleksander@aleksander.es>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "fu-qmi-pdc-updater.h"
+
+#define FU_QMI_PDC_MAX_OPEN_ATTEMPTS 8
+
+struct _FuQmiPdcUpdater {
+	GObject		parent_instance;
+	gchar		*qmi_port;
+	QmiDevice	*qmi_device;
+	QmiClientPdc	*qmi_client;
+};
+
+G_DEFINE_TYPE (FuQmiPdcUpdater, fu_qmi_pdc_updater, G_TYPE_OBJECT)
+
+typedef struct {
+	GMainLoop	*mainloop;
+	QmiDevice	*qmi_device;
+	QmiClientPdc	*qmi_client;
+	GError		*error;
+	guint		open_attempts;
+} OpenContext;
+
+static void fu_qmi_pdc_updater_qmi_device_open_attempt (OpenContext *ctx);
+
+static void
+fu_qmi_pdc_updater_qmi_device_open_abort_ready (GObject *qmi_device, GAsyncResult *res, gpointer user_data)
+{
+	OpenContext *ctx = (OpenContext *) user_data;
+
+	g_assert (ctx->error != NULL);
+
+	/* ignore errors when aborting open */
+	qmi_device_close_finish (QMI_DEVICE (qmi_device), res, NULL);
+
+	ctx->open_attempts--;
+	if (ctx->open_attempts == 0) {
+		g_clear_object (&ctx->qmi_client);
+		g_clear_object (&ctx->qmi_device);
+		g_main_loop_quit (ctx->mainloop);
+		return;
+	}
+
+	/* retry */
+	g_clear_error (&ctx->error);
+	fu_qmi_pdc_updater_qmi_device_open_attempt (ctx);
+}
+
+static void
+fu_qmi_pdc_updater_open_abort (OpenContext *ctx)
+{
+	qmi_device_close_async (ctx->qmi_device,
+				15, NULL, fu_qmi_pdc_updater_qmi_device_open_abort_ready, ctx);
+}
+
+static void
+fu_qmi_pdc_updater_qmi_device_allocate_client_ready (GObject *qmi_device, GAsyncResult *res, gpointer user_data)
+{
+	OpenContext *ctx = (OpenContext *) user_data;
+
+	ctx->qmi_client = QMI_CLIENT_PDC (qmi_device_allocate_client_finish (QMI_DEVICE (qmi_device), res, &ctx->error));
+	if (ctx->qmi_client == NULL) {
+		fu_qmi_pdc_updater_open_abort (ctx);
+		return;
+	}
+
+	g_main_loop_quit (ctx->mainloop);
+}
+
+static void
+fu_qmi_pdc_updater_qmi_device_open_ready (GObject *qmi_device, GAsyncResult *res, gpointer user_data)
+{
+	OpenContext *ctx = (OpenContext *) user_data;
+
+	if (!qmi_device_open_finish (QMI_DEVICE (qmi_device), res, &ctx->error)) {
+		fu_qmi_pdc_updater_open_abort (ctx);
+		return;
+	}
+
+	qmi_device_allocate_client (ctx->qmi_device, QMI_SERVICE_PDC, QMI_CID_NONE, 5, NULL,
+				    fu_qmi_pdc_updater_qmi_device_allocate_client_ready, ctx);
+}
+
+static void
+fu_qmi_pdc_updater_qmi_device_open_attempt (OpenContext *ctx)
+{
+	QmiDeviceOpenFlags open_flags = QMI_DEVICE_OPEN_FLAGS_NONE;
+
+	g_debug ("trying to open QMI device...");
+
+	/* automatically detect QMI and MBIM ports */
+	open_flags |= QMI_DEVICE_OPEN_FLAGS_AUTO;
+	/* qmi pdc requires indications, so enable them by default */
+	open_flags |= QMI_DEVICE_OPEN_FLAGS_EXPECT_INDICATIONS;
+	/* all communication through the proxy */
+	open_flags |= QMI_DEVICE_OPEN_FLAGS_PROXY;
+
+	qmi_device_open (ctx->qmi_device, open_flags, 5, NULL,
+			 fu_qmi_pdc_updater_qmi_device_open_ready, ctx);
+}
+
+static void
+fu_qmi_pdc_updater_qmi_device_new_ready (GObject *source, GAsyncResult *res, gpointer user_data)
+{
+	OpenContext *ctx = (OpenContext *) user_data;
+
+	ctx->qmi_device = qmi_device_new_finish (res, &ctx->error);
+	if (ctx->qmi_device == NULL) {
+		g_main_loop_quit (ctx->mainloop);
+		return;
+	}
+
+	fu_qmi_pdc_updater_qmi_device_open_attempt (ctx);
+}
+
+gboolean
+fu_qmi_pdc_updater_open (FuQmiPdcUpdater *self, GError **error)
+{
+	g_autoptr(GMainLoop) mainloop = g_main_loop_new (NULL, FALSE);
+	g_autoptr(GFile) qmi_device_file = g_file_new_for_path (self->qmi_port);
+	OpenContext ctx = {
+		.mainloop = mainloop,
+		.open_attempts = FU_QMI_PDC_MAX_OPEN_ATTEMPTS,
+	};
+
+	qmi_device_new (qmi_device_file, NULL, fu_qmi_pdc_updater_qmi_device_new_ready, &ctx);
+	g_main_loop_run (mainloop);
+
+	/* either we have all device, client and config list  set, or otherwise error is set */
+
+	if ((ctx.qmi_device != NULL) && (ctx.qmi_client != NULL)) {
+		g_assert (!ctx.error);
+		self->qmi_device = ctx.qmi_device;
+		self->qmi_client = ctx.qmi_client;
+		/* success */
+		return TRUE;
+	}
+
+	g_assert (ctx.error != NULL);
+	g_warning ("open failed: %s", ctx.error->message);
+
+	g_assert (ctx.qmi_device == NULL);
+	g_assert (ctx.qmi_client == NULL);
+	g_propagate_error (error, ctx.error);
+	return FALSE;
+}
+
+typedef struct {
+	GMainLoop	   *mainloop;
+	QmiDevice	   *qmi_device;
+	QmiClientPdc	   *qmi_client;
+	GError		   *error;
+} CloseContext;
+
+static void
+fu_qmi_pdc_updater_qmi_device_close_ready (GObject *qmi_device, GAsyncResult *res, gpointer user_data)
+{
+	CloseContext *ctx = (CloseContext *) user_data;
+
+	/* ignore errors when closing if we had one already set when releasing client */
+	qmi_device_close_finish (QMI_DEVICE (qmi_device), res, (ctx->error == NULL) ? &ctx->error : NULL);
+	g_clear_object (&ctx->qmi_device);
+	g_main_loop_quit (ctx->mainloop);
+}
+
+static void
+fu_qmi_pdc_updater_qmi_device_release_client_ready (GObject *qmi_device, GAsyncResult *res, gpointer user_data)
+{
+	CloseContext *ctx = (CloseContext *) user_data;
+
+	qmi_device_release_client_finish (QMI_DEVICE (qmi_device), res, &ctx->error);
+	g_clear_object (&ctx->qmi_client);
+
+	qmi_device_close_async (ctx->qmi_device,
+				15, NULL, fu_qmi_pdc_updater_qmi_device_close_ready, ctx);
+}
+
+gboolean
+fu_qmi_pdc_updater_close (FuQmiPdcUpdater *self, GError **error)
+{
+	g_autoptr(GMainLoop) mainloop = g_main_loop_new (NULL, FALSE);
+	CloseContext ctx = {
+		.mainloop = mainloop,
+		.qmi_device = g_steal_pointer (&self->qmi_device),
+		.qmi_client = g_steal_pointer (&self->qmi_client),
+	};
+
+	qmi_device_release_client (ctx.qmi_device, QMI_CLIENT (ctx.qmi_client),
+				   QMI_DEVICE_RELEASE_CLIENT_FLAGS_RELEASE_CID,
+				   5, NULL, fu_qmi_pdc_updater_qmi_device_release_client_ready, &ctx);
+	g_main_loop_run (mainloop);
+
+	/* we should always have both device and client cleared, and optionally error set */
+
+	g_assert (ctx.qmi_device == NULL);
+	g_assert (ctx.qmi_client == NULL);
+
+	if (ctx.error != NULL) {
+		g_propagate_error (error, ctx.error);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+#define QMI_LOAD_CHUNK_SIZE 0x400
+
+typedef struct {
+	GMainLoop	*mainloop;
+	QmiClientPdc	*qmi_client;
+	GError		*error;
+	gulong		 indication_id;
+	guint		 timeout_id;
+	GBytes		*blob;
+	GArray		*digest;
+	gsize		 offset;
+	guint		 token;
+} WriteContext;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(QmiMessagePdcLoadConfigInput, qmi_message_pdc_load_config_input_unref)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(QmiMessagePdcLoadConfigOutput, qmi_message_pdc_load_config_output_unref)
+#pragma clang diagnostic pop
+
+static void fu_qmi_pdc_updater_load_config (WriteContext *ctx);
+
+static gboolean
+fu_qmi_pdc_updater_load_config_timeout (gpointer user_data)
+{
+	WriteContext *ctx = user_data;
+
+	ctx->timeout_id = 0;
+	g_signal_handler_disconnect (ctx->qmi_client, ctx->indication_id);
+	ctx->indication_id = 0;
+
+	g_set_error_literal (&ctx->error, G_IO_ERROR, G_IO_ERROR_FAILED,
+			     "couldn't load mcfg: timed out");
+	g_main_loop_quit (ctx->mainloop);
+
+	return G_SOURCE_REMOVE;
+}
+
+static void
+fu_qmi_pdc_updater_load_config_indication (QmiClientPdc *client,
+					   QmiIndicationPdcLoadConfigOutput *output,
+					   WriteContext *ctx)
+{
+	gboolean frame_reset;
+	guint32 remaining_size;
+	guint16 error_code = 0;
+
+	g_source_remove (ctx->timeout_id);
+	ctx->timeout_id = 0;
+	g_signal_handler_disconnect (ctx->qmi_client, ctx->indication_id);
+	ctx->indication_id = 0;
+
+	if (!qmi_indication_pdc_load_config_output_get_indication_result (output, &error_code, &ctx->error)) {
+		g_main_loop_quit (ctx->mainloop);
+		return;
+	}
+
+	if (error_code != 0) {
+		/* when a given mcfg file already exists in the device, an "invalid id" error is returned;
+		 * the error naming here is a bit off, as the same protocol error number is used both for
+		 * 'invalid id' and 'invalid qos id'
+		 */
+		if (error_code == QMI_PROTOCOL_ERROR_INVALID_QOS_ID) {
+			g_debug ("file already available in device");
+			g_main_loop_quit (ctx->mainloop);
+			return;
+		}
+
+		g_set_error (&ctx->error, G_IO_ERROR, G_IO_ERROR_FAILED,
+			     "couldn't load mcfg: %s", qmi_protocol_error_get_string ((QmiProtocolError) error_code));
+		g_main_loop_quit (ctx->mainloop);
+		return;
+	}
+
+	if (qmi_indication_pdc_load_config_output_get_frame_reset (output, &frame_reset, NULL) && frame_reset) {
+		g_set_error (&ctx->error, G_IO_ERROR, G_IO_ERROR_FAILED,
+			     "couldn't load mcfg: sent data discarded");
+		g_main_loop_quit (ctx->mainloop);
+		return;
+	}
+
+	if (!qmi_indication_pdc_load_config_output_get_remaining_size (output, &remaining_size, &ctx->error)) {
+		g_prefix_error (&ctx->error, "couldn't load remaining size: ");
+		g_main_loop_quit (ctx->mainloop);
+		return;
+	}
+
+	if (remaining_size == 0) {
+		g_debug ("finished loading mcfg");
+		g_main_loop_quit (ctx->mainloop);
+		return;
+	}
+
+	g_debug ("loading next chunk (%u bytes remaining)", remaining_size);
+	fu_qmi_pdc_updater_load_config (ctx);
+}
+
+static void
+fu_qmi_pdc_updater_load_config_ready (GObject *qmi_client, GAsyncResult *res, gpointer user_data)
+{
+	WriteContext *ctx = (WriteContext *) user_data;
+	g_autoptr(QmiMessagePdcLoadConfigOutput) output = NULL;
+
+	output = qmi_client_pdc_load_config_finish (QMI_CLIENT_PDC (qmi_client), res, &ctx->error);
+	if (output == NULL) {
+		g_main_loop_quit (ctx->mainloop);
+		return;
+	}
+
+	if (!qmi_message_pdc_load_config_output_get_result (output, &ctx->error)) {
+		g_main_loop_quit (ctx->mainloop);
+		return;
+	}
+
+	/* after receiving the response to our request, we now expect an indication
+	 * with the actual result of the operation */
+	g_assert (ctx->indication_id == 0);
+	ctx->indication_id = g_signal_connect (ctx->qmi_client, "load-config",
+					       G_CALLBACK (fu_qmi_pdc_updater_load_config_indication), ctx);
+
+	/* don't wait forever */
+	g_assert (ctx->timeout_id == 0);
+	ctx->timeout_id = g_timeout_add_seconds (5, fu_qmi_pdc_updater_load_config_timeout, ctx);
+}
+
+static void
+fu_qmi_pdc_updater_load_config (WriteContext *ctx)
+{
+	g_autoptr(QmiMessagePdcLoadConfigInput) input = NULL;
+	g_autoptr(GArray) chunk = NULL;
+	gsize full_size;
+	gsize chunk_size;
+
+	input = qmi_message_pdc_load_config_input_new ();
+	qmi_message_pdc_load_config_input_set_token (input, ctx->token++, NULL);
+
+	full_size = g_bytes_get_size (ctx->blob);
+	chunk_size = (((ctx->offset + QMI_LOAD_CHUNK_SIZE) > full_size) ?
+		      (full_size - ctx->offset) :
+		      QMI_LOAD_CHUNK_SIZE);
+
+	chunk = g_array_sized_new (FALSE, FALSE, sizeof (guint8), chunk_size);
+	g_array_set_size (chunk, chunk_size);
+	memcpy (chunk->data, (const guint8 *)g_bytes_get_data (ctx->blob, NULL) + ctx->offset, chunk_size);
+
+	qmi_message_pdc_load_config_input_set_config_chunk (input,
+							    QMI_PDC_CONFIGURATION_TYPE_SOFTWARE,
+							    ctx->digest,
+							    full_size,
+							    chunk,
+							    NULL);
+	ctx->offset += chunk_size;
+
+	qmi_client_pdc_load_config (ctx->qmi_client, input, 10, NULL, fu_qmi_pdc_updater_load_config_ready, ctx);
+}
+
+gboolean
+fu_qmi_pdc_updater_write (FuQmiPdcUpdater *self, const gchar *filename, GBytes *blob, GError **error)
+{
+	g_autoptr(GMainLoop) mainloop = g_main_loop_new (NULL, FALSE);
+	g_autoptr(GChecksum) checksum = NULL;
+	g_autoptr(GArray) digest = NULL;
+	gsize file_size;
+	gsize hash_size;
+	WriteContext ctx = {
+		.mainloop = mainloop,
+		.qmi_client = self->qmi_client,
+		.blob = blob,
+	};
+
+	/* get checksum, to be used as unique id */
+	file_size = g_bytes_get_size (ctx.blob);
+	hash_size = g_checksum_type_get_length (G_CHECKSUM_SHA1);
+	checksum = g_checksum_new (G_CHECKSUM_SHA1);
+	g_checksum_update (checksum, g_bytes_get_data (ctx.blob, NULL), file_size);
+	/* libqmi expects a GArray of bytes, not a GByteArray */
+	digest = g_array_sized_new (FALSE, FALSE, sizeof (guint8), hash_size);
+	g_array_set_size (digest, hash_size);
+	g_checksum_get_digest (checksum, (guint8 *)digest->data, &hash_size);
+	ctx.digest = digest;
+
+	fu_qmi_pdc_updater_load_config (&ctx);
+	g_main_loop_run (mainloop);
+
+	if (ctx.error != NULL) {
+		g_propagate_error (error, ctx.error);
+		return FALSE;
+	}
+
+	return TRUE;
+}
+
+static void
+fu_qmi_pdc_updater_init (FuQmiPdcUpdater *self)
+{
+}
+
+static void
+fu_qmi_pdc_updater_finalize (GObject *object)
+{
+	FuQmiPdcUpdater *self = FU_QMI_PDC_UPDATER (object);
+	g_assert (self->qmi_client == NULL);
+	g_assert (self->qmi_device == NULL);
+	g_free (self->qmi_port);
+	G_OBJECT_CLASS (fu_qmi_pdc_updater_parent_class)->finalize (object);
+}
+
+static void
+fu_qmi_pdc_updater_class_init (FuQmiPdcUpdaterClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+	object_class->finalize = fu_qmi_pdc_updater_finalize;
+}
+
+FuQmiPdcUpdater *
+fu_qmi_pdc_updater_new (const gchar *path)
+{
+	FuQmiPdcUpdater *self = g_object_new (FU_TYPE_QMI_PDC_UPDATER, NULL);
+	self->qmi_port = g_strdup (path);
+	return self;
+}

--- a/plugins/modem-manager/fu-qmi-pdc-updater.h
+++ b/plugins/modem-manager/fu-qmi-pdc-updater.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2019 Aleksander Morgado <aleksander@aleksander.es>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#ifndef __FU_QMI_PDC_UPDATER_H
+#define __FU_QMI_PDC_UPDATER_H
+
+#include <libqmi-glib.h>
+
+G_BEGIN_DECLS
+
+#define FU_TYPE_QMI_PDC_UPDATER (fu_qmi_pdc_updater_get_type ())
+G_DECLARE_FINAL_TYPE (FuQmiPdcUpdater, fu_qmi_pdc_updater, FU, QMI_PDC_UPDATER, GObject)
+
+FuQmiPdcUpdater	*fu_qmi_pdc_updater_new		(const gchar		*qmi_port);
+gboolean	fu_qmi_pdc_updater_open		(FuQmiPdcUpdater	*self,
+						 GError			**error);
+gboolean	fu_qmi_pdc_updater_write	(FuQmiPdcUpdater	*self,
+						 const gchar		*filename,
+						 GBytes			*blob,
+						 GError			**error);
+gboolean	fu_qmi_pdc_updater_close	(FuQmiPdcUpdater	*self,
+						 GError			**error);
+
+G_END_DECLS
+
+#endif /* __FU_QMI_PDC_UPDATER_H */

--- a/plugins/modem-manager/meson.build
+++ b/plugins/modem-manager/meson.build
@@ -5,6 +5,8 @@ shared_module('fu_plugin_modem_manager',
   sources : [
     'fu-plugin-modem-manager.c',
     'fu-mm-device.c',
+    'fu-qmi-pdc-updater.c',
+    'fu-mm-utils.c'
   ],
   include_directories : [
     include_directories('../..'),
@@ -22,5 +24,6 @@ shared_module('fu_plugin_modem_manager',
   dependencies : [
     plugin_deps,
     libmm_glib,
+    libqmi_glib,
   ],
 )

--- a/plugins/modem-manager/meson.build
+++ b/plugins/modem-manager/meson.build
@@ -1,0 +1,26 @@
+cargs = ['-DG_LOG_DOMAIN="FuPluginMm"']
+
+shared_module('fu_plugin_modem_manager',
+  fu_hash,
+  sources : [
+    'fu-plugin-modem-manager.c',
+    'fu-mm-device.c',
+  ],
+  include_directories : [
+    include_directories('../..'),
+    include_directories('../../src'),
+    include_directories('../../libfwupd'),
+  ],
+  install : true,
+  install_dir: plugin_dir,
+  c_args : [
+    cargs,
+  ],
+  link_with : [
+    libfwupdprivate,
+  ],
+  dependencies : [
+    plugin_deps,
+    libmm_glib,
+  ],
+)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,6 +93,29 @@ parts:
       - -lib/girepository-1.0
       - -lib/pkgconfig
       - -share/
+  # this is for the library only, we don't care about the daemon "in-snap"
+  modemmanager:
+    plugin: autotools
+    source: https://gitlab.freedesktop.org/mobile-broadband/ModemManager.git
+    #not yet tagged
+    #source-tag: 1.10.0
+    after: [gudev, gettext]
+    # build without these; system daemon needs them
+    configflags:
+      - --without-mbim
+      - --without-qmi
+    prime:
+      - -include
+      - -etc
+      - -sbin
+      - -bin
+      - -share
+      - -lib/*.*a
+      - -lib/pkgconfig
+      - -lib/ModemManager
+      - -lib/systemd
+      - -lib/udev
+      - -lib/girepository-1.0
   libusb:
     plugin: autotools
     source: https://github.com/libusb/libusb/releases/download/v1.0.22/libusb-1.0.22.tar.bz2
@@ -259,7 +282,7 @@ parts:
       - -usr/share/gir-1.0
       - -usr/share/upstart
       - -usr/lib/*/pkgconfig
-    after: [gudev, gusb, gnu-efi, libefivar-fixpkgconfig, libsmbios, build-introspection, gettext]
+    after: [gudev, gusb, gnu-efi, libefivar-fixpkgconfig, libsmbios, build-introspection, gettext, modemmanager]
   fix-bash-completion:
     plugin: make
     source: contrib/snap/fix-bash-completion


### PR DESCRIPTION
@hughsie @superm1 this is what I came up with for the DW5821e....

This module requires first a fastboot-based firmware download (e.g. to flash the modem system) plus then N qmi-pdc-based downloads (one for each carrier-specific configuration provided for the associated modem system).

The most controversial change is probably the looping in the engine and how the plugins specify the list of supported methods that the engine should trigger for separate detach/update/attach operations.

Comments welcome!