### PR TITLE
contrib/debian: always build without -Bsymbolic-functions

### DIFF
--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -4,6 +4,11 @@
 export LC_ALL := C.UTF-8
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
+# Link without -Bsymbolic-functions
+ifneq (,$(LDFLAGS))
+  LDFLAGS := $(filter-out %-Bsymbolic-functions,$(LDFLAGS))
+endif
+
 #GPGME needs this for proper building on 32 bit archs
 ifeq "$(DEB_HOST_ARCH_BITS)" "32"
 	export DEB_CFLAGS_MAINT_APPEND = -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE


### PR DESCRIPTION
Ubuntu packaging may enable -Bsymbolic-functions unconditionally and
that totally breaks the plugin loading logic in fwupd. So, make sure
that specific linker option is never used.

Type of pull request:
- [ ] New plugin
- [X] Code fix
- [ ] Feature
- [ ] Documentation
