### PR TITLE
ata: Default to the non-activation 0xE subcommand

### DIFF
--- a/plugins/ata/fu-self-test.c
+++ b/plugins/ata/fu-self-test.c
@@ -29,7 +29,7 @@ fu_ata_id_func (void)
 	dev = fu_ata_device_new_from_blob ((guint8 *)data, sz, &error);
 	g_assert_no_error (error);
 	g_assert_nonnull (dev);
-	g_assert_cmpint (fu_ata_device_get_transfer_mode (dev), ==, 0x3);
+	g_assert_cmpint (fu_ata_device_get_transfer_mode (dev), ==, 0xe);
 	g_assert_cmpint (fu_ata_device_get_transfer_blocks (dev), ==, 0x1);
 	g_assert_cmpstr (fu_device_get_serial (FU_DEVICE (dev)), ==, "A45A078A198600476509");
 	g_assert_cmpstr (fu_device_get_name (FU_DEVICE (dev)), ==, "SATA SSD");


### PR DESCRIPTION
During download and activation we have to reset the drive to apply the new
firmware. If the kernel gets an unexpected ATA reset then it might panic.
Default to activating the command on the next drive power-up to be safe.

Many thanks to the Dell storage team for the advice.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
