### PR TITLE
fwupd: Hide firmware-packager behind meson option

### DIFF
--- a/contrib/firmware-packager/meson.build
+++ b/contrib/firmware-packager/meson.build
@@ -1,2 +1,4 @@
-install_data('firmware-packager',
-             install_dir : 'share/fwupd')
+if get_option('firmware-packager')
+  install_data('firmware-packager',
+               install_dir : 'share/fwupd')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,5 +1,6 @@
 option('daemon', type : 'boolean', value : true, description : 'enable the fwupd daemon')
 option('consolekit', type : 'boolean', value : true, description : 'enable ConsoleKit support')
+option('firmware-packager', type : 'boolean', value : true, description : 'enable firmware-packager installation')
 option('gpg', type : 'boolean', value : true, description : 'enable the GPG verification support')
 option('gtkdoc', type : 'boolean', value : true, description : 'enable developer documentation')
 option('introspection', type : 'boolean', value : true, description : 'generate GObject Introspection data')


### PR DESCRIPTION
fwupd installs by default firmware-packager (a python3 script) into
the CrOS image. CrOS does not support python3 interpreter and fails
passing the TestValidInterpreter. Removing this script from the default
installation fixes the issue.

TEST=emerge-sarien fwupd
BUG=chromium:857263,b/121131967

Change-Id: I855c7994fd15faa0ce3d520734537674d7538b4e

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
