### PR TITLE
udev: Manally call fu_device_setup() to convert the instance IDs

### DIFF
--- a/plugins/udev/fu-plugin-udev.c
+++ b/plugins/udev/fu-plugin-udev.c
@@ -93,6 +93,10 @@ fu_plugin_udev_device_added (FuPlugin *plugin, FuUdevDevice *device, GError **er
 	if (g_file_test (rom_fn, G_FILE_TEST_EXISTS))
 		fu_device_set_metadata (FU_DEVICE (device), "RomFilename", rom_fn);
 
+	/* we never open the device, so convert the instance IDs */
+	if (!fu_device_setup (FU_DEVICE (device), error))
+		return FALSE;
+
 	/* insert to hash */
 	fu_plugin_device_add (plugin, FU_DEVICE (device));
 	return TRUE;


### PR DESCRIPTION
The udev plugin is somewhat special as it uses a non-subclassed FuDevice that
never gets 'opened'.

This means that we never automatically call fu_device_setup() and thus the
instance IDs are not converted into GUIDs before the device is added.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
