### PR TITLE
circleci: Manage the lifecycle of the snap

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,54 @@ jobs:
       - run:
           name: "Build Snap"
           command: snapcraft
+      - persist_to_workspace:
+          root: .
+          paths:
+            - "*.snap"
+
+  publish-edge:
+    docker:
+      - image: cibuilds/snapcraft:stable
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: "Publish to Store"
+          command: |
+            mkdir .snapcraft
+            echo $SNAPCRAFT_LOGIN_FILE | base64 --decode --ignore-garbage > .snapcraft/snapcraft.cfg
+            snapcraft push *.snap --release edge
+
+  publish-stable:
+    docker:
+      - image: cibuilds/snapcraft:stable
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: "Publish to Store"
+          command: |
+            mkdir .snapcraft
+            echo $SNAPCRAFT_LOGIN_FILE | base64 --decode --ignore-garbage > .snapcraft/snapcraft.cfg
+            snapcraft push *.snap --release stable
 
 workflows:
   version: 2
   main:
     jobs:
       - build
+      - publish-edge:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+      - publish-stable:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+


### PR DESCRIPTION
* Publish master snaps to edge after build.
* Publish tagged snaps to the stable channel after build.

I added the variable `SNAPCRAFT_LOGIN_FILE` to circleci.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

So assuming this all works https://build.snapcraft.io/user/hughsie will need to get the launchpad builder turned off so they don't conflict too.