### PR TITLE
trivial: Export the FwupdDevice flags as readable JSON

### DIFF
--- a/libfwupd/fwupd-device.c
+++ b/libfwupd/fwupd-device.c
@@ -1664,7 +1664,18 @@ fwupd_device_to_json (FwupdDevice *device, JsonBuilder *builder)
 	fwupd_device_json_add_string (builder, FWUPD_RESULT_KEY_SUMMARY, priv->summary);
 	fwupd_device_json_add_string (builder, FWUPD_RESULT_KEY_DESCRIPTION, priv->description);
 	fwupd_device_json_add_string (builder, FWUPD_RESULT_KEY_PLUGIN, priv->plugin);
-	fwupd_device_json_add_int (builder, FWUPD_RESULT_KEY_FLAGS, priv->flags);
+	if (priv->flags != FWUPD_DEVICE_FLAG_NONE) {
+		json_builder_set_member_name (builder, FWUPD_RESULT_KEY_FLAGS);
+		json_builder_begin_array (builder);
+		for (guint i = 0; i < 64; i++) {
+			const gchar *tmp;
+			if ((priv->flags & ((guint64) 1 << i)) == 0)
+				continue;
+			tmp = fwupd_device_flag_to_string ((guint64) 1 << i);
+			json_builder_add_string_value (builder, tmp);
+		}
+		json_builder_end_array (builder);
+	}
 	if (priv->checksums->len > 0) {
 		json_builder_set_member_name (builder, "Checksums");
 		json_builder_begin_array (builder);

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -13,6 +13,7 @@
 #include "fwupd-common.h"
 #include "fwupd-enums.h"
 #include "fwupd-error.h"
+#include "fwupd-device-private.h"
 #include "fwupd-release-private.h"
 #include "fwupd-remote-private.h"
 
@@ -261,11 +262,15 @@ static void
 fwupd_device_func (void)
 {
 	gboolean ret;
+	g_autofree gchar *data = NULL;
 	g_autofree gchar *str = NULL;
 	g_autoptr(FwupdDevice) dev = NULL;
 	g_autoptr(FwupdRelease) rel = NULL;
 	g_autoptr(GError) error = NULL;
 	g_autoptr(GString) str_ascii = NULL;
+	g_autoptr(JsonBuilder) builder = NULL;
+	g_autoptr(JsonGenerator) json_generator = NULL;
+	g_autoptr(JsonNode) json_root = NULL;
 
 	/* create dummy object */
 	dev = fwupd_device_new ();
@@ -322,6 +327,56 @@ fwupd_device_func (void)
 		"  Size:                 1.0 kB\n"
 		"  Uri:                  http://foo.com\n"
 		"  TrustFlags:           payload\n", &error);
+	g_assert_no_error (error);
+	g_assert (ret);
+
+	/* export to json */
+	builder = json_builder_new ();
+	json_builder_begin_object (builder);
+	fwupd_device_to_json (dev, builder);
+	json_builder_end_object (builder);
+	json_root = json_builder_get_root (builder);
+	json_generator = json_generator_new ();
+	json_generator_set_pretty (json_generator, TRUE);
+	json_generator_set_root (json_generator, json_root);
+	data = json_generator_to_data (json_generator, NULL);
+	g_assert_nonnull (data);
+	ret = fu_test_compare_lines (data,
+		"{\n"
+		"  \"Name\" : \"ColorHug2\",\n"
+		"  \"DeviceId\" : \"USB:foo\",\n"
+		"  \"Guid\" : [\n"
+		"    \"2082b5e0-7a64-478a-b1b2-e3404fab6dad\",\n"
+		"    \"00000000-0000-0000-0000-000000000000\"\n"
+		"  ],\n"
+		"  \"Flags\" : [\n"
+		"    \"updatable\",\n"
+		"    \"require-ac\"\n"
+		"  ],\n"
+		"  \"Checksums\" : [\n"
+		"    \"SHA1(beefdead)\"\n"
+		"  ],\n"
+		"  \"Icons\" : [\n"
+		"    \"input-gaming\",\n"
+		"    \"input-mouse\"\n"
+		"  ],\n"
+		"  \"Created\" : 1,\n"
+		"  \"Modified\" : 86400,\n"
+		"  \"Releases\" : [\n"
+		"    {\n"
+		"      \"AppstreamId\" : \"org.dave.ColorHug.firmware\",\n"
+		"      \"Description\" : \"<p>Hi there!</p>\",\n"
+		"      \"Version\" : \"1.2.3\",\n"
+		"      \"Filename\" : \"firmware.bin\",\n"
+		"      \"Checksum\" : [\n"
+		"        \"SHA1(deadbeef)\"\n"
+		"      ],\n"
+		"      \"Size\" : 1024,\n"
+		"      \"Uri\" : \"http://foo.com\",\n"
+		"      \"TrustFlags\" : 1\n"
+		"    }\n"
+		"  ]\n"
+		"}", &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 }


### PR DESCRIPTION
Rather than displaying:

    "Flags" : 9,

Use the more understandable:

    "Flags" : [
      "updatable",
      "require-ac"
    ],

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
