### PR TITLE
Add support for delayed activation command

### DIFF
--- a/contrib/debian/fwupd.install
+++ b/contrib/debian/fwupd.install
@@ -12,6 +12,7 @@ usr/lib/*/fwupd
 usr/lib/*/fwupdtool
 usr/share/man/man1/*
 lib/systemd/system/*
+lib/systemd/system-shutdown/*
 var/lib/fwupd
 lib/udev/rules.d/*
 data/daemon.conf etc/fwupd

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -253,6 +253,7 @@ mkdir -p --mode=0700 $RPM_BUILD_ROOT%{_localstatedir}/lib/fwupd/gnupg
 %{_libdir}/libfwupd*.so.*
 %{_libdir}/girepository-1.0/Fwupd-2.0.typelib
 /usr/lib/udev/rules.d/*.rules
+/usr/lib/systemd/system-shutdown/fwupd.shutdown
 %dir %{_libdir}/fwupd-plugins-3
 %{_libdir}/fwupd-plugins-3/libfu_plugin_altos.so
 %{_libdir}/fwupd-plugins-3/libfu_plugin_amt.so

--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -1,4 +1,5 @@
 _fwupdmgr_cmd_list=(
+	'activate'
 	'clear-history'
 	'clear-offline'
 	'clear-results'
@@ -70,7 +71,7 @@ _fwupdmgr()
 	command=${COMP_WORDS[1]}
 
 	case $command in
-	clear-results|downgrade|get-releases|get-results|unlock|verify|verify-update)
+	activate|clear-results|downgrade|get-releases|get-results|unlock|verify|verify-update)
 		if [[ "$prev" = "$command" ]]; then
 			_show_device_ids
 		else

--- a/data/bash-completion/fwupdtool.in
+++ b/data/bash-completion/fwupdtool.in
@@ -1,4 +1,5 @@
 _fwupdtool_cmd_list=(
+	'activate'
 	'build-firmware'
 	'get-updates'
 	'get-details'
@@ -64,7 +65,7 @@ _fwupdtool()
 			_show_modifiers
 		fi
 		;;
-	attach|detach)
+	attach|detach|activate)
 		if [[ "$prev" = "$command" ]]; then
 			_show_device_ids
 		#modifiers

--- a/data/fwupd.shutdown.in
+++ b/data/fwupd.shutdown.in
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# no history database exists
+[ -f @localstatedir@/lib/fwupd/pending.db ] || exit 0
+
+# activate firmware when we have a read-only filesysten
+@libexecdir@/fwupd/fwupdtool activate

--- a/data/meson.build
+++ b/data/meson.build
@@ -41,6 +41,7 @@ if get_option('systemd')
   con2.set('libexecdir', libexecdir)
   con2.set('bindir', bindir)
   con2.set('datadir', datadir)
+  con2.set('localstatedir', localstatedir)
 
   rw_directories = []
   rw_directories += join_paths (localstatedir, 'lib', 'fwupd')
@@ -79,6 +80,15 @@ if get_option('systemd')
     configuration : con2,
     install: true,
     install_dir: systemdunitdir,
+  )
+
+  # for activation
+  configure_file(
+    input : 'fwupd.shutdown.in',
+    output : 'fwupd.shutdown',
+    configuration : con2,
+    install: true,
+    install_dir: systemd.get_pkgconfig_variable('systemdshutdowndir'),
   )
 endif
 

--- a/libfwupd/fwupd-client.h
+++ b/libfwupd/fwupd-client.h
@@ -78,6 +78,10 @@ gboolean	 fwupd_client_unlock			(FwupdClient	*client,
 							 const gchar	*device_id,
 							 GCancellable	*cancellable,
 							 GError		**error);
+gboolean	 fwupd_client_activate			(FwupdClient	*client,
+							 GCancellable	*cancellable,
+							 const gchar	*device_id,
+							 GError		**error);
 gboolean	 fwupd_client_clear_results		(FwupdClient	*client,
 							 const gchar	*device_id,
 							 GCancellable	*cancellable,

--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -159,6 +159,8 @@ fwupd_device_flag_to_string (FwupdDeviceFlags device_flag)
 		return "another-write-required";
 	if (device_flag == FWUPD_DEVICE_FLAG_NO_AUTO_INSTANCE_IDS)
 		return "no-auto-instance-ids";
+	if (device_flag == FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION)
+		return "needs-activation";
 	if (device_flag == FWUPD_DEVICE_FLAG_UNKNOWN)
 		return "unknown";
 	return NULL;
@@ -219,6 +221,8 @@ fwupd_device_flag_from_string (const gchar *device_flag)
 		return FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED;
 	if (g_strcmp0 (device_flag, "no-auto-instance-ids") == 0)
 		return FWUPD_DEVICE_FLAG_NO_AUTO_INSTANCE_IDS;
+	if (g_strcmp0 (device_flag, "needs-activation") == 0)
+		return FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION;
 	return FWUPD_DEVICE_FLAG_UNKNOWN;
 }
 

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -87,6 +87,7 @@ typedef enum {
  * @FWUPD_DEVICE_FLAG_NEEDS_SHUTDOWN:		Requires system shutdown to apply firmware
  * @FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED:	Requires the update to be retried with a new plugin
  * @FWUPD_DEVICE_FLAG_NO_AUTO_INSTANCE_IDS:	Do not add instance IDs from the device baseclass
+ * @FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION:		Device update needs to be separately activated
  *
  * The device flags.
  **/
@@ -111,6 +112,7 @@ typedef enum {
 #define FWUPD_DEVICE_FLAG_NEEDS_SHUTDOWN	(1u << 17)	/* Since: 1.2.4 */
 #define FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED (1u << 18)	/* Since: 1.2.5 */
 #define FWUPD_DEVICE_FLAG_NO_AUTO_INSTANCE_IDS	(1u << 19)	/* Since: 1.2.5 */
+#define FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION	(1u << 20)	/* Since: 1.2.6 */
 #define FWUPD_DEVICE_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 0.7.3 */
 typedef guint64 FwupdDeviceFlags;
 

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -320,3 +320,9 @@ LIBFWUPD_1.2.5 {
     fwupd_guid_to_string;
   local: *;
 } LIBFWUPD_1.2.4;
+
+LIBFWUPD_1.2.6 {
+  global:
+    fwupd_client_activate;
+  local: *;
+} LIBFWUPD_1.2.5;

--- a/plugins/ata/fu-plugin-ata.c
+++ b/plugins/ata/fu-plugin-ata.c
@@ -58,3 +58,13 @@ fu_plugin_update (FuPlugin *plugin,
 		return FALSE;
 	return fu_device_write_firmware (device, blob_fw, error);
 }
+
+gboolean
+fu_plugin_activate (FuPlugin *plugin, FuDevice *device, GError **error)
+{
+	g_autoptr(FuDeviceLocker) locker = NULL;
+	locker = fu_device_locker_new (device, error);
+	if (locker == NULL)
+		return FALSE;
+	return fu_device_activate (device, error);
+}

--- a/plugins/dell-dock/fu-plugin-dell-dock.c
+++ b/plugins/dell-dock/fu-plugin-dell-dock.c
@@ -240,3 +240,20 @@ fu_plugin_composite_cleanup (FuPlugin *plugin,
 
 	return fu_dell_dock_ec_reboot_dock (parent, error);
 }
+
+gboolean
+fu_plugin_activate (FuPlugin *plugin, FuDevice *device, GError **error)
+{
+	g_autoptr(FuDeviceLocker) locker = NULL;
+	if (!FU_IS_DELL_DOCK_EC (device)) {
+		g_set_error_literal (error, FWUPD_ERROR, FWUPD_ERROR_INVALID_FILE,
+				     "Invalid device to activate");
+		return FALSE;
+	}
+
+	locker = fu_device_locker_new (device, error);
+	if (locker == NULL)
+		return FALSE;
+
+	return fu_device_activate (device, error);
+}

--- a/plugins/test/fu-plugin-test.c
+++ b/plugins/test/fu-plugin-test.c
@@ -124,7 +124,9 @@ fu_plugin_update (FuPlugin *plugin,
 		  FwupdInstallFlags flags,
 		  GError **error)
 {
-	if (g_strcmp0 (g_getenv ("FWUPD_PLUGIN_TEST"), "fail") == 0) {
+	const gchar *test = g_getenv ("FWUPD_PLUGIN_TEST");
+	gboolean requires_activation = g_strcmp0 (test, "requires-activation") == 0;
+	if (g_strcmp0 (test, "fail") == 0) {
 		g_set_error_literal (error,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_NOT_SUPPORTED,
@@ -148,7 +150,7 @@ fu_plugin_update (FuPlugin *plugin,
 	}
 
 	/* composite test, upgrade composite devices */
-	if (g_strcmp0 (g_getenv ("FWUPD_PLUGIN_TEST"), "composite") == 0) {
+	if (g_strcmp0 (test, "composite") == 0) {
 		if (g_strcmp0 (fu_device_get_logical_id (device), "child1") == 0) {
 			fu_device_set_version (device, "2");
 			return TRUE;
@@ -159,14 +161,18 @@ fu_plugin_update (FuPlugin *plugin,
 	}
 
 	/* upgrade, or downgrade */
-	if (flags & FWUPD_INSTALL_FLAG_ALLOW_OLDER) {
-		fu_device_set_version (device, "1.2.2");
+	if (requires_activation) {
+		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
 	} else {
-		fu_device_set_version (device, "1.2.3");
+		if (flags & FWUPD_INSTALL_FLAG_ALLOW_OLDER) {
+			fu_device_set_version (device, "1.2.2");
+		} else {
+			fu_device_set_version (device, "1.2.3");
+		}
 	}
 
 	/* do this all over again */
-	if (g_strcmp0 (g_getenv ("FWUPD_PLUGIN_TEST"), "another-write-required") == 0) {
+	if (g_strcmp0 (test, "another-write-required") == 0) {
 		g_unsetenv ("FWUPD_PLUGIN_TEST");
 		fu_device_add_flag (device, FWUPD_DEVICE_FLAG_ANOTHER_WRITE_REQUIRED);
 	}
@@ -175,6 +181,13 @@ fu_plugin_update (FuPlugin *plugin,
 	fu_device_set_metadata_integer (device, "nr-update",
 					fu_device_get_metadata_integer (device, "nr-update") + 1);
 
+	return TRUE;
+}
+
+gboolean
+fu_plugin_activate (FuPlugin *plugin, FuDevice *device, GError **error)
+{
+	fu_device_set_version (device, "1.2.3");
 	return TRUE;
 }
 

--- a/policy/org.freedesktop.fwupd.policy.in
+++ b/policy/org.freedesktop.fwupd.policy.in
@@ -90,6 +90,17 @@
     </defaults>
   </action>
 
+  <action id="org.freedesktop.fwupd.device-activate">
+    <description>Activate the new firmware on the device</description>
+    <!-- TRANSLATORS: this is the PolicyKit modal dialog -->
+    <message>Authentication is required to switch to the new firmware version</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
   <action id="org.freedesktop.fwupd.verify-update">
     <description>Update the stored device verification information</description>
     <!-- TRANSLATORS: this is the PolicyKit modal dialog -->

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -11,3 +11,5 @@ install_if_missing share/polkit-1/rules.d/org.freedesktop.fwupd.rules /usr
 install_if_missing share/dbus-1/system-services/org.freedesktop.fwupd.service /usr
 install_if_missing share/dbus-1/interfaces/org.freedesktop.fwupd.xml /usr
 install_if_missing etc/dbus-1/system.d/org.freedesktop.fwupd.conf /
+#activation via systemd
+install_if_missing /lib/systemd/system-shutdown/fwupd.shutdown /

--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -2085,6 +2085,35 @@ fu_device_setup (FuDevice *self, GError **error)
 }
 
 /**
+ * fu_device_activate:
+ * @self: A #FuDevice
+ * @error: A #GError, or %NULL
+ *
+ * Activates up a device, which normally means the device switches to a new
+ * firmware verson. This should only be called when data loss cannot occur.
+ *
+ * Returns: %TRUE for success
+ *
+ * Since: 1.2.6
+ **/
+gboolean
+fu_device_activate (FuDevice *self, GError **error)
+{
+	FuDeviceClass *klass = FU_DEVICE_GET_CLASS (self);
+
+	g_return_val_if_fail (FU_IS_DEVICE (self), FALSE);
+	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+	/* subclassed */
+	if (klass->activate != NULL) {
+		if (!klass->activate (self, error))
+			return FALSE;
+	}
+
+	return TRUE;
+}
+
+/**
  * fu_device_probe_invalidate:
  * @self: A #FuDevice
  *

--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -50,8 +50,10 @@ struct _FuDeviceClass
 							 FuDevice	*donor);
 	gboolean		 (*poll)		(FuDevice	*self,
 							 GError		**error);
+	gboolean		 (*activate)		(FuDevice	*self,
+							 GError		**error);
 	/*< private >*/
-	gpointer	padding[20];
+	gpointer	padding[19];
 };
 
 /**
@@ -219,6 +221,8 @@ gboolean	 fu_device_close			(FuDevice	*self,
 gboolean	 fu_device_probe			(FuDevice	*self,
 							 GError		**error);
 gboolean	 fu_device_setup			(FuDevice	*self,
+							 GError		**error);
+gboolean	 fu_device_activate			(FuDevice	*self,
 							 GError		**error);
 void		 fu_device_probe_invalidate		(FuDevice	*self);
 gboolean	 fu_device_poll				(FuDevice	*self,

--- a/src/fu-engine.h
+++ b/src/fu-engine.h
@@ -111,6 +111,9 @@ gboolean	 fu_engine_install_tasks		(FuEngine	*self,
 GPtrArray	*fu_engine_get_details			(FuEngine	*self,
 							 gint		 fd,
 							 GError		**error);
+gboolean	 fu_engine_activate			(FuEngine	*self,
+							 const gchar	*device_id,
+							 GError		**error);
 
 /* for the self tests */
 void		 fu_engine_add_device			(FuEngine	*self,

--- a/src/fu-main.c
+++ b/src/fu-main.c
@@ -387,6 +387,32 @@ fu_main_authorize_unlock_cb (GObject *source, GAsyncResult *res, gpointer user_d
 }
 
 static void
+fu_main_authorize_activate_cb (GObject *source, GAsyncResult *res, gpointer user_data)
+{
+	g_autoptr(FuMainAuthHelper) helper = (FuMainAuthHelper *) user_data;
+	g_autoptr(GError) error = NULL;
+	g_autoptr(PolkitAuthorizationResult) auth = NULL;
+
+	/* get result */
+	fu_main_set_status (helper->priv, FWUPD_STATUS_IDLE);
+	auth = polkit_authority_check_authorization_finish (POLKIT_AUTHORITY (source),
+							    res, &error);
+	if (!fu_main_authorization_is_valid (auth, &error)) {
+		g_dbus_method_invocation_return_gerror (helper->invocation, error);
+		return;
+	}
+
+	/* authenticated */
+	if (!fu_engine_activate (helper->priv->engine, helper->device_id, &error)) {
+		g_dbus_method_invocation_return_gerror (helper->invocation, error);
+		return;
+	}
+
+	/* success */
+	g_dbus_method_invocation_return_value (helper->invocation, NULL);
+}
+
+static void
 fu_main_authorize_verify_update_cb (GObject *source, GAsyncResult *res, gpointer user_data)
 {
 	g_autoptr(FuMainAuthHelper) helper = (FuMainAuthHelper *) user_data;
@@ -894,6 +920,34 @@ fu_main_daemon_method_call (GDBusConnection *connection, const gchar *sender,
 						      POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
 						      NULL,
 						      fu_main_authorize_unlock_cb,
+						      g_steal_pointer (&helper));
+		return;
+	}
+	if (g_strcmp0 (method_name, "Activate") == 0) {
+		const gchar *device_id = NULL;
+		g_autoptr(FuMainAuthHelper) helper = NULL;
+		g_autoptr(PolkitSubject) subject = NULL;
+
+		g_variant_get (parameters, "(&s)", &device_id);
+		g_debug ("Called %s(%s)", method_name, device_id);
+		if (!fu_main_device_id_valid (device_id, &error)) {
+			g_dbus_method_invocation_return_gerror (invocation, error);
+			return;
+		}
+
+		/* authenticate */
+		fu_main_set_status (priv, FWUPD_STATUS_WAITING_FOR_AUTH);
+		helper = g_new0 (FuMainAuthHelper, 1);
+		helper->priv = priv;
+		helper->invocation = g_object_ref (invocation);
+		helper->device_id = g_strdup (device_id);
+		subject = polkit_system_bus_name_new (sender);
+		polkit_authority_check_authorization (priv->authority, subject,
+						      "org.freedesktop.fwupd.device-activate",
+						      NULL,
+						      POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+						      NULL,
+						      fu_main_authorize_activate_cb,
 						      g_steal_pointer (&helper));
 		return;
 	}

--- a/src/fu-plugin-private.h
+++ b/src/fu-plugin-private.h
@@ -99,6 +99,9 @@ gboolean	 fu_plugin_runner_verify		(FuPlugin	*self,
 							 FuDevice	*device,
 							 FuPluginVerifyFlags flags,
 							 GError		**error);
+gboolean	 fu_plugin_runner_activate 		(FuPlugin *self,
+							 FuDevice *device,
+							 GError **error);
 gboolean	 fu_plugin_runner_unlock		(FuPlugin	*self,
 							 FuDevice	*device,
 							 GError		**error);

--- a/src/fu-plugin-vfuncs.h
+++ b/src/fu-plugin-vfuncs.h
@@ -36,6 +36,9 @@ gboolean	 fu_plugin_verify			(FuPlugin	*plugin,
 gboolean	 fu_plugin_unlock			(FuPlugin	*plugin,
 							 FuDevice	*dev,
 							 GError		**error);
+gboolean	 fu_plugin_activate			(FuPlugin	*plugin,
+							 FuDevice	*dev,
+							 GError		**error);
 gboolean	 fu_plugin_clear_results		(FuPlugin	*plugin,
 							 FuDevice	*dev,
 							 GError		**error);

--- a/src/fu-plugin.c
+++ b/src/fu-plugin.c
@@ -1442,6 +1442,33 @@ fu_plugin_runner_verify (FuPlugin *self,
 }
 
 gboolean
+fu_plugin_runner_activate (FuPlugin *self, FuDevice *device, GError **error)
+{
+	guint64 flags;
+
+	/* final check */
+	flags = fu_device_get_flags (device);
+	if ((flags & FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION) == 0) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_NOT_SUPPORTED,
+			     "Device %s does not need activation",
+			     fu_device_get_id (device));
+		return FALSE;
+	}
+
+	/* run vfunc */
+	if (!fu_plugin_runner_device_generic (self, device,
+					      "fu_plugin_activate", error))
+		return FALSE;
+
+	/* update with correct flags */
+	fu_device_remove_flag (device, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
+	fu_device_set_modified (device, (guint64) g_get_real_time () / G_USEC_PER_SEC);
+	return TRUE;
+}
+
+gboolean
 fu_plugin_runner_unlock (FuPlugin *self, FuDevice *device, GError **error)
 {
 	guint64 flags;

--- a/src/org.freedesktop.fwupd.xml
+++ b/src/org.freedesktop.fwupd.xml
@@ -308,6 +308,25 @@
     </method>
 
     <!--***********************************************************-->
+    <method name='Activate'>
+      <doc:doc>
+        <doc:description>
+          <doc:para>
+            Activate a firmware update on the device.
+          </doc:para>
+        </doc:description>
+      </doc:doc>
+      <arg type='s' name='id' direction='in'>
+        <doc:doc>
+          <doc:summary>
+            <doc:para>
+              An ID, typically the sha hash of the device string.</doc:para>
+          </doc:summary>
+        </doc:doc>
+      </arg>
+    </method>
+
+    <!--***********************************************************-->
     <method name='GetResults'>
       <doc:doc>
         <doc:description>


### PR DESCRIPTION
This command is intended to be called later for functionality that may not be safe at standard runtime.

The two cases that are envisioned so far:
* Calling ATA microcode activate command (`0xF`) when filesystem is not mounted
* Calling dell-dock's dock reboot when rebooting a machine if the update was pending

I've not plumbed it up to systemd yet, mostly because i'm a little bit confused by whether the action should live in `/lib/systemd/system-shutdown` or a unit that requires `umount.target`.  In either case, I think that will be a follow up PR.

CC @djcampello,
This is something that matches what we talked about using for logout.  I think we'll need to store something to `pending.db` and then a shell script could potentially launch it on logout.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
