### PR TITLE
Add C build configuration for LGTM.com

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,4 +1,20 @@
 extraction:
   python:
     python_setup:
-      version: 3
+      version: "3"
+  cpp:
+    prepare:
+      packages:
+      - bsdtar
+      - python3-gi
+      - libcogl-pango-dev
+      - python3-pil
+      - python3-cairo
+    after_prepare:
+    - "wget -O libxmlb.zip https://github.com/hughsie/libxmlb/archive/master.zip"
+    - "bsdtar --strip-components=1 -xvf libxmlb.zip -C subprojects/libxmlb"
+    index:
+      build_command:
+      - "meson setup build"
+      - "ninja -C build"
+ 


### PR DESCRIPTION
Following conversation on the lgtm discussion forum: https://discuss.lgtm.com/t/fwupd-project-not-detected-as-c-project/1742

This should allow LGTM.com to build the C code. Once it's merged i'll trigger this on LGTM.
