### PR TITLE
uefi: fix segfault in fwup_set_update_statuses

### DIFF
--- a/plugins/uefi/efi/fwupdate.c
+++ b/plugins/uefi/efi/fwupdate.c
@@ -595,7 +595,7 @@ fwup_set_update_statuses(FWUP_UPDATE_TABLE **updates)
 {
 	EFI_STATUS rc;
 	for (UINTN i = 0; i < FWUP_NUM_CAPSULE_UPDATES_MAX; i++) {
-		if (updates[i]->name == NULL)
+		if (updates[i] == NULL || updates[i]->name == NULL)
 			break;
 		rc = fwup_set_variable(updates[i]->name, &fwupdate_guid,
 				       updates[i]->info, updates[i]->size,


### PR DESCRIPTION
Hey there!
I tried updating my system (Thinkpad T460) today. `fwupdmgr` finished its job and suggested a reboot. After booting into the UEFI updater I got to see this text for >3 minutes:
```
Found update fwupd- ...
Adding new capsule
```
This is reproducible with `v1.2.4` and `master`.

I tried debugging this by inserting a bunch of printfs:
```diff
diff --git a/plugins/uefi/efi/fwupdate.c b/plugins/uefi/efi/fwupdate.c
index 5dd32729..bbddb849 100644
--- a/plugins/uefi/efi/fwupdate.c
+++ b/plugins/uefi/efi/fwupdate.c
@@ -594,18 +594,28 @@ static EFI_STATUS
 fwup_set_update_statuses(FWUP_UPDATE_TABLE **updates)
 {
        EFI_STATUS rc;
+       fwup_debug(L"fwup_set_update_statuses");
        for (UINTN i = 0; i < FWUP_NUM_CAPSULE_UPDATES_MAX; i++) {
+               fwup_debug(L"probing i=%d", i);
+               fwup_debug(L"  table=0x%x", updates[i]);
+               fwup_debug(L"  name=0x%x", updates[i]->name);
                if (updates[i]->name == NULL)
                        break;
+               fwup_debug(L"  i=%d, name=%s", i, updates[i]->name);
+               fwup_debug(L"  size=%d, attrs=0x%x", updates[i]->size, updates[i]->attrs);
                rc = fwup_set_variable(updates[i]->name, &fwupdate_guid,
                                       updates[i]->info, updates[i]->size,
                                       updates[i]->attrs);
+               fwup_debug(L"  => rc=%d", rc);
                if (EFI_ERROR(rc)) {
                        fwup_warning(L"Could not update variable status for '%s': %r",
                                     updates[i]->name, rc);
                        return rc;
                }
        }
+       fwup_debug(L"~fwup_set_update_statuses");
        return EFI_SUCCESS;
 }
```
![img_20190215_181135](https://user-images.githubusercontent.com/3913977/52875345-6f8c7280-3154-11e9-8d79-e16370a2d5d2.jpg)

I don't know why `*0 == 0xF0000283` on my system, but this breaks the `updates[i]->name == NULL` check.


Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation

Xref https://github.com/hughsie/fwupd/issues/656
