### PR TITLE
Add fwupd_guid_from_string() to drop dep on uuid

### DIFF
--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -1109,21 +1109,6 @@
       <package variant="x86_64" />
     </distro>
   </dependency>
-  <dependency type="build" id="uuid-dev">
-    <distro id="centos">
-      <package>libuuid-devel</package>
-    </distro>
-    <distro id="debian">
-      <control />
-      <package variant="x86_64" />
-      <package variant="s390x">uuid-dev:s390x</package>
-      <package variant="i386" />
-    </distro>
-    <distro id="ubuntu">
-      <control />
-      <package variant="x86_64" />
-    </distro>
-  </dependency>
   <dependency type="build" id="valac">
     <distro id="arch">
       <package>vala</package>

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -54,7 +54,6 @@ BuildRequires: valgrind-devel
 %endif
 BuildRequires: elfutils-libelf-devel
 BuildRequires: gtk-doc
-BuildRequires: libuuid-devel
 BuildRequires: gnutls-devel
 BuildRequires: gnutls-utils
 BuildRequires: meson

--- a/contrib/snap/snapcraft-master.yaml
+++ b/contrib/snap/snapcraft-master.yaml
@@ -215,7 +215,6 @@ parts:
       - libsqlite3-dev
       - locales
       - pkg-config
-      - uuid-dev
     stage-packages:
       - libgcab-1.0-0
       - libarchive13

--- a/libfwupd/fwupd-common.c
+++ b/libfwupd/fwupd-common.c
@@ -15,7 +15,6 @@
 #include <string.h>
 #include <sys/utsname.h>
 #include <json-glib/json-glib.h>
-#include <uuid.h>
 
 /**
  * fwupd_checksum_guess_kind:
@@ -523,12 +522,12 @@ typedef struct __attribute__((packed)) {
 	guint16		c;
 	guint16		d;
 	guint8		e[6];
-} FwupdGuid;
+} fwupd_guid_native_t;
 
 /**
- * fwupd_guid_from_buf:
+ * fwupd_guid_to_string:
+ * @guid: a #fwupd_guid_t to read
  * @flags: some %FwupdGuidFlags, e.g. %FWUPD_GUID_FLAG_MIXED_ENDIAN
- * @buf: data to read, at least 16 bytes in length
  *
  * Returns a text GUID of mixed or BE endian for a packed buffer.
  *
@@ -537,39 +536,187 @@ typedef struct __attribute__((packed)) {
  * Since: 1.2.5
  **/
 gchar *
-fwupd_guid_from_buf (const guint8 *buf, FwupdGuidFlags flags)
+fwupd_guid_to_string (const fwupd_guid_t *guid, FwupdGuidFlags flags)
 {
-	FwupdGuid guid;
+	fwupd_guid_native_t gnat;
+
+	g_return_val_if_fail (guid != NULL, NULL);
 
 	/* copy to avoid issues with aligning */
-	memcpy (&guid, buf, sizeof(FwupdGuid));
+	memcpy (&gnat, guid, sizeof(gnat));
 
 	/* mixed is bizaar, but specified as the DCE encoding */
 	if (flags & FWUPD_GUID_FLAG_MIXED_ENDIAN) {
 		return g_strdup_printf ("%08x-%04x-%04x-%04x-%02x%02x%02x%02x%02x%02x",
-					GUINT32_FROM_LE(guid.a),
-					GUINT16_FROM_LE(guid.b),
-					GUINT16_FROM_LE(guid.c),
-					GUINT16_FROM_BE(guid.d),
-					guid.e[0], guid.e[1],
-					guid.e[2], guid.e[3],
-					guid.e[4], guid.e[5]);
+					GUINT32_FROM_LE(gnat.a),
+					GUINT16_FROM_LE(gnat.b),
+					GUINT16_FROM_LE(gnat.c),
+					GUINT16_FROM_BE(gnat.d),
+					gnat.e[0], gnat.e[1],
+					gnat.e[2], gnat.e[3],
+					gnat.e[4], gnat.e[5]);
 	}
 	return g_strdup_printf ("%08x-%04x-%04x-%04x-%02x%02x%02x%02x%02x%02x",
-				GUINT32_FROM_BE(guid.a),
-				GUINT16_FROM_BE(guid.b),
-				GUINT16_FROM_BE(guid.c),
-				GUINT16_FROM_BE(guid.d),
-				guid.e[0], guid.e[1],
-				guid.e[2], guid.e[3],
-				guid.e[4], guid.e[5]);
+				GUINT32_FROM_BE(gnat.a),
+				GUINT16_FROM_BE(gnat.b),
+				GUINT16_FROM_BE(gnat.c),
+				GUINT16_FROM_BE(gnat.d),
+				gnat.e[0], gnat.e[1],
+				gnat.e[2], gnat.e[3],
+				gnat.e[4], gnat.e[5]);
+}
+
+#if !GLIB_CHECK_VERSION(2,54,0)
+static gboolean
+str_has_sign (const gchar *str)
+{
+	return str[0] == '-' || str[0] == '+';
+}
+
+static gboolean
+str_has_hex_prefix (const gchar *str)
+{
+	return str[0] == '0' && g_ascii_tolower (str[1]) == 'x';
+}
+
+static gboolean
+g_ascii_string_to_unsigned (const gchar *str,
+			    guint base,
+			    guint64 min,
+			    guint64 max,
+			    guint64 *out_num,
+			    GError **error)
+{
+	const gchar *end_ptr = NULL;
+	gint saved_errno = 0;
+	guint64 number;
+
+	g_return_val_if_fail (str != NULL, FALSE);
+	g_return_val_if_fail (base >= 2 && base <= 36, FALSE);
+	g_return_val_if_fail (min <= max, FALSE);
+	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+	if (str[0] == '\0') {
+		g_set_error_literal (error,
+				     G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+				     "Empty string is not a number");
+		return FALSE;
+	}
+
+	errno = 0;
+	number = g_ascii_strtoull (str, (gchar **)&end_ptr, base);
+	saved_errno = errno;
+
+	if (g_ascii_isspace (str[0]) || str_has_sign (str) ||
+	    (base == 16 && str_has_hex_prefix (str)) ||
+	    (saved_errno != 0 && saved_errno != ERANGE) ||
+	    end_ptr == NULL ||
+	    *end_ptr != '\0') {
+		g_set_error (error,
+			     G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+			     "“%s” is not an unsigned number", str);
+		return FALSE;
+	}
+	if (saved_errno == ERANGE || number < min || number > max) {
+		g_autofree gchar *min_str = g_strdup_printf ("%" G_GUINT64_FORMAT, min);
+		g_autofree gchar *max_str = g_strdup_printf ("%" G_GUINT64_FORMAT, max);
+		g_set_error (error,
+			     G_IO_ERROR, G_IO_ERROR_INVALID_DATA,
+			     "Number “%s” is out of bounds [%s, %s]",
+			     str, min_str, max_str);
+		return FALSE;
+	}
+	if (out_num != NULL)
+		*out_num = number;
+	return TRUE;
+}
+#endif /* GLIB_CHECK_VERSION(2,54,0) */
+
+/**
+ * fwupd_guid_from_string:
+ * @guidstr: (nullable): a GUID, e.g. `00112233-4455-6677-8899-aabbccddeeff`
+ * @guid: a #fwupd_guid_t, or NULL to just check the GUID
+ * @flags: some %FwupdGuidFlags, e.g. %FWUPD_GUID_FLAG_MIXED_ENDIAN
+ * @error: A #GError or %NULL
+ *
+ * Converts a string GUID into its binary encoding. All string GUIDs are
+ * formatted as big endian but on-disk can be encoded in different ways.
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 1.2.5
+ **/
+gboolean
+fwupd_guid_from_string (const gchar *guidstr,
+			fwupd_guid_t *guid,
+			FwupdGuidFlags flags,
+			GError **error)
+{
+	fwupd_guid_native_t gu = { 0x0 };
+	gboolean mixed_endian = flags & FWUPD_GUID_FLAG_MIXED_ENDIAN;
+	guint64 tmp;
+	g_auto(GStrv) split = NULL;
+
+	g_return_val_if_fail (guidstr != NULL, FALSE);
+
+	/* split into sections */
+	if (strlen (guidstr) != 36) {
+		g_set_error_literal (error,
+				     G_IO_ERROR,
+				     G_IO_ERROR_INVALID_DATA,
+				     "is not valid format");
+		return FALSE;
+	}
+	split = g_strsplit (guidstr, "-", 5);
+	if (g_strv_length (split) != 5) {
+		g_set_error_literal (error,
+				     G_IO_ERROR,
+				     G_IO_ERROR_INVALID_DATA,
+				     "is not valid format, no dashes");
+		return FALSE;
+	}
+	if (strlen (split[0]) != 8 && strlen (split[1]) != 4 &&
+	    strlen (split[2]) != 4 && strlen (split[3]) != 4 &&
+	    strlen (split[4]) != 12) {
+		g_set_error_literal (error,
+				     G_IO_ERROR,
+				     G_IO_ERROR_INVALID_DATA,
+				     "is not valid format, not GUID");
+		return FALSE;
+	}
+
+	/* parse */
+	if (!g_ascii_string_to_unsigned (split[0], 16, 0, 0xffffffff, &tmp, error))
+		return FALSE;
+	gu.a = mixed_endian ? GUINT32_TO_LE(tmp) : GUINT32_TO_BE(tmp);
+	if (!g_ascii_string_to_unsigned (split[1], 16, 0, 0xffff, &tmp, error))
+		return FALSE;
+	gu.b = mixed_endian ? GUINT16_TO_LE(tmp) : GUINT16_TO_BE(tmp);
+	if (!g_ascii_string_to_unsigned (split[2], 16, 0, 0xffff, &tmp, error))
+		return FALSE;
+	gu.c = mixed_endian ? GUINT16_TO_LE(tmp) : GUINT16_TO_BE(tmp);
+	if (!g_ascii_string_to_unsigned (split[3], 16, 0, 0xffff, &tmp, error))
+		return FALSE;
+	gu.d = GUINT16_TO_BE(tmp);
+	for (guint i = 0; i < 6; i++) {
+		gchar buffer[3] = { 0x0 };
+		memcpy (buffer, split[4] + (i * 2), 2);
+		if (!g_ascii_string_to_unsigned (buffer, 16, 0, 0xff, &tmp, error))
+			return FALSE;
+		gu.e[i] = tmp;
+	}
+	if (guid != NULL)
+		memcpy (guid, &gu, sizeof(gu));
+
+	/* success */
+	return TRUE;
 }
 
 /**
- * fwupd_guid_from_data:
- * @flags: some %FwupdGuidFlags, e.g. %FWUPD_GUID_FLAG_NAMESPACE_MICROSOFT
+ * fwupd_guid_hash_data:
  * @data: data to hash
  * @datasz: length of @data
+ * @flags: some %FwupdGuidFlags, e.g. %FWUPD_GUID_FLAG_NAMESPACE_MICROSOFT
  *
  * Returns a GUID for some data. This uses a hash and so even small
  * differences in the @data will produce radically different return values.
@@ -582,14 +729,13 @@ fwupd_guid_from_buf (const guint8 *buf, FwupdGuidFlags flags)
  * Since: 1.2.5
  **/
 gchar *
-fwupd_guid_from_data (const guint8 *data, gsize datasz, FwupdGuidFlags flags)
+fwupd_guid_hash_data (const guint8 *data, gsize datasz, FwupdGuidFlags flags)
 {
 	const gchar *namespace_id = FWUPD_GUID_NAMESPACE_DEFAULT;
 	gsize digestlen = 20;
 	guint8 hash[20];
-	gint rc;
-	uuid_t uu_namespace;
-	uuid_t uu_new;
+	fwupd_guid_t uu_namespace;
+	fwupd_guid_t uu_new;
 	g_autoptr(GChecksum) csum = NULL;
 
 	g_return_val_if_fail (namespace_id != NULL, NULL);
@@ -600,31 +746,30 @@ fwupd_guid_from_data (const guint8 *data, gsize datasz, FwupdGuidFlags flags)
 	if (flags & FWUPD_GUID_FLAG_NAMESPACE_MICROSOFT)
 		namespace_id = FWUPD_GUID_NAMESPACE_MICROSOFT;
 
-	/* convert the namespace to binary */
-	rc = uuid_parse (namespace_id, uu_namespace);
-	if (rc != 0)
+	/* convert the namespace to binary: hardcoded BE, not @flags */
+	if (!fwupd_guid_from_string (namespace_id, &uu_namespace, FWUPD_GUID_FLAG_NONE, NULL))
 		return NULL;
 
 	/* hash the namespace and then the string */
 	csum = g_checksum_new (G_CHECKSUM_SHA1);
-	g_checksum_update (csum, (guchar *) uu_namespace, 16);
+	g_checksum_update (csum, (guchar *) &uu_namespace, sizeof(uu_namespace));
 	g_checksum_update (csum, (guchar *) data, (gssize) datasz);
 	g_checksum_get_digest (csum, hash, &digestlen);
 
 	/* copy most parts of the hash 1:1 */
-	memcpy (uu_new, hash, 16);
+	memcpy (uu_new, hash, sizeof(uu_new));
 
 	/* set specific bits according to Section 4.1.3 */
 	uu_new[6] = (guint8) ((uu_new[6] & 0x0f) | (5 << 4));
 	uu_new[8] = (guint8) ((uu_new[8] & 0x3f) | 0x80);
-	return fwupd_guid_from_buf (uu_new, flags);
+	return fwupd_guid_to_string ((const fwupd_guid_t *) &uu_new, flags);
 }
 
 /**
  * fwupd_guid_is_valid:
- * @guid: string to check
+ * @guid: string to check, e.g. `00112233-4455-6677-8899-aabbccddeeff`
  *
- * Checks the source string is a valid string GUID descriptor.
+ * Checks the string is a valid GUID.
  *
  * Returns: %TRUE if @guid was a valid GUID, %FALSE otherwise
  *
@@ -633,20 +778,17 @@ fwupd_guid_from_data (const guint8 *data, gsize datasz, FwupdGuidFlags flags)
 gboolean
 fwupd_guid_is_valid (const gchar *guid)
 {
-	gint rc;
-	uuid_t uu;
 	if (guid == NULL)
 		return FALSE;
-	if (strlen (guid) != 36)
+	if (!fwupd_guid_from_string (guid, NULL, FWUPD_GUID_FLAG_NONE, NULL))
 		return FALSE;
-	rc = uuid_parse (guid, uu);
-	if (uuid_is_null (uu))
+	if (g_strcmp0 (guid, "00000000-0000-0000-0000-000000000000") == 0)
 		return FALSE;
-	return rc == 0;
+	return TRUE;
 }
 
 /**
- * fwupd_guid_from_string:
+ * fwupd_guid_hash_string:
  * @str: A source string to use as a key
  *
  * Returns a GUID for a given string. This uses a hash and so even small
@@ -665,10 +807,10 @@ fwupd_guid_is_valid (const gchar *guid)
  * Since: 1.2.5
  **/
 gchar *
-fwupd_guid_from_string (const gchar *str)
+fwupd_guid_hash_string (const gchar *str)
 {
 	if (str == NULL)
 		return NULL;
-	return fwupd_guid_from_data ((const guint8 *) str, strlen (str),
+	return fwupd_guid_hash_data ((const guint8 *) str, strlen (str),
 				     FWUPD_GUID_FLAG_NONE);
 }

--- a/libfwupd/fwupd-common.h
+++ b/libfwupd/fwupd-common.h
@@ -31,6 +31,11 @@ typedef enum {
 	FWUPD_GUID_FLAG_LAST
 } FwupdGuidFlags;
 
+/* GObject Introspection does not understand typedefs with sizes */
+#ifndef __GI_SCANNER__
+typedef guint8 fwupd_guid_t[16];
+#endif
+
 const gchar	*fwupd_checksum_get_best		(GPtrArray	*checksums);
 const gchar	*fwupd_checksum_get_by_kind		(GPtrArray	*checksums,
 							 GChecksumType	 kind);
@@ -42,11 +47,25 @@ gchar		*fwupd_build_machine_id			(const gchar 	*salt,
 GHashTable	*fwupd_get_os_release			(GError		**error);
 gchar		*fwupd_build_history_report_json	(GPtrArray	*devices,
 							 GError		**error);
-gboolean	 fwupd_guid_is_valid			(const gchar	*guid);
-gchar		*fwupd_guid_from_buf			(const guint8	*buf,
+
+#ifndef __GI_SCANNER__
+gchar		*fwupd_guid_to_string			(const fwupd_guid_t *guid,
 							 FwupdGuidFlags	 flags);
-gchar		*fwupd_guid_from_string			(const gchar	*str);
-gchar		*fwupd_guid_from_data			(const guint8	*data,
+gboolean	 fwupd_guid_from_string			(const gchar	*guidstr,
+							 fwupd_guid_t	*guid,
+							 FwupdGuidFlags	 flags,
+							 GError		**error);
+#else
+gchar		*fwupd_guid_to_string			(const guint8	 guid[16],
+							 FwupdGuidFlags	 flags);
+gboolean	 fwupd_guid_from_string			(const gchar	*guidstr,
+							 guint8		 guid[16],
+							 FwupdGuidFlags	 flags,
+							 GError		**error);
+#endif
+gboolean	 fwupd_guid_is_valid			(const gchar	*guid);
+gchar		*fwupd_guid_hash_string			(const gchar	*str);
+gchar		*fwupd_guid_hash_data			(const guint8	*data,
 							 gsize		 datasz,
 							 FwupdGuidFlags	 flags);
 

--- a/libfwupd/fwupd-device.c
+++ b/libfwupd/fwupd-device.c
@@ -1642,7 +1642,7 @@ fwupd_device_to_string (FwupdDevice *device)
 	for (guint i = 0; i < priv->instance_ids->len; i++) {
 		const gchar *instance_id = g_ptr_array_index (priv->instance_ids, i);
 		g_hash_table_insert (ids,
-				     fwupd_guid_from_string (instance_id),
+				     fwupd_guid_hash_string (instance_id),
 				     g_strdup (instance_id));
 	}
 	for (guint i = 0; i < priv->guids->len; i++) {

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -313,9 +313,10 @@ LIBFWUPD_1.2.5 {
     fwupd_device_add_instance_id;
     fwupd_device_get_instance_ids;
     fwupd_device_has_instance_id;
-    fwupd_guid_from_buf;
-    fwupd_guid_from_data;
     fwupd_guid_from_string;
+    fwupd_guid_hash_data;
+    fwupd_guid_hash_string;
     fwupd_guid_is_valid;
+    fwupd_guid_to_string;
   local: *;
 } LIBFWUPD_1.2.4;

--- a/libfwupd/meson.build
+++ b/libfwupd/meson.build
@@ -46,7 +46,6 @@ fwupd = shared_library(
     giounix,
     soup,
     libjsonglib,
-    uuid,
   ],
   c_args : [
       cargs,
@@ -101,7 +100,6 @@ if get_option('introspection')
     dependencies : [
       giounix,
       soup,
-      uuid,
     ],
     includes : [
       'Gio-2.0',

--- a/meson.build
+++ b/meson.build
@@ -183,7 +183,6 @@ if get_option('gpg')
   conf.set('ENABLE_GPG', '1')
 endif
 libm = cc.find_library('m', required: false)
-uuid = dependency('uuid')
 libgcab = dependency('libgcab-1.0')
 if libgcab.version().version_compare('>= 0.8')
   conf.set('HAVE_GCAB_0_8', '1')

--- a/plugins/amt/fu-plugin-amt.c
+++ b/plugins/amt/fu-plugin-amt.c
@@ -13,7 +13,6 @@
 #include <linux/mei.h>
 #include <string.h>
 #include <sys/ioctl.h>
-#include <uuid.h>
 
 #include "fu-plugin-vfuncs.h"
 
@@ -446,10 +445,10 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(mei_context, mei_context_free)
 static FuDevice *
 fu_plugin_amt_create_device (GError **error)
 {
-	gchar guid_buf[37];
 	guint8 state;
 	struct amt_code_versions ver;
-	uuid_t uu;
+	fwupd_guid_t uu;
+	g_autofree gchar *guid_buf = NULL;
 	g_autofree struct amt_host_if_resp_header *response = NULL;
 	g_autoptr(FuDevice) dev = NULL;
 	g_autoptr(GString) version_bl = g_string_new (NULL);
@@ -507,7 +506,7 @@ fu_plugin_amt_create_device (GError **error)
 
 	/* add guid */
 	memcpy (&uu, &ctx->guid, 16);
-	uuid_unparse (uu, guid_buf);
+	guid_buf = fwupd_guid_to_string ((const fwupd_guid_t *) &uu, FWUPD_GUID_FLAG_NONE);
 	fu_device_add_guid (dev, guid_buf);
 
 	/* get version numbers */

--- a/plugins/amt/meson.build
+++ b/plugins/amt/meson.build
@@ -18,6 +18,5 @@ shared_module('fu_plugin_amt',
   c_args : cargs,
   dependencies : [
     plugin_deps,
-    uuid,
   ],
 )

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -144,7 +144,8 @@ fu_ata_device_get_guid_safe (const guint16 *buf, guint16 addr_start)
 {
 	if (!fu_common_guid_is_plausible ((guint8 *) (buf + addr_start)))
 		return NULL;
-	return fwupd_guid_from_buf ((const guint8 *) (buf + addr_start), FWUPD_GUID_FLAG_MIXED_ENDIAN);
+	return fwupd_guid_to_string ((const fwupd_guid_t *) (buf + addr_start),
+				     FWUPD_GUID_FLAG_MIXED_ENDIAN);
 }
 
 static void
@@ -171,7 +172,7 @@ fu_ata_device_parse_id_maybe_dell (FuAtaDevice *self, const guint16 *buf)
 	/* add instance ID *and* GUID as using no-auto-instance-ids */
 	guid_id = g_strdup_printf ("STORAGE-DELL-%s", component_id);
 	fu_device_add_instance_id (FU_DEVICE (self), guid_id);
-	guid = fwupd_guid_from_string (guid_id);
+	guid = fwupd_guid_hash_string (guid_id);
 	fu_device_add_guid (FU_DEVICE (self), guid);
 
 	/* also add the EFI GUID */

--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -627,11 +627,11 @@ fu_plugin_dell_detect_tpm (FuPlugin *plugin, GError **error)
 	}
 
 	tpm_guid_raw = g_strdup_printf ("%04x-%s", system_id, tpm_mode);
-	tpm_guid = fwupd_guid_from_string (tpm_guid_raw);
+	tpm_guid = fwupd_guid_hash_string (tpm_guid_raw);
 	tpm_id = g_strdup_printf ("DELL-%s" G_GUINT64_FORMAT, tpm_guid);
 
 	tpm_guid_raw_alt = g_strdup_printf ("%04x-%s", system_id, tpm_mode_alt);
-	tpm_guid_alt = fwupd_guid_from_string (tpm_guid_raw_alt);
+	tpm_guid_alt = fwupd_guid_hash_string (tpm_guid_raw_alt);
 	tpm_id_alt = g_strdup_printf ("DELL-%s" G_GUINT64_FORMAT, tpm_guid_alt);
 
 	g_debug ("Creating primary TPM GUID %s and secondary TPM GUID %s",

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -80,7 +80,8 @@ fu_nvme_device_get_guid_safe (const guint8 *buf, guint16 addr_start)
 {
 	if (!fu_common_guid_is_plausible (buf + addr_start))
 		return NULL;
-	return fwupd_guid_from_buf (buf + addr_start, FWUPD_GUID_FLAG_MIXED_ENDIAN);
+	return fwupd_guid_to_string ((const fwupd_guid_t *) buf + addr_start,
+				     FWUPD_GUID_FLAG_MIXED_ENDIAN);
 }
 
 static gboolean
@@ -193,7 +194,7 @@ fu_nvme_device_parse_cns_maybe_dell (FuNvmeDevice *self, const guint8 *buf)
 	/* add instance ID *and* GUID as using no-auto-instance-ids */
 	devid = g_strdup_printf ("STORAGE-DELL-%s", component_id);
 	fu_device_add_instance_id (FU_DEVICE (self), devid);
-	guid = fwupd_guid_from_string (devid);
+	guid = fwupd_guid_hash_string (devid);
 	fu_device_add_guid (FU_DEVICE (self), guid);
 
 	/* also add the EFI GUID */

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -211,7 +211,6 @@ parts:
       - libsqlite3-dev
       - locales
       - pkg-config
-      - uuid-dev
     stage-packages:
       - libgcab-1.0-0
       - libarchive13

--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -538,7 +538,7 @@ fu_device_add_parent_guid (FuDevice *self, const gchar *guid)
 
 	/* make valid */
 	if (!fwupd_guid_is_valid (guid)) {
-		g_autofree gchar *tmp = fwupd_guid_from_string (guid);
+		g_autofree gchar *tmp = fwupd_guid_hash_string (guid);
 		if (fu_device_has_parent_guid (self, tmp))
 			return;
 		g_debug ("using %s for %s", tmp, guid);
@@ -787,7 +787,7 @@ fu_device_has_guid (FuDevice *self, const gchar *guid)
 {
 	/* make valid */
 	if (!fwupd_guid_is_valid (guid)) {
-		g_autofree gchar *tmp = fwupd_guid_from_string (guid);
+		g_autofree gchar *tmp = fwupd_guid_hash_string (guid);
 		return fwupd_device_has_guid (FWUPD_DEVICE (self), tmp);
 	}
 
@@ -822,7 +822,7 @@ fu_device_add_instance_id (FuDevice *self, const gchar *instance_id)
  * @guid: A GUID, e.g. `2082b5e0-7a64-478a-b1b2-e3404fab6dad`
  *
  * Adds a GUID to the device. If the @guid argument is not a valid GUID then it
- * is converted to a GUID using fwupd_guid_from_string().
+ * is converted to a GUID using fwupd_guid_hash_string().
  *
  * Since: 0.7.2
  **/
@@ -842,7 +842,7 @@ fu_device_add_guid (FuDevice *self, const gchar *guid)
  * @guid: A GUID, e.g. `2082b5e0-7a64-478a-b1b2-e3404fab6dad`
  *
  * Adds a GUID to the device. If the @guid argument is not a valid GUID then it
- * is converted to a GUID using fwupd_guid_from_string().
+ * is converted to a GUID using fwupd_guid_hash_string().
  *
  * A counterpart GUID is typically the GUID of the same device in bootloader
  * or runtime mode, if they have a different device PCI or USB ID. Adding this
@@ -855,7 +855,7 @@ fu_device_add_counterpart_guid (FuDevice *self, const gchar *guid)
 {
 	/* make valid */
 	if (!fwupd_guid_is_valid (guid)) {
-		g_autofree gchar *tmp = fwupd_guid_from_string (guid);
+		g_autofree gchar *tmp = fwupd_guid_hash_string (guid);
 		fwupd_device_add_guid (FWUPD_DEVICE (self), tmp);
 		return;
 	}
@@ -2019,7 +2019,7 @@ fu_device_convert_instance_ids (FuDevice *self)
 		return;
 	for (guint i = 0; i < instance_ids->len; i++) {
 		const gchar *instance_id = g_ptr_array_index (instance_ids, i);
-		g_autofree gchar *guid = fwupd_guid_from_string (instance_id);
+		g_autofree gchar *guid = fwupd_guid_hash_string (instance_id);
 		fu_device_add_guid_safe (self, guid);
 	}
 }

--- a/src/fu-hwids.c
+++ b/src/fu-hwids.c
@@ -96,7 +96,7 @@ fu_hwids_get_guid_for_str (const gchar *str, GError **error)
 		data[i] = GUINT16_TO_LE(data[i]);
 
 	/* convert to a GUID */
-	return fwupd_guid_from_data ((guint8*) data, items_written * 2,
+	return fwupd_guid_hash_data ((guint8*) data, items_written * 2,
 				     FWUPD_GUID_FLAG_NAMESPACE_MICROSOFT);
 }
 

--- a/src/fu-quirks.c
+++ b/src/fu-quirks.c
@@ -99,7 +99,7 @@ fu_quirks_build_group_key (const gchar *group)
 			gsize len = strlen (guid_prefixes[i]);
 			if (fwupd_guid_is_valid (group + len))
 				return g_strdup (group + len);
-			return fwupd_guid_from_string (group + len);
+			return fwupd_guid_hash_string (group + len);
 		}
 	}
 


### PR DESCRIPTION
This also allows us to write mixed-endian structures and adds tests. As part of
this commit we've also changed the API of something that's not yet been in any
tarball release, so no pitchforks please.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [x] Feature
- [ ] Documentation
