### PR TITLE
Wip/superm1/fix ata activate

### DIFF
--- a/contrib/ci/Dockerfile-debian.in
+++ b/contrib/ci/Dockerfile-debian.in
@@ -1,5 +1,19 @@
 FROM %%%ARCH_PREFIX%%%debian:testing
 %%%OS%%%
+RUN echo "deb http://ftp.us.debian.org/debian unstable main contrib non-free" >> /etc/apt/sources.list
+RUN echo 'Package: *\n\
+Pin: release a=testing\n\
+Pin-Priority: 900\n\
+\n\
+Package: *\n\
+Pin: release a=unstable\n\
+Pin-Priority: 800\n\
+\n\
+Package: libxmlb-dev\n\
+Pin: release a=unstable\n\
+Pin-Priority: 901\n'\
+ > /etc/apt/preferences
+RUN cat /etc/apt/preferences
 RUN echo fubar > /etc/machine-id
 %%%ARCH_SPECIFIC_COMMAND%%%
 %%%INSTALL_DEPENDENCIES_COMMAND%%%

--- a/meson.build
+++ b/meson.build
@@ -155,7 +155,7 @@ gudev = dependency('gudev-1.0')
 if gudev.version().version_compare('>= 232')
   conf.set('HAVE_GUDEV_232', '1')
 endif
-libxmlb = dependency('xmlb', version : '>= 0.1.5', fallback : ['libxmlb', 'libxmlb_dep'])
+libxmlb = dependency('xmlb', version : '>= 0.1.7', fallback : ['libxmlb', 'libxmlb_dep'])
 gusb = dependency('gusb', version : '>= 0.2.9')
 sqlite = dependency('sqlite3')
 libarchive = dependency('libarchive')


### PR DESCRIPTION
For me, this fixes activation on shutdown with ATA disks.

I ran into 2 distinct issues:
* The standby immediate and microcode activate commands don't transfer any data
* I had an older `libxmlb` and it wasn't at all obvious that it was failing with a read only filesystem

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
