### PR TITLE
meson: print stderr of python3 command instead of stdout

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -239,7 +239,7 @@ if get_option('plugin_uefi')
   conf.set_quoted('EFI_MACHINE_TYPE_NAME', EFI_MACHINE_TYPE_NAME)
   r = run_command([python3, 'po/test-deps'])
   if r.returncode() != 0
-    error(r.stdout())
+    error(r.stderr())
   endif
 endif
 


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
