### PR TITLE
po/make-images.sh: quote LOCALEDIR and PYTHON3

### DIFF
--- a/po/make-images.sh
+++ b/po/make-images.sh
@@ -6,8 +6,8 @@
 # Distributed under terms of the GPLv2 license.
 #
 
-LOCALEDIR=${DESTDIR}$1
-PYTHON3=$2
+LOCALEDIR="${DESTDIR}$1"
+PYTHON3="$2"
 
 install -m 0755 -d $LOCALEDIR
 ${PYTHON3} ${MESON_SOURCE_ROOT}/po/make-images "Installing firmware update…" $LOCALEDIR ${MESON_SOURCE_ROOT}/po/LINGUAS


### PR DESCRIPTION
Allows people to specifiy a white-space separated value for them

Void Linux runs them under qemu-user-static like so

`qemu-aarch64-static -L ./usr/aarch64-linux-gnu
./usr/aarch64-linux-gnu/usr/bin/python3`

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
