### PR TITLE
Defer the InstanceID->GUID hashing until after setup

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -157,6 +157,8 @@ fwupd_device_flag_to_string (FwupdDeviceFlags device_flag)
 		return "ignore-validation";
 	if (device_flag == FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED)
 		return "another-write-required";
+	if (device_flag == FWUPD_DEVICE_FLAG_NO_AUTO_INSTANCE_IDS)
+		return "no-auto-instance-ids";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -215,6 +217,8 @@ fwupd_device_flag_from_string (const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_IGNORE_VALIDATION;
 	if (g_strcmp0 (device_flag, "another-write-required") == 0)
 		return FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED;
+	if (g_strcmp0 (device_flag, "no-auto-instance-ids") == 0)
+		return FWUPD_DEVICE_FLAG_NO_AUTO_INSTANCE_IDS;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -85,6 +85,7 @@ typedef enum {
  * @FWUPD_DEVICE_FLAG_TRUSTED:			Extra metadata can be exposed about this device
  * @FWUPD_DEVICE_FLAG_NEEDS_SHUTDOWN:		Requires system shutdown to apply firmware
  * @FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED:	Requires the update to be retried with a new plugin
+ * @FWUPD_DEVICE_FLAG_NO_AUTO_INSTANCE_IDS:	Do not add instance IDs from the device baseclass
  *
  * The device flags.
  **/
@@ -108,6 +109,7 @@ typedef enum {
 #define FWUPD_DEVICE_FLAG_TRUSTED		(1u << 16)	/* Since: 1.1.2 */
 #define FWUPD_DEVICE_FLAG_NEEDS_SHUTDOWN	(1u << 17)	/* Since: 1.2.4 */
 #define FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED (1u << 18)	/* Since: 1.2.5 */
+#define FWUPD_DEVICE_FLAG_NO_AUTO_INSTANCE_IDS	(1u << 19)	/* Since: 1.2.5 */
 #define FWUPD_DEVICE_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 0.7.3 */
 typedef guint64 FwupdDeviceFlags;
 

--- a/plugins/nvme/fu-self-test.c
+++ b/plugins/nvme/fu-self-test.c
@@ -8,6 +8,7 @@
 
 #include <fwupd.h>
 
+#include "fu-device-private.h"
 #include "fu-nvme-device.h"
 #include "fu-test.h"
 
@@ -29,6 +30,7 @@ fu_nvme_cns_func (void)
 	dev = fu_nvme_device_new_from_blob ((guint8 *)data, sz, &error);
 	g_assert_no_error (error);
 	g_assert_nonnull (dev);
+	fu_device_convert_instance_ids (FU_DEVICE (dev));
 	g_assert_cmpstr (fu_device_get_name (FU_DEVICE (dev)), ==, "THNSN5512GPU7 TOSHIBA");
 	g_assert_cmpstr (fu_device_get_version (FU_DEVICE (dev)), ==, "410557LA");
 	g_assert_cmpstr (fu_device_get_serial (FU_DEVICE (dev)), ==, "37RSDEADBEEF");

--- a/plugins/wacom-raw/fu-plugin-wacom-raw.c
+++ b/plugins/wacom-raw/fu-plugin-wacom-raw.c
@@ -56,7 +56,7 @@ fu_plugin_udev_device_added (FuPlugin *plugin, FuUdevDevice *device, GError **er
 		return TRUE;
 
 	/* EMR */
-	if (fu_device_has_guid (FU_DEVICE (device), "WacomEMR")) {
+	if (fu_device_has_instance_id (FU_DEVICE (device), "WacomEMR")) {
 		g_autoptr(FuWacomEmrDevice) dev = fu_wacom_emr_device_new (device);
 		g_autoptr(FuDeviceLocker) locker = fu_device_locker_new (dev, error);
 		if (locker == NULL)
@@ -65,7 +65,7 @@ fu_plugin_udev_device_added (FuPlugin *plugin, FuUdevDevice *device, GError **er
 	}
 
 	/* AES */
-	if (fu_device_has_guid (FU_DEVICE (device), "WacomAES")) {
+	if (fu_device_has_instance_id (FU_DEVICE (device), "WacomAES")) {
 		g_autoptr(FuWacomAesDevice) dev = fu_wacom_aes_device_new (device);
 		g_autoptr(FuDeviceLocker) locker = fu_device_locker_new (dev, error);
 		if (locker == NULL)

--- a/plugins/wacom-raw/fu-wacom-emr-device.c
+++ b/plugins/wacom-raw/fu-wacom-emr-device.c
@@ -186,7 +186,7 @@ fu_wacom_emr_device_write_firmware (FuDevice *device, GPtrArray *chunks, GError 
 	guint8 idx = 0;
 
 	/* erase W9013 */
-	if (fu_device_has_guid (device, "WacomEMR_W9013")) {
+	if (fu_device_has_instance_id (device, "WacomEMR_W9013")) {
 		fu_device_set_status (device, FWUPD_STATUS_DEVICE_ERASE);
 		if (!fu_wacom_emr_device_w9013_erase_data (self, error))
 			return FALSE;
@@ -197,7 +197,7 @@ fu_wacom_emr_device_write_firmware (FuDevice *device, GPtrArray *chunks, GError 
 	}
 
 	/* erase W9021 */
-	if (fu_device_has_guid (device, "WacomEMR_W9021")) {
+	if (fu_device_has_instance_id (device, "WacomEMR_W9021")) {
 		if (!fu_wacom_device_w9021_erase_all (self, error))
 			return FALSE;
 	}

--- a/src/fu-device-private.h
+++ b/src/fu-device-private.h
@@ -29,6 +29,7 @@ gboolean	 fu_device_ensure_id			(FuDevice	*self,
 							 GError		**error);
 void		 fu_device_incorporate_from_component	(FuDevice	*device,
 							 XbNode		*component);
+void		 fu_device_convert_instance_ids		(FuDevice	*self);
 
 G_END_DECLS
 

--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -79,6 +79,7 @@ FuDevice	*fu_device_new				(void);
 #define fu_device_add_flag(d,v)			fwupd_device_add_flag(FWUPD_DEVICE(d),v)
 #define fu_device_remove_flag(d,v)		fwupd_device_remove_flag(FWUPD_DEVICE(d),v)
 #define fu_device_has_flag(d,v)			fwupd_device_has_flag(FWUPD_DEVICE(d),v)
+#define fu_device_has_instance_id(d,v)		fwupd_device_has_instance_id(FWUPD_DEVICE(d),v)
 #define fu_device_add_checksum(d,v)		fwupd_device_add_checksum(FWUPD_DEVICE(d),v)
 #define fu_device_add_release(d,v)		fwupd_device_add_release(FWUPD_DEVICE(d),v)
 #define fu_device_add_icon(d,v)			fwupd_device_add_icon(FWUPD_DEVICE(d),v)

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -406,16 +406,19 @@ fu_engine_device_priority_func (void)
 	fu_device_set_priority (device1, 0);
 	fu_device_set_plugin (device1, "udev");
 	fu_device_add_instance_id (device1, "GUID1");
+	fu_device_convert_instance_ids (device1);
 	fu_engine_add_device (engine, device1);
 	fu_device_set_id (device2, "id2");
 	fu_device_set_priority (device2, 1);
 	fu_device_set_plugin (device2, "redfish");
 	fu_device_add_instance_id (device2, "GUID1");
+	fu_device_convert_instance_ids (device2);
 	fu_engine_add_device (engine, device2);
 	fu_device_set_id (device3, "id3");
 	fu_device_set_priority (device3, 0);
 	fu_device_set_plugin (device3, "uefi");
 	fu_device_add_instance_id (device3, "GUID1");
+	fu_device_convert_instance_ids (device3);
 	fu_engine_add_device (engine, device3);
 
 	/* get the high prio device */
@@ -452,17 +455,20 @@ fu_engine_device_parent_func (void)
 	fu_device_set_id (device1, "child");
 	fu_device_add_instance_id (device1, "child-GUID-1");
 	fu_device_add_parent_guid (device1, "parent-GUID");
+	fu_device_convert_instance_ids (device1);
 	fu_engine_add_device (engine, device1);
 
 	/* parent */
 	fu_device_set_id (device2, "parent");
 	fu_device_add_instance_id (device2, "parent-GUID");
 	fu_device_set_vendor (device2, "oem");
+	fu_device_convert_instance_ids (device2);
 
 	/* add another child */
 	fu_device_set_id (device3, "child2");
 	fu_device_add_instance_id (device3, "child-GUID-2");
 	fu_device_add_parent_guid (device3, "parent-GUID");
+	fu_device_convert_instance_ids (device3);
 	fu_device_add_child (device2, device3);
 
 	/* add two together */
@@ -1150,6 +1156,7 @@ fu_device_list_delay_func (void)
 	fu_device_set_id (device1, "device1");
 	fu_device_add_instance_id (device1, "foobar");
 	fu_device_set_remove_delay (device1, 100);
+	fu_device_convert_instance_ids (device1);
 	fu_device_list_add (device_list, device1);
 	g_assert_cmpint (added_cnt, ==, 1);
 	g_assert_cmpint (removed_cnt, ==, 0);
@@ -1278,11 +1285,13 @@ fu_device_list_replug_user_func (void)
 	fu_device_add_instance_id (device1, "bar");
 	fu_device_set_plugin (device1, "self-test");
 	fu_device_set_remove_delay (device1, FU_DEVICE_REMOVE_DELAY_USER_REPLUG);
+	fu_device_convert_instance_ids (device1);
 	fu_device_set_id (device2, "device2");
 	fu_device_add_instance_id (device2, "baz");
 	fu_device_add_instance_id (device2, "bar"); /* matches */
 	fu_device_set_plugin (device2, "self-test");
 	fu_device_set_remove_delay (device2, FU_DEVICE_REMOVE_DELAY_USER_REPLUG);
+	fu_device_convert_instance_ids (device2);
 
 	/* not yet added */
 	ret = fu_device_list_wait_for_replug (device_list, device1, &error);
@@ -1341,6 +1350,7 @@ fu_device_list_compatible_func (void)
 	fu_device_add_instance_id (device1, "foobar");
 	fu_device_add_instance_id (device1, "bootloader");
 	fu_device_set_remove_delay (device1, 100);
+	fu_device_convert_instance_ids (device1);
 	fu_device_list_add (device_list, device1);
 	g_assert_cmpint (added_cnt, ==, 1);
 	g_assert_cmpint (removed_cnt, ==, 0);
@@ -1350,6 +1360,7 @@ fu_device_list_compatible_func (void)
 	fu_device_set_id (device2, "device2");
 	fu_device_set_plugin (device2, "plugin-for-bootloader");
 	fu_device_add_instance_id (device2, "bootloader");
+	fu_device_convert_instance_ids (device2);
 
 	/* verify only a changed event was generated */
 	added_cnt = removed_cnt = changed_cnt = 0;
@@ -1409,6 +1420,7 @@ fu_device_list_remove_chain_func (void)
 	/* add child */
 	fu_device_set_id (device_child, "child");
 	fu_device_add_instance_id (device_child, "child-GUID-1");
+	fu_device_convert_instance_ids (device_child);
 	fu_device_list_add (device_list, device_child);
 	g_assert_cmpint (added_cnt, ==, 1);
 	g_assert_cmpint (removed_cnt, ==, 0);
@@ -1417,6 +1429,7 @@ fu_device_list_remove_chain_func (void)
 	/* add parent */
 	fu_device_set_id (device_parent, "parent");
 	fu_device_add_instance_id (device_parent, "parent-GUID-1");
+	fu_device_convert_instance_ids (device_parent);
 	fu_device_add_child (device_parent, device_child);
 	fu_device_list_add (device_list, device_parent);
 	g_assert_cmpint (added_cnt, ==, 2);
@@ -1457,9 +1470,11 @@ fu_device_list_func (void)
 	/* add both */
 	fu_device_set_id (device1, "device1");
 	fu_device_add_instance_id (device1, "foobar");
+	fu_device_convert_instance_ids (device1);
 	fu_device_list_add (device_list, device1);
 	fu_device_set_id (device2, "device2");
 	fu_device_add_instance_id (device2, "baz");
+	fu_device_convert_instance_ids (device2);
 	fu_device_list_add (device_list, device2);
 	g_assert_cmpint (added_cnt, ==, 2);
 	g_assert_cmpint (removed_cnt, ==, 0);
@@ -1841,6 +1856,7 @@ fu_plugin_quirks_device_func (void)
 	fu_device_set_quirks (device, quirks);
 	fu_device_add_flag (device, FWUPD_DEVICE_FLAG_UPDATABLE);
 	fu_device_add_instance_id (device, "USB\\VID_0BDA&PID_1100");
+	fu_device_convert_instance_ids (device);
 	g_assert_cmpstr (fu_device_get_name (device), ==, "Hub");
 
 	/* ensure children are created */


### PR DESCRIPTION
This allows hardware from OEMs to *not* match generic firmware supplied by the
device manufacturer. The idea being, that the OEM will supply firmware that
will actually work on the device.

Based on a patch from Mario Limonciello, many thanks.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
