### PR TITLE
trivial: fu-progressbar: Hide backspace characters when refreshing ti…

### DIFF
--- a/src/fu-progressbar.c
+++ b/src/fu-progressbar.c
@@ -97,6 +97,8 @@ fu_progressbar_status_to_string (FwupdStatus status)
 static void
 fu_progressbar_erase_line (FuProgressbar *self)
 {
+	if (!self->interactive)
+		return;
 	for (guint i = 0; i < self->to_erase; i++)
 		g_print ("\b");
 	self->to_erase = 0;


### PR DESCRIPTION
…tles

If running non-interactive with a composite device update then while "switching"
devices a bunch of backspace characters are output before the title.

For example:
```
010#010#010#010#010#010#010#010#010#010#010
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
