### PR TITLE
Add support to run snap build in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: cibuilds/snapcraft:stable
+    steps:
+      - checkout
+      - run:
+          name: "Build Snap"
+          command: snapcraft
+
+workflows:
+  version: 2
+  main:
+    jobs:
+      - build


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

Once circle CI is enabled for fwupd this should hopefully build the fwupd snap on Circle CI.

If it works out well, we could potentially have this "publish" snaps to snapcraft as well rather than using Launchpad.