### PR TITLE
device: convert instance ids after probe() vfunc

### DIFF
--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -1998,6 +1998,10 @@ fu_device_probe (FuDevice *self, GError **error)
 		if (!klass->probe (self, error))
 			return FALSE;
 	}
+
+	/* convert the instance IDs to GUIDs */
+	fu_device_convert_instance_ids (self);
+
 	priv->done_probe = TRUE;
 	return TRUE;
 }


### PR DESCRIPTION
As per the documentation in fu_device_convert_instance_ids(), it
is assumed that the generic device implementation does this operation
implicitly after probe() so plugins do not need to explicitly do it.

Type of pull request:
- [ ] New plugin
- [X] Code fix
- [ ] Feature
- [ ] Documentation
