### PR TITLE
trivial: modify appstream metadata for some warnings

### DIFF
--- a/data/org.freedesktop.fwupd.metainfo.xml
+++ b/data/org.freedesktop.fwupd.metainfo.xml
@@ -21,8 +21,6 @@
     </p>
   </description>
   <url type="bugtracker">https://github.com/hughsie/fwupd/issues</url>
-  <url type="donation"/>
-  <url type="help"/>
   <url type="homepage">https://fwupd.org/</url>
   <url type="translate">https://www.transifex.com/freedesktop/fwupd/</url>
   <update_contact>richard_at_hughsie.com</update_contact>
@@ -30,6 +28,9 @@
   <content_rating type="oars-1.0">
     <content_attribute id="social-info">moderate</content_attribute>
   </content_rating>
+  <provides>
+    <binary>fwupdmgr</binary>
+  </provides>
   <releases>
     <release version="1.2.5" date="2019-02-25">
       <description>


### PR DESCRIPTION
The following warnings were displayed by Debian appstream metadata
validation.

```
metainfo-validation-issue
Validation of the metainfo file found a problem: Found empty 'url' tag.
metainfo-validation-issue
Validation of the metainfo file found a problem: Type 'console-application' component, but no information about binaries in $PATH was provided via a provides/binary tag.
metainfo-validation-issue
Validation of the metainfo file found a problem: Found empty 'url' tag.
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [x] Documentation
