### PR TITLE
Ensure the PKCS-7 client certificate exists at startup

### DIFF
--- a/src/fu-keyring-pkcs7.c
+++ b/src/fu-keyring-pkcs7.c
@@ -591,12 +591,6 @@ fu_keyring_pkcs7_verify_data (FuKeyring *keyring,
 	g_auto(gnutls_x509_crt_t) crt = NULL;
 	g_autoptr(GString) authority_newest = g_string_new (NULL);
 
-	/* ensure the client certificate exists */
-	if (!fu_keyring_pkcs7_ensure_client_certificate (self, error)) {
-		g_prefix_error (error, "failed to generate client certificate: ");
-		return NULL;
-	}
-
 	/* startup */
 	rc = gnutls_pkcs7_init (&pkcs7);
 	if (rc != GNUTLS_E_SUCCESS) {


### PR DESCRIPTION
This ensures the certificate is always present even before the user has
generated a report or manually signed test data.

Also, if the GnuTLS version is too old just log a message and continue.
