### PR TITLE
trivial: ci: move s390x build into CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,18 @@
 version: 2
 jobs:
-  build:
+  build-s390x:
+    machine:
+      image: circleci/classic:latest
+    steps:
+      - checkout
+      - run:
+          name: "Build container"
+          command: OS=debian-s390x ./contrib/ci/generate_docker.py
+      - run:
+          name: "Run build script"
+          command: docker run --privileged -e CI=true -t -v `pwd`/dist:/build/dist fwupd-debian-s390x
+
+  build-snap:
     docker:
       - image: superm1/snapcraft-edge:latest
     steps:
@@ -46,16 +58,17 @@ workflows:
   version: 2
   main:
     jobs:
-      - build
+      - build-s390x
+      - build-snap
       - publish-edge:
           requires:
-            - build
+            - build-snap
           filters:
             branches:
               only: master
       - publish-stable:
           requires:
-            - build
+            - build-snap
           filters:
             branches:
               ignore: /.*/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
   - docker
 
 env:
-  - OS=debian-s390x
   - OS=fedora
   - OS=debian-x86_64
   - OS=arch


### PR DESCRIPTION
This should hopefully make daily CI runs operate faster by balancing
some across Travis CI and some across Circle CI.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
