### PR TITLE
unifying: Fix regression when recovering from failed flash

### DIFF
--- a/plugins/unifying/fu-plugin-unifying.c
+++ b/plugins/unifying/fu-plugin-unifying.c
@@ -88,12 +88,16 @@ fu_plugin_udev_device_added (FuPlugin *plugin, FuUdevDevice *device, GError **er
 
 	/* runtime */
 	if (fu_device_has_custom_flag (FU_DEVICE (device), "is-receiver")) {
-		dev = g_object_new (FU_TYPE_UNIFYING_RUNTIME, NULL);
+		dev = g_object_new (FU_TYPE_UNIFYING_RUNTIME,
+				    "version-format", FU_VERSION_FORMAT_PLAIN,
+				    NULL);
 		fu_device_incorporate (dev, FU_DEVICE (device));
 	} else {
 
 		/* create device so we can run ->probe() and add UFY GUIDs */
-		dev = g_object_new (FU_TYPE_UNIFYING_PERIPHERAL, NULL);
+		dev = g_object_new (FU_TYPE_UNIFYING_PERIPHERAL,
+				    "version-format", FU_VERSION_FORMAT_PLAIN,
+				    NULL);
 		fu_device_incorporate (dev, FU_DEVICE (device));
 		if (!fu_device_probe (dev, error))
 			return FALSE;
@@ -131,10 +135,14 @@ fu_plugin_usb_device_added (FuPlugin *plugin, FuUsbDevice *device, GError **erro
 		return TRUE;
 	}
 	if (fu_device_has_custom_flag (FU_DEVICE (device), "is-nordic")) {
-		dev = g_object_new (FU_TYPE_UNIFYING_BOOTLOADER_NORDIC, NULL);
+		dev = g_object_new (FU_TYPE_UNIFYING_BOOTLOADER_NORDIC,
+				    "version-format", FU_VERSION_FORMAT_PLAIN,
+				    NULL);
 		fu_device_incorporate (dev, FU_DEVICE (device));
 	} else if (fu_device_has_custom_flag (FU_DEVICE (device), "is-texas")) {
-		dev = g_object_new (FU_TYPE_UNIFYING_BOOTLOADER_TEXAS, NULL);
+		dev = g_object_new (FU_TYPE_UNIFYING_BOOTLOADER_TEXAS,
+				    "version-format", FU_VERSION_FORMAT_PLAIN,
+				    NULL);
 		fu_device_incorporate (dev, FU_DEVICE (device));
 		g_usleep (200*1000);
 	}

--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -63,6 +63,7 @@ enum {
 	PROP_PHYSICAL_ID,
 	PROP_LOGICAL_ID,
 	PROP_QUIRKS,
+	PROP_VERSION_FORMAT,
 	PROP_LAST
 };
 
@@ -81,6 +82,9 @@ fu_device_get_property (GObject *object, guint prop_id,
 		break;
 	case PROP_PROGRESS:
 		g_value_set_uint (value, priv->progress);
+		break;
+	case PROP_VERSION_FORMAT:
+		g_value_set_uint (value, priv->version_format);
 		break;
 	case PROP_PHYSICAL_ID:
 		g_value_set_string (value, fu_device_get_physical_id (self));
@@ -108,6 +112,9 @@ fu_device_set_property (GObject *object, guint prop_id,
 		break;
 	case PROP_PROGRESS:
 		fu_device_set_progress (self, g_value_get_uint (value));
+		break;
+	case PROP_VERSION_FORMAT:
+		fu_device_set_version_format (self, g_value_get_uint (value));
 		break;
 	case PROP_PHYSICAL_ID:
 		fu_device_set_physical_id (self, g_value_get_string (value));
@@ -2195,6 +2202,14 @@ fu_device_class_init (FuDeviceClass *klass)
 				   G_PARAM_READWRITE |
 				   G_PARAM_STATIC_NAME);
 	g_object_class_install_property (object_class, PROP_PROGRESS, pspec);
+
+	pspec = g_param_spec_uint ("version-format", NULL, NULL,
+				   FU_VERSION_FORMAT_UNKNOWN,
+				   FU_VERSION_FORMAT_LAST,
+				   FU_VERSION_FORMAT_UNKNOWN,
+				   G_PARAM_READWRITE |
+				   G_PARAM_STATIC_NAME);
+	g_object_class_install_property (object_class, PROP_VERSION_FORMAT, pspec);
 
 	pspec = g_param_spec_object ("quirks", NULL, NULL,
 				     FU_TYPE_QUIRKS,


### PR DESCRIPTION
The unifying version numbers are of the form 'RQR24.00_B0000' which means we
have to force the plugin to 'plain' version format to avoid stripping out the
non-semver chars.

Fixes https://github.com/hughsie/fwupd/issues/1018

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
