### PR TITLE
Return the newest device when using fu_history_get_device_by_id()

### DIFF
--- a/src/fu-history.c
+++ b/src/fu-history.c
@@ -725,7 +725,8 @@ fu_history_get_device_by_id (FuHistory *self, const gchar *device_id, GError **e
 					"version_old, "
 					"checksum_device, "
 					"protocol FROM history WHERE "
-				 "device_id = ?1 LIMIT 1", -1, &stmt, NULL);
+				 "device_id = ?1 ORDER BY device_created DESC "
+				 "LIMIT 1", -1, &stmt, NULL);
 	if (rc != SQLITE_OK) {
 		g_set_error (error, FWUPD_ERROR, FWUPD_ERROR_INTERNAL,
 			     "Failed to prepare SQL to get history: %s",


### PR DESCRIPTION
Always return the newest-created device when there are multiple results.

Might fix https://github.com/hughsie/fwupd/issues/1118
