### PR TITLE
Add optional vfuncs to allow detaching and attaching verify()

### DIFF
--- a/src/fu-plugin-vfuncs.h
+++ b/src/fu-plugin-vfuncs.h
@@ -33,6 +33,12 @@ gboolean	 fu_plugin_verify			(FuPlugin	*plugin,
 							 FuDevice	*dev,
 							 FuPluginVerifyFlags flags,
 							 GError		**error);
+gboolean	 fu_plugin_verify_attach		(FuPlugin	*plugin,
+							 FuDevice	*dev,
+							 GError		**error);
+gboolean	 fu_plugin_verify_detach		(FuPlugin	*plugin,
+							 FuDevice	*dev,
+							 GError		**error);
 gboolean	 fu_plugin_unlock			(FuPlugin	*plugin,
 							 FuDevice	*dev,
 							 GError		**error);


### PR DESCRIPTION
Some devices (e.g. Wacom, DFU and SuperIO) require the device to be in
'bootloader' mode before the device checksums can be populated.

Rather than each plugin handle both the open()->detach()->detach()->close()
sequence handle this in the plugin loader. It's not super-easy to do the right
thing for the failure case, and having two new dedicated vfuncs makes it a lot
simpler.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
