### PR TITLE
trivial: bump libxmlb subproject dependency

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -11,7 +11,7 @@ extraction:
       - python3-pil
       - python3-cairo
     after_prepare:
-    - "wget -O libxmlb.zip https://github.com/hughsie/libxmlb/archive/0.1.5.zip"
+    - "wget -O libxmlb.zip https://github.com/hughsie/libxmlb/archive/0.1.7.zip"
     - "mkdir -p subprojects/libxmlb"
     - "bsdtar --strip-components=1 -xvf libxmlb.zip -C subprojects/libxmlb"
     index:

--- a/subprojects/libxmlb.wrap
+++ b/subprojects/libxmlb.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory = libxmlb
 url = https://github.com/hughsie/libxmlb.git
-revision = 0.1.5
+revision = 0.1.7


### PR DESCRIPTION
Although it's an optional bump, this is needed for
88dc0f4bf088de7892447cdff8e8cea5e77d5383 to fully work.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
