### PR TITLE
fwpup.service: use display-manager.service instead of gdm.service

### DIFF
--- a/data/fwupd.service.in
+++ b/data/fwupd.service.in
@@ -2,7 +2,7 @@
 Description=Firmware update daemon
 Documentation=https://fwupd.org/
 After=dbus.service
-Before=gdm.service
+Before=display-manager.service
 
 [Service]
 Type=dbus


### PR DESCRIPTION
Instead of referring to just *gdm.service* use the alias *display-manager.service* instead to allow other display managers like *sddm* too.

Type of pull request:
- [x] Feature
