### PR TITLE
Rename FwupdRelease:trust-flags to FwupdRelease:flags

### DIFF
--- a/libfwupd/fwupd-enums.c
+++ b/libfwupd/fwupd-enums.c
@@ -365,3 +365,45 @@ fwupd_keyring_kind_to_string (FwupdKeyringKind keyring_kind)
 		return "pkcs7";
 	return NULL;
 }
+
+/**
+ * fwupd_release_flag_to_string:
+ * @release_flag: A #FwupdReleaseFlags, e.g. %FWUPD_RELEASE_FLAG_TRUSTED_PAYLOAD
+ *
+ * Converts a #FwupdReleaseFlags to a string.
+ *
+ * Return value: identifier string
+ *
+ * Since: 1.2.6
+ **/
+const gchar *
+fwupd_release_flag_to_string (FwupdReleaseFlags release_flag)
+{
+	if (release_flag == FWUPD_RELEASE_FLAG_NONE)
+		return "none";
+	if (release_flag == FWUPD_RELEASE_FLAG_TRUSTED_PAYLOAD)
+		return "trusted-payload";
+	if (release_flag == FWUPD_RELEASE_FLAG_TRUSTED_METADATA)
+		return "trusted-metadata";
+	return NULL;
+}
+
+/**
+ * fwupd_release_flag_from_string:
+ * @release_flag: A string, e.g. `trusted-payload`
+ *
+ * Converts a string to a #FwupdReleaseFlags.
+ *
+ * Return value: enumerated value
+ *
+ * Since: 1.2.6
+ **/
+FwupdReleaseFlags
+fwupd_release_flag_from_string (const gchar *release_flag)
+{
+	if (g_strcmp0 (release_flag, "trusted-payload") == 0)
+		return FWUPD_RELEASE_FLAG_TRUSTED_PAYLOAD;
+	if (g_strcmp0 (release_flag, "trusted-metadata") == 0)
+		return FWUPD_RELEASE_FLAG_TRUSTED_METADATA;
+	return FWUPD_RELEASE_FLAG_NONE;
+}

--- a/libfwupd/fwupd-enums.h
+++ b/libfwupd/fwupd-enums.h
@@ -117,6 +117,20 @@ typedef enum {
 typedef guint64 FwupdDeviceFlags;
 
 /**
+ * FwupdReleaseFlags:
+ * @FWUPD_RELEASE_FLAG_NONE:			No flags set
+ * @FWUPD_RELEASE_FLAG_TRUSTED_PAYLOAD:		The payload binary is trusted
+ * @FWUPD_RELEASE_FLAG_TRUSTED_METADATA:	The payload metadata is trusted
+ *
+ * The release flags.
+ **/
+#define FWUPD_RELEASE_FLAG_NONE			(0u)		/* Since: 1.2.6 */
+#define FWUPD_RELEASE_FLAG_TRUSTED_PAYLOAD	(1u << 0)	/* Since: 1.2.6 */
+#define FWUPD_RELEASE_FLAG_TRUSTED_METADATA	(1u << 1)	/* Since: 1.2.6 */
+#define FWUPD_RELEASE_FLAG_UNKNOWN		G_MAXUINT64	/* Since: 1.2.6 */
+typedef guint64 FwupdReleaseFlags;
+
+/**
  * FwupdInstallFlags:
  * @FWUPD_INSTALL_FLAG_NONE:			No flags set
  * @FWUPD_INSTALL_FLAG_OFFLINE:			Schedule this for next boot
@@ -180,6 +194,8 @@ const gchar	*fwupd_status_to_string			(FwupdStatus	 status);
 FwupdStatus	 fwupd_status_from_string		(const gchar	*status);
 const gchar	*fwupd_device_flag_to_string		(FwupdDeviceFlags device_flag);
 FwupdDeviceFlags fwupd_device_flag_from_string		(const gchar	*device_flag);
+const gchar	*fwupd_release_flag_to_string		(FwupdReleaseFlags release_flag);
+FwupdReleaseFlags fwupd_release_flag_from_string	(const gchar	*release_flag);
 const gchar	*fwupd_update_state_to_string		(FwupdUpdateState update_state);
 FwupdUpdateState fwupd_update_state_from_string		(const gchar	*update_state);
 const gchar	*fwupd_trust_flag_to_string		(FwupdTrustFlags trust_flag);

--- a/libfwupd/fwupd-release.h
+++ b/libfwupd/fwupd-release.h
@@ -89,9 +89,20 @@ void		 fwupd_release_set_size			(FwupdRelease	*release,
 const gchar	*fwupd_release_get_license		(FwupdRelease	*release);
 void		 fwupd_release_set_license		(FwupdRelease	*release,
 							 const gchar	*license);
-FwupdTrustFlags	 fwupd_release_get_trust_flags		(FwupdRelease	*release);
+FwupdTrustFlags	 fwupd_release_get_trust_flags		(FwupdRelease	*release)
+G_DEPRECATED_FOR(fwupd_release_get_flags);
 void		 fwupd_release_set_trust_flags		(FwupdRelease	*release,
-							 FwupdTrustFlags trust_flags);
+							 FwupdTrustFlags trust_flags)
+G_DEPRECATED_FOR(fwupd_release_set_flags);
+FwupdReleaseFlags fwupd_release_get_flags		(FwupdRelease	*release);
+void		 fwupd_release_set_flags		(FwupdRelease	*release,
+							 FwupdReleaseFlags flags);
+void		 fwupd_release_add_flag			(FwupdRelease	*release,
+							 FwupdReleaseFlags flag);
+void		 fwupd_release_remove_flag		(FwupdRelease	*release,
+							 FwupdReleaseFlags flag);
+gboolean	 fwupd_release_has_flag			(FwupdRelease	*release,
+							 FwupdReleaseFlags flag);
 guint32		 fwupd_release_get_install_duration	(FwupdRelease	*release);
 void		 fwupd_release_set_install_duration	(FwupdRelease	*release,
 							 guint32	 duration);

--- a/libfwupd/fwupd-self-test.c
+++ b/libfwupd/fwupd-self-test.c
@@ -286,7 +286,7 @@ fwupd_device_func (void)
 	fwupd_device_add_icon (dev, "input-mouse");
 	fwupd_device_add_flag (dev, FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	rel = fwupd_release_new ();
-	fwupd_release_set_trust_flags (rel, FWUPD_TRUST_FLAG_PAYLOAD);
+	fwupd_release_add_flag (rel, FWUPD_RELEASE_FLAG_TRUSTED_PAYLOAD);
 	fwupd_release_add_checksum (rel, "deadbeef");
 	fwupd_release_set_description (rel, "<p>Hi there!</p>");
 	fwupd_release_set_filename (rel, "firmware.bin");
@@ -326,7 +326,7 @@ fwupd_device_func (void)
 		"  Checksum:             SHA1(deadbeef)\n"
 		"  Size:                 1.0 kB\n"
 		"  Uri:                  http://foo.com\n"
-		"  TrustFlags:           payload\n", &error);
+		"  Flags:                trusted-payload\n", &error);
 	g_assert_no_error (error);
 	g_assert (ret);
 
@@ -373,7 +373,9 @@ fwupd_device_func (void)
 		"      ],\n"
 		"      \"Size\" : 1024,\n"
 		"      \"Uri\" : \"http://foo.com\",\n"
-		"      \"TrustFlags\" : 1\n"
+		"      \"Flags\" : [\n"
+		"        \"trusted-payload\"\n"
+		"      ]\n"
 		"    }\n"
 		"  ]\n"
 		"}", &error);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -325,6 +325,13 @@ LIBFWUPD_1.2.6 {
   global:
     fwupd_client_activate;
     fwupd_device_to_json;
+    fwupd_release_add_flag;
+    fwupd_release_flag_from_string;
+    fwupd_release_flag_to_string;
+    fwupd_release_get_flags;
+    fwupd_release_has_flag;
+    fwupd_release_remove_flag;
+    fwupd_release_set_flags;
     fwupd_release_to_json;
   local: *;
 } LIBFWUPD_1.2.5;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2334,7 +2334,7 @@ fu_engine_get_silo_from_blob (FuEngine *self, GBytes *blob_cab, GError **error)
 static FwupdDevice *
 fu_engine_get_result_from_component (FuEngine *self, XbNode *component, GError **error)
 {
-	FwupdTrustFlags trust_flags = FWUPD_TRUST_FLAG_NONE;
+	FwupdReleaseFlags release_flags = FWUPD_RELEASE_FLAG_NONE;
 	g_autoptr(FuInstallTask) task = NULL;
 	g_autoptr(FwupdDevice) dev = NULL;
 	g_autoptr(FwupdRelease) rel = NULL;
@@ -2401,9 +2401,9 @@ fu_engine_get_result_from_component (FuEngine *self, XbNode *component, GError *
 			     error_local->message);
 		return NULL;
 	}
-	if (!fu_keyring_get_release_trust_flags (release,
-						 &trust_flags,
-						 &error_local)) {
+	if (!fu_keyring_get_release_flags (release,
+					   &release_flags,
+					   &error_local)) {
 		if (g_error_matches (error_local,
 				     FWUPD_ERROR,
 				     FWUPD_ERROR_NOT_SUPPORTED)) {
@@ -2426,7 +2426,7 @@ fu_engine_get_result_from_component (FuEngine *self, XbNode *component, GError *
 			fwupd_device_set_description (dev, xml);
 	}
 	rel = fwupd_release_new ();
-	fwupd_release_set_trust_flags (rel, trust_flags);
+	fwupd_release_set_flags (rel, release_flags);
 	fu_engine_set_release_from_appstream (self, rel, component, release);
 	fwupd_device_add_release (dev, rel);
 	return g_steal_pointer (&dev);

--- a/src/fu-install-task.c
+++ b/src/fu-install-task.c
@@ -20,7 +20,7 @@ struct _FuInstallTask
 	GObject			 parent_instance;
 	FuDevice		*device;
 	XbNode			*component;
-	FwupdTrustFlags		 trust_flags;
+	FwupdReleaseFlags		 trust_flags;
 	gboolean		 is_downgrade;
 };
 
@@ -65,9 +65,9 @@ fu_install_task_get_component (FuInstallTask *self)
  * NOTE: This is only set after fu_install_task_check_requirements() has been
  * called successfully.
  *
- * Returns: the #FwupdTrustFlags, e.g. #FWUPD_TRUST_FLAG_PAYLOAD
+ * Returns: the #FwupdReleaseFlags, e.g. #FWUPD_TRUST_FLAG_PAYLOAD
  **/
-FwupdTrustFlags
+FwupdReleaseFlags
 fu_install_task_get_trust_flags (FuInstallTask *self)
 {
 	g_return_val_if_fail (FU_IS_INSTALL_TASK (self), FALSE);
@@ -250,7 +250,7 @@ fu_install_task_check_requirements (FuInstallTask *self,
 	}
 
 	/* verify */
-	if (!fu_keyring_get_release_trust_flags (release, &self->trust_flags, &error_local)) {
+	if (!fu_keyring_get_release_flags (release, &self->trust_flags, &error_local)) {
 		if (g_error_matches (error_local, FWUPD_ERROR, FWUPD_ERROR_NOT_SUPPORTED)) {
 			g_warning ("Ignoring verification for %s: %s",
 				   fu_device_get_name (self->device),

--- a/src/fu-install-task.h
+++ b/src/fu-install-task.h
@@ -20,7 +20,7 @@ FuInstallTask	*fu_install_task_new			(FuDevice	*device,
 							 XbNode		*component);
 FuDevice	*fu_install_task_get_device		(FuInstallTask	*self);
 XbNode		*fu_install_task_get_component		(FuInstallTask	*self);
-FwupdTrustFlags	 fu_install_task_get_trust_flags	(FuInstallTask	*self);
+FwupdReleaseFlags fu_install_task_get_trust_flags	(FuInstallTask	*self);
 gboolean	 fu_install_task_get_is_downgrade	(FuInstallTask	*self);
 gboolean	 fu_install_task_check_requirements	(FuInstallTask	*self,
 							 FwupdInstallFlags flags,

--- a/src/fu-keyring-utils.c
+++ b/src/fu-keyring-utils.c
@@ -66,19 +66,19 @@ fu_keyring_create_for_kind (FwupdKeyringKind kind, GError **error)
 }
 
 /**
- * fu_keyring_get_release_trust_flags:
+ * fu_keyring_get_release_flags:
  * @release: A #XbNode, e.g. %FWUPD_KEYRING_KIND_GPG
- * @trust_flags: A #FwupdTrustFlags, e.g. %FWUPD_TRUST_FLAG_PAYLOAD
+ * @flags: A #FwupdReleaseFlags, e.g. %FWUPD_RELEASE_FLAG_TRUSTED_PAYLOAD
  * @error: A #GError, or %NULL
  *
  * Uses the correct keyring to get the trust flags for a given release.
  *
- * Returns: %TRUE if @trust_flags has been set
+ * Returns: %TRUE if @flags has been set
  **/
 gboolean
-fu_keyring_get_release_trust_flags (XbNode *release,
-				    FwupdTrustFlags *trust_flags,
-				    GError **error)
+fu_keyring_get_release_flags (XbNode *release,
+			      FwupdReleaseFlags *flags,
+			      GError **error)
 {
 	FwupdKeyringKind keyring_kind = FWUPD_KEYRING_KIND_UNKNOWN;
 	GBytes *blob_payload;
@@ -169,6 +169,6 @@ fu_keyring_get_release_trust_flags (XbNode *release,
 
 	/* awesome! */
 	g_debug ("marking payload as trusted");
-	*trust_flags |= FWUPD_TRUST_FLAG_PAYLOAD;
+	*flags |= FWUPD_RELEASE_FLAG_TRUSTED_PAYLOAD;
 	return TRUE;
 }

--- a/src/fu-keyring-utils.h
+++ b/src/fu-keyring-utils.h
@@ -15,8 +15,8 @@ G_BEGIN_DECLS
 
 FuKeyring	*fu_keyring_create_for_kind		(FwupdKeyringKind kind,
 							 GError		**error);
-gboolean	 fu_keyring_get_release_trust_flags	(XbNode		*release,
-							 FwupdTrustFlags *trust_flags,
+gboolean	 fu_keyring_get_release_flags		(XbNode		*release,
+							 FwupdReleaseFlags *flags,
 							 GError		**error);
 
 G_END_DECLS

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -987,7 +987,7 @@ fu_engine_history_func (void)
 		"  [Release]\n"
 		"  Version:              1.2.3\n"
 		"  Checksum:             SHA1(%s)\n"
-		"  TrustFlags:           none\n"
+		"  Flags:                none\n"
 		"  VersionFormat:        triplet\n",
 		checksum);
 	ret = fu_test_compare_lines (device_str, device_str_expected, &error);
@@ -1221,7 +1221,7 @@ fu_engine_history_error_func (void)
 		"  [Release]\n"
 		"  Version:              1.2.3\n"
 		"  Checksum:             SHA1(%s)\n"
-		"  TrustFlags:           none\n"
+		"  Flags:                none\n"
 		"  VersionFormat:        triplet\n",
 		checksum);
 	ret = fu_test_compare_lines (device_str, device_str_expected, &error);


### PR DESCRIPTION
In the future we'll want to use this flag to signify if the release is an
upgrade, downgrade, below the version-lowest, or if it is locked in some way.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
