### PR TITLE
trivial: Correct the license for some metadata files

### DIFF
--- a/data/remotes.d/lvfs-testing.metainfo.xml
+++ b/data/remotes.d/lvfs-testing.metainfo.xml
@@ -4,7 +4,7 @@
 <component type="source">
   <id>org.freedesktop.fwupd.remotes.lvfs-testing</id>
   <name>Linux Vendor Firmware Service (testing firmware)</name>
-  <metadata_license>CC0</metadata_license>
+  <metadata_license>CC0-1.0</metadata_license>
   <agreement version_id="1.0">
     <agreement_section>
       <description>

--- a/data/remotes.d/lvfs.metainfo.xml
+++ b/data/remotes.d/lvfs.metainfo.xml
@@ -4,7 +4,7 @@
 <component type="source">
   <id>org.freedesktop.fwupd.remotes.lvfs</id>
   <name>Linux Vendor Firmware Service (stable firmware)</name>
-  <metadata_license>CC0</metadata_license>
+  <metadata_license>CC0-1.0</metadata_license>
   <agreement version_id="1.0">
     <agreement_section>
       <description>


### PR DESCRIPTION
These warnings were coming up in the Debian build:
```
W: fwupd source: inconsistent-appstream-metadata-license data/remotes.d/lvfs-testing.metainfo.xml (cc0 != cc0-1.0)
W: fwupd source: inconsistent-appstream-metadata-license data/remotes.d/lvfs.metainfo.xml (cc0 != cc0-1.0)
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation
