### PR TITLE
Ensure libxmlb dir exists for LGTM.com

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -12,6 +12,7 @@ extraction:
       - python3-cairo
     after_prepare:
     - "wget -O libxmlb.zip https://github.com/hughsie/libxmlb/archive/master.zip"
+    - "mkdir -p subprojects/libxmlb"
     - "bsdtar --strip-components=1 -xvf libxmlb.zip -C subprojects/libxmlb"
     index:
       build_command:


### PR DESCRIPTION
Looks like I forgot one little thing, in my testing I somehow had created this directory and thought it already existed in the repo, forgetting to add it as a build step:

https://lgtm.com/logs/e70808197d3d89717166824b4a7070ce6aa41bdf/lang:cpp