### PR TITLE
fu-common-cab: Correct handling of CAB files w/ nested directories an…

### DIFF
--- a/src/fu-common-cab.c
+++ b/src/fu-common-cab.c
@@ -33,7 +33,7 @@ _gcab_cabinet_get_file_by_name (GCabCabinet *cabinet, const gchar *basename)
 		g_autoptr(GSList) files = gcab_folder_get_files (cabfolder);
 		for (GSList *l = files; l != NULL; l = l->next) {
 			GCabFile *cabfile = GCAB_FILE (l->data);
-			if (g_strcmp0 (gcab_file_get_name (cabfile), basename) == 0)
+			if (g_strcmp0 (gcab_file_get_extract_name (cabfile), basename) == 0)
 				return cabfile;
 		}
 #endif


### PR DESCRIPTION
…d older libgcab

CABs like this are commonly created by `makecab.exe` on Windows.
```
DriverPackage\filename.bin
DriverPackage\filename.metainfo.xml
```

On gcab < 1.0 the comparison needs to be made without this directory name.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
