### PR TITLE
Do not fail to start the daemon if tpm2_pcrlist hangs

### DIFF
--- a/plugins/flashrom/fu-plugin-flashrom.c
+++ b/plugins/flashrom/fu-plugin-flashrom.c
@@ -153,7 +153,7 @@ fu_plugin_update_prepare (FuPlugin *plugin,
 			"--verbose", NULL };
 		if (!fu_common_spawn_sync ((const gchar * const *) argv,
 					   fu_plugin_flashrom_read_cb, device,
-					   NULL, error)) {
+					   0, NULL, error)) {
 			g_prefix_error (error, "failed to get original firmware: ");
 			return FALSE;
 		}
@@ -190,7 +190,7 @@ fu_plugin_update (FuPlugin *plugin,
 	argv[4] = firmware_fn;
 	if (!fu_common_spawn_sync ((const gchar * const *) argv,
 				   fu_plugin_flashrom_write_cb, device,
-				   NULL, error)) {
+				   0, NULL, error)) {
 		g_prefix_error (error, "failed to write firmware: ");
 		return FALSE;
 	}

--- a/plugins/uefi/fu-uefi-pcrs.c
+++ b/plugins/uefi/fu-uefi-pcrs.c
@@ -93,7 +93,7 @@ static gboolean
 fu_uefi_pcrs_setup_tpm20 (FuUefiPcrs *self, const gchar *argv0, GError **error)
 {
 	const gchar *argv[] = { argv0, NULL };
-	return fu_common_spawn_sync (argv, fu_uefi_pcrs_parse_line, self, NULL, error);
+	return fu_common_spawn_sync (argv, fu_uefi_pcrs_parse_line, self, 1500, NULL, error);
 }
 
 gboolean

--- a/src/fu-common.h
+++ b/src/fu-common.h
@@ -44,6 +44,7 @@ typedef void	(*FuOutputHandler)		(const gchar	*line,
 gboolean	 fu_common_spawn_sync		(const gchar * const *argv,
 						 FuOutputHandler handler_cb,
 						 gpointer	 handler_user_data,
+						 guint		 timeout_ms,
 						 GCancellable	*cancellable,
 						 GError		**error);
 

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -2478,10 +2478,28 @@ fu_common_spawn_func (void)
 	g_assert (fn != NULL);
 	argv[0] = fn;
 	ret = fu_common_spawn_sync (argv,
-				    fu_test_stdout_cb, &lines, NULL, &error);
+				    fu_test_stdout_cb, &lines, 0, NULL, &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 	g_assert_cmpint (lines, ==, 6);
+}
+
+static void
+fu_common_spawn_timeout_func (void)
+{
+	gboolean ret;
+	guint lines = 0;
+	g_autoptr(GError) error = NULL;
+	g_autofree gchar *fn = NULL;
+	const gchar *argv[3] = { "replace", "test", NULL };
+
+	fn = fu_test_get_filename (TESTDATADIR, "spawn.sh");
+	g_assert (fn != NULL);
+	argv[0] = fn;
+	ret = fu_common_spawn_sync (argv, fu_test_stdout_cb, &lines, 50, NULL, &error);
+	g_assert_error (error, G_IO_ERROR, G_IO_ERROR_CANCELLED);
+	g_assert (!ret);
+	g_assert_cmpint (lines, ==, 1);
 }
 
 static void
@@ -3388,6 +3406,7 @@ main (int argc, char **argv)
 	g_test_add_func ("/fwupd/common{cab-error-missing-file}", fu_common_store_cab_error_missing_file_func);
 	g_test_add_func ("/fwupd/common{cab-error-size}", fu_common_store_cab_error_size_func);
 	g_test_add_func ("/fwupd/common{spawn)", fu_common_spawn_func);
+	g_test_add_func ("/fwupd/common{spawn-timeout)", fu_common_spawn_timeout_func);
 	g_test_add_func ("/fwupd/common{firmware-builder}", fu_common_firmware_builder_func);
 	return g_test_run ();
 }

--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -744,7 +744,7 @@ fu_util_download_out_of_process (const gchar *uri, const gchar *fn, GError **err
 			g_debug ("%s", error_local->message);
 			continue;
 		}
-		return fu_common_spawn_sync (argv[i], NULL, NULL, NULL, error);
+		return fu_common_spawn_sync (argv[i], NULL, NULL, 0, NULL, error);
 	}
 	g_set_error_literal (error,
 			     FWUPD_ERROR,


### PR DESCRIPTION
In some situations SELinux prevents fwupd from executing tpm2_pcrlist, but the
failure mode is that the process just hangs and never completes. This causes
systemd to time out the fwupd daemon startup and then errors to be shown in
GNOME Software.

To prevent this happening, add an optional timeout argument to
fu_common_spawn_sync() and cancel the subprocess if it takes longer than this
to complete.

See https://bugzilla.redhat.com/show_bug.cgi?id=1665701 for details.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
