### PR TITLE
nvme: When adding vendor GUIDs clear all other GUIDs from device

### DIFF
--- a/libfwupd/fwupd-device.c
+++ b/libfwupd/fwupd-device.c
@@ -364,6 +364,24 @@ fwupd_device_get_guid_default (FwupdDevice *device)
 }
 
 /**
+ * fwupd_device_reset_guids:
+ * @device: A #FwupdDevice
+ *
+ * Removes all GUIDs from the device
+ *
+ * Since: 1.2.5
+ **/
+void
+fwupd_device_reset_guids (FwupdDevice *device)
+{
+	FwupdDevicePrivate *priv = GET_PRIVATE (device);
+	g_return_if_fail (FWUPD_IS_DEVICE (device));
+	if (priv->guids->len == 0)
+		return;
+	g_ptr_array_set_size (priv->guids, 0);
+}
+
+/**
  * fwupd_device_get_instance_ids:
  * @device: A #FwupdDevice
  *

--- a/libfwupd/fwupd-device.h
+++ b/libfwupd/fwupd-device.h
@@ -100,6 +100,7 @@ void		 fwupd_device_add_guid			(FwupdDevice	*device,
 							 const gchar	*guid);
 gboolean	 fwupd_device_has_guid			(FwupdDevice	*device,
 							 const gchar	*guid);
+void		 fwupd_device_reset_guids		(FwupdDevice	*device);
 GPtrArray	*fwupd_device_get_guids			(FwupdDevice	*device);
 const gchar	*fwupd_device_get_guid_default		(FwupdDevice	*device);
 void		 fwupd_device_add_instance_id		(FwupdDevice	*device,

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -313,6 +313,7 @@ LIBFWUPD_1.2.5 {
     fwupd_device_add_instance_id;
     fwupd_device_get_instance_ids;
     fwupd_device_has_instance_id;
+    fwupd_device_reset_guids;
     fwupd_guid_from_buf;
     fwupd_guid_from_data;
     fwupd_guid_from_string;

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -184,6 +184,7 @@ fu_nvme_device_parse_cns_maybe_dell (FuNvmeDevice *self, const guint8 *buf)
 		g_debug ("invalid component ID, skipping");
 		return;
 	}
+	fu_device_reset_guids (FU_DEVICE (self));
 	devid = g_strdup_printf ("STORAGE-DELL-%s", component_id);
 	fu_device_add_instance_id (FU_DEVICE (self), devid);
 

--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -118,6 +118,7 @@ FuDevice	*fu_device_new				(void);
 #define fu_device_get_vendor_id(d)		fwupd_device_get_vendor_id(FWUPD_DEVICE(d))
 #define fu_device_get_flashes_left(d)		fwupd_device_get_flashes_left(FWUPD_DEVICE(d))
 #define fu_device_get_install_duration(d)	fwupd_device_get_install_duration(FWUPD_DEVICE(d))
+#define fu_device_reset_guids(d)		fwupd_device_reset_guids(FWUPD_DEVICE(d))
 
 /* accessors */
 gchar		*fu_device_to_string			(FuDevice	*self);


### PR DESCRIPTION
These should be preferred to use.  Non-vendor firmware will not work
properly but otherwise fwupd will try to load "generic" firmware to
the device if the vendor does target the "generic" device GUID.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
