### PR TITLE
trivial: storage: Update minimum Dell component ID length to 6

### DIFF
--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -160,7 +160,7 @@ fu_ata_device_parse_id_maybe_dell (FuAtaDevice *self, const guint16 *buf)
 	component_id = fu_ata_device_get_string (buf, 137, 140);
 	if (component_id == NULL ||
 	   !g_str_is_ascii (component_id) ||
-	    strlen (component_id) < 4) {
+	    strlen (component_id) < 6) {
 		g_debug ("invalid component ID, skipping");
 		return;
 	}

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -182,7 +182,7 @@ fu_nvme_device_parse_cns_maybe_dell (FuNvmeDevice *self, const guint8 *buf)
 	component_id = fu_nvme_device_get_string_safe (buf, 0xc36, 0xc3d);
 	if (component_id == NULL ||
 	   !g_str_is_ascii (component_id) ||
-	    strlen (component_id) < 4) {
+	    strlen (component_id) < 6) {
 		g_debug ("invalid component ID, skipping");
 		return;
 	}


### PR DESCRIPTION
Dell storage team confirmed that nothing shorter than 6 will ever
be used and so this heuristic can be stronger.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
