### PR TITLE
Allow compilation on meson 0.45 again

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('fwupd', 'c',
   version : '1.2.6',
   license : 'LGPL-2.1+',
-  meson_version : '>=0.47.0',
+  meson_version : '>=0.44.0',
   default_options : ['warning_level=2', 'c_std=c99'],
 )
 
@@ -115,8 +115,14 @@ test_link_args = [
   '-Wl,-z,now',
 ]
 foreach arg: test_link_args
-  if cc.has_link_argument(arg)
-    global_link_args += arg
+  if meson.version().version_compare('>=0.46.0')
+    if cc.has_link_argument(arg)
+      global_link_args += arg
+    endif
+  else
+    if cc.has_argument(arg)
+      global_link_args += arg
+    endif
   endif
 endforeach
 add_global_link_arguments(


### PR DESCRIPTION
Revert "trivial: Bump meson dependency to 0.47.0"
This reverts commit 7cff2dcb25e4503cbf077744e4aa5a930371f4ae.

Revert "Bump requirement to meson 0.46.0"
This reverts commit 5caffbfb9c9a39de8aaf523c13670a10df9496cf.

This is for backporting into Ubuntu 18.04 which has meson 0.45.

This is the fwupd side of https://github.com/hughsie/libxmlb/pull/18

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
