### PR TITLE
uefi: add a new option to specify the os name

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -28,3 +28,4 @@ option('efi-ld', type : 'string', value : 'ld', description : 'the linker to use
 option('efi-libdir', type : 'string', description : 'path to the EFI lib directory')
 option('efi-ldsdir', type : 'string', description : 'path to the EFI lds directory')
 option('efi-includedir', type : 'string', value : '/usr/include/efi', description : 'path to the EFI header directory')
+option('efi_os_dir', type: 'string', description : 'the name of OS directory in ESP')

--- a/plugins/uefi/fu-uefi-common.c
+++ b/plugins/uefi/fu-uefi-common.c
@@ -246,6 +246,7 @@ gchar *
 fu_uefi_get_esp_path_for_os (const gchar *esp_path)
 {
 	const gchar *os_release_id = NULL;
+#ifndef EFI_OS_DIR
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GHashTable) os_release = fwupd_get_os_release (&error_local);
 	if (os_release != NULL) {
@@ -255,6 +256,9 @@ fu_uefi_get_esp_path_for_os (const gchar *esp_path)
 	}
 	if (os_release_id == NULL)
 		os_release_id = "unknown";
+#else
+	os_release_id = EFI_OS_DIR;
+#endif
 	return g_build_filename (esp_path, "EFI", os_release_id, NULL);
 }
 

--- a/plugins/uefi/meson.build
+++ b/plugins/uefi/meson.build
@@ -3,6 +3,11 @@ subdir('efi')
 cargs = ['-DG_LOG_DOMAIN="FuPluginUefi"']
 cargs += '-DEFI_APP_LOCATION_BUILD="' + app.full_path() + '"'
 
+efi_os_dir = get_option('efi_os_dir')
+if efi_os_dir != ''
+  cargs += '-DEFI_OS_DIR="' + efi_os_dir + '"'
+endif
+
 install_data(['uefi.quirk'],
   install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
 )


### PR DESCRIPTION
fu_uefi_get_esp_path_for_os() generates the path to the OS directory
based on "ID" in /etc/os-release, and it may not work for some distros.

Take openSUSE as an example, the "ID" for openSUSE Leap is
"opensuse-leap" and that for openSUSE Tumbleweed is "opensuse-tumbleweed".
However, both of them use the same OS directory in the ESP, i.e.
"/EFI/opensuse".

This commit adds a new build option, efi-osdir, to allow the packager to
specify the name of OS directory at build time instead of the runtime
detection.

Signed-off-by: Gary Lin <glin@suse.com>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [X] Feature
- [ ] Documentation
