### PR TITLE
fu-tool: Save device state to @LOCALSTATEDIR@/lib/fwupd/state.json on…

### DIFF
--- a/data/bash-completion/fwupdtool.in
+++ b/data/bash-completion/fwupdtool.in
@@ -19,6 +19,7 @@ _fwupdtool_cmd_list=(
 
 _fwupdtool_opts=(
 	'--verbose'
+	'--enable-json-state'
 	'--allow-reinstall'
 	'--allow-older'
 	'--force'

--- a/libfwupd/fwupd-common.h
+++ b/libfwupd/fwupd-common.h
@@ -48,7 +48,6 @@ gchar		*fwupd_build_machine_id			(const gchar 	*salt,
 GHashTable	*fwupd_get_os_release			(GError		**error);
 gchar		*fwupd_build_history_report_json	(GPtrArray	*devices,
 							 GError		**error);
-
 #ifndef __GI_SCANNER__
 gchar		*fwupd_guid_to_string			(const fwupd_guid_t *guid,
 							 FwupdGuidFlags	 flags);

--- a/libfwupd/fwupd-device-private.h
+++ b/libfwupd/fwupd-device-private.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <glib-object.h>
+#include <json-glib/json-glib.h>
 
 #include "fwupd-device.h"
 
@@ -18,6 +19,8 @@ GVariant	*fwupd_device_to_variant_full		(FwupdDevice	*device,
 							 FwupdDeviceFlags flags);
 void		 fwupd_device_incorporate		(FwupdDevice	*self,
 							 FwupdDevice	*donor);
+void		 fwupd_device_to_json			(FwupdDevice *device,
+							 JsonBuilder *builder);
 
 G_END_DECLS
 

--- a/libfwupd/fwupd-release-private.h
+++ b/libfwupd/fwupd-release-private.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <glib-object.h>
+#include <json-glib/json-glib.h>
 
 #include "fwupd-release.h"
 
@@ -14,6 +15,8 @@ G_BEGIN_DECLS
 
 FwupdRelease	*fwupd_release_from_variant		(GVariant	*data);
 GVariant	*fwupd_release_to_variant		(FwupdRelease	*release);
+void		 fwupd_release_to_json			(FwupdRelease *release,
+							 JsonBuilder *builder);
 
 G_END_DECLS
 

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -324,5 +324,7 @@ LIBFWUPD_1.2.5 {
 LIBFWUPD_1.2.6 {
   global:
     fwupd_client_activate;
+    fwupd_device_to_json;
+    fwupd_release_to_json;
   local: *;
 } LIBFWUPD_1.2.5;

--- a/libfwupd/meson.build
+++ b/libfwupd/meson.build
@@ -156,6 +156,7 @@ if get_option('tests')
     dependencies : [
       gio,
       soup,
+      libjsonglib,
     ],
     link_with : fwupd,
     c_args : [

--- a/plugins/udev/meson.build
+++ b/plugins/udev/meson.build
@@ -36,6 +36,7 @@ executable(
   ],
   dependencies : [
     plugin_deps,
+    libjsonglib,
   ],
   link_with : [
     libfwupdprivate,

--- a/src/meson.build
+++ b/src/meson.build
@@ -55,6 +55,7 @@ libfwupdprivate = static_library(
     soup,
     sqlite,
     libarchive,
+    libjsonglib,
     libxmlb,
     valgrind,
   ],
@@ -167,6 +168,7 @@ fwupdtool = executable(
     sqlite,
     valgrind,
     libarchive,
+    libjsonglib,
   ],
   link_with : [
     fwupd,
@@ -251,6 +253,7 @@ executable(
     sqlite,
     valgrind,
     libarchive,
+    libjsonglib,
   ],
   link_with : fwupd,
   c_args : [
@@ -324,6 +327,7 @@ if get_option('tests')
       sqlite,
       valgrind,
       libarchive,
+      libjsonglib,
     ],
     link_with : [
       fwupd,


### PR DESCRIPTION
… actions

The intended use case is for ChromeOS to be able to save information about
devices on the system when `fwupdtool update` was run to display in the UX at
a later time.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
