### PR TITLE
fu-tool: save history from stuff installed with `fwupdtool`

### DIFF
--- a/src/fu-tool.c
+++ b/src/fu-tool.c
@@ -637,6 +637,7 @@ fu_util_install_blob (FuUtilPrivate *priv, gchar **values, GError **error)
 			return FALSE;
 		}
 	}
+	priv->flags = FWUPD_INSTALL_FLAG_NO_HISTORY;
 	if (!fu_engine_install_blob (priv->engine, device, blob_fw, priv->flags, error))
 		return FALSE;
 	if (priv->cleanup_blob) {
@@ -1496,7 +1497,6 @@ main (int argc, char *argv[])
 	}
 
 	/* set flags */
-	priv->flags |= FWUPD_INSTALL_FLAG_NO_HISTORY;
 	if (allow_reinstall)
 		priv->flags |= FWUPD_INSTALL_FLAG_ALLOW_REINSTALL;
 	if (allow_older)


### PR DESCRIPTION
This is a vestigate of `fwupdtool` originally only being used for
`install-blob`.  Now that it can do a local `update` command and
local `install` command, it's important to update the history
database from `fwupdtool` as well.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
