### PR TITLE
Add a component property to express the firmware scope

### DIFF
--- a/libfwupd/fwupd-enums-private.h
+++ b/libfwupd/fwupd-enums-private.h
@@ -16,6 +16,7 @@ G_BEGIN_DECLS
 #define FWUPD_RESULT_KEY_PARENT_DEVICE_ID	"ParentDeviceId"/* s */
 #define FWUPD_RESULT_KEY_FILENAME		"Filename"	/* s */
 #define FWUPD_RESULT_KEY_PROTOCOL		"Protocol"	/* s */
+#define FWUPD_RESULT_KEY_CATEGORIES		"Categories"	/* as */
 #define FWUPD_RESULT_KEY_FLAGS			"Flags"		/* t */
 #define FWUPD_RESULT_KEY_FLASHES_LEFT		"FlashesLeft"	/* u */
 #define FWUPD_RESULT_KEY_INSTALL_DURATION	"InstallDuration"	/* u */

--- a/libfwupd/fwupd-release.h
+++ b/libfwupd/fwupd-release.h
@@ -37,6 +37,11 @@ void		 fwupd_release_set_version		(FwupdRelease	*release,
 const gchar	*fwupd_release_get_uri			(FwupdRelease	*release);
 void		 fwupd_release_set_uri			(FwupdRelease	*release,
 							 const gchar	*uri);
+GPtrArray	*fwupd_release_get_categories		(FwupdRelease	*release);
+void		 fwupd_release_add_category		(FwupdRelease	*release,
+							 const gchar	*category);
+gboolean	 fwupd_release_has_category		(FwupdRelease	*release,
+							 const gchar	*category);
 GPtrArray	*fwupd_release_get_checksums		(FwupdRelease	*release);
 void		 fwupd_release_add_checksum		(FwupdRelease	*release,
 							 const gchar	*checksum);

--- a/libfwupd/fwupd.map
+++ b/libfwupd/fwupd.map
@@ -340,3 +340,11 @@ LIBFWUPD_1.2.6 {
     fwupd_remote_get_approval_required;
   local: *;
 } LIBFWUPD_1.2.5;
+
+LIBFWUPD_1.2.7 {
+  global:
+    fwupd_release_add_category;
+    fwupd_release_get_categories;
+    fwupd_release_has_category;
+  local: *;
+} LIBFWUPD_1.2.6;

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -256,6 +256,7 @@ fu_engine_set_release_from_appstream (FuEngine *self,
 	const gchar *remote_id;
 	guint64 tmp64;
 	g_autofree gchar *version_rel = NULL;
+	g_autoptr(GPtrArray) cats = NULL;
 	g_autoptr(XbNode) description = NULL;
 
 	/* set from the component */
@@ -340,6 +341,13 @@ fu_engine_set_release_from_appstream (FuEngine *self,
 	tmp64 = xb_node_get_attr_as_uint (release, "install_duration");
 	if (tmp64 != G_MAXUINT64)
 		fwupd_release_set_install_duration (rel, tmp64);
+	cats = xb_node_query (component, "categories/category", 0, NULL);
+	if (cats != NULL) {
+		for (guint i = 0; i < cats->len; i++) {
+			XbNode *n = g_ptr_array_index (cats, i);
+			fwupd_release_add_category (rel, xb_node_get_text (n));
+		}
+	}
 	tmp = xb_node_query_text (component, "custom/value[@key='LVFS::UpdateProtocol']", NULL);
 	if (tmp != NULL)
 		fwupd_release_set_protocol (rel, tmp);

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -460,3 +460,45 @@ fu_util_setup_networking (GError **error)
 	soup_session_remove_feature_by_type (session, SOUP_TYPE_CONTENT_DECODER);
 	return g_steal_pointer (&session);
 }
+
+gchar *
+fu_util_release_get_name (FwupdRelease *release)
+{
+	const gchar *name = fwupd_release_get_name (release);
+	GPtrArray *cats = fwupd_release_get_categories (release);
+
+	for (guint i = 0; i < cats->len; i++) {
+		const gchar *cat = g_ptr_array_index (cats, i);
+		if (g_strcmp0 (cat, "X-Device") == 0) {
+			/* TRANSLATORS: a specific part of hardware,
+			 * the first %s is the device name, e.g. 'Unifying Receiver` */
+			return g_strdup_printf (_("%s Device Update"), name);
+		}
+		if (g_strcmp0 (cat, "X-System") == 0) {
+			/* TRANSLATORS: the entire system, e.g. all internal devices,
+			 * the first %s is the device name, e.g. 'ThinkPad P50` */
+			return g_strdup_printf (_("%s System Update"), name);
+		}
+		if (g_strcmp0 (cat, "X-EmbeddedController") == 0) {
+			/* TRANSLATORS: the EC is typically the keyboard controller chip,
+			 * the first %s is the device name, e.g. 'ThinkPad P50` */
+			return g_strdup_printf (_("%s Embedded Controller Update"), name);
+		}
+		if (g_strcmp0 (cat, "X-ManagementEngine") == 0) {
+			/* TRANSLATORS: ME stands for Management Engine, the Intel AMT thing,
+			 * the first %s is the device name, e.g. 'ThinkPad P50` */
+			return g_strdup_printf (_("%s ME Update"), name);
+		}
+		if (g_strcmp0 (cat, "X-Controller") == 0) {
+			/* TRANSLATORS: the controller is a device that has other devices
+			 * plugged into it, for example ThunderBolt, FireWire or USB,
+			 * the first %s is the device name, e.g. 'Intel ThunderBolt` */
+			return g_strdup_printf (_("%s Controller Update"), name);
+		}
+	}
+
+	/* TRANSLATORS: this is the fallback where we don't know if the release
+	 * is updating the system, the device, or a device class, or something else --
+	 * the first %s is the device name, e.g. 'ThinkPad P50` */
+	return g_strdup_printf (_("%s Update"), name);
+}

--- a/src/fu-util-common.h
+++ b/src/fu-util-common.h
@@ -56,5 +56,6 @@ gboolean	 fu_util_cmd_array_run		(GPtrArray	*array,
 						 const gchar	*command,
 						 gchar		**values,
 						 GError		**error);
+gchar		*fu_util_release_get_name	(FwupdRelease	*release);
 
 G_END_DECLS

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -1263,7 +1263,7 @@ fu_util_get_releases (FuUtilPrivate *priv, gchar **values, GError **error)
 		fu_util_print_data (_("Version"), fwupd_release_get_version (rel));
 
 		/* TRANSLATORS: section header for the release name */
-		fu_util_print_data (_("Name"), fwupd_release_get_name (rel));
+		fu_util_print_data (_("Name"), fu_util_release_get_name (rel));
 
 		/* TRANSLATORS: section header for the release one line summary */
 		fu_util_print_data (_("Summary"), fwupd_release_get_summary (rel));
@@ -1559,7 +1559,7 @@ fu_util_get_updates (FuUtilPrivate *priv, gchar **values, GError **error)
 					    fwupd_release_get_version (rel));
 
 			/* TRANSLATORS: section header for the release name */
-			fu_util_print_data (_("Update Name"), fwupd_release_get_name (rel));
+			fu_util_print_data (_("Update Name"), fu_util_release_get_name (rel));
 
 			/* TRANSLATORS: section header for the release one line summary */
 			fu_util_print_data (_("Update Summary"), fwupd_release_get_summary (rel));


### PR DESCRIPTION
Some firmwares only update one part of the system, e.g. the EC or ME firmware.
Other updates include all the updates needed for the whole system, and vendors
have been doing different things with the component name due to this.

To fix, add an enumerated set of firmware 'scopes' that can be set by the
uploader in the metainfo.xml file (or changed the LVFS) which automatically
set the name suffix.

Only append the translated version in the client when LVFS::UpdateScope has
not been set, as the LVFS is still operating in compatibility mode and setting
the <name> with the prefix. Add the support to fwupd now so we can switch in
about 6 months time.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
