### PR TITLE
ata: Flush cache before standby and activate

### DIFF
--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -36,6 +36,7 @@ struct ata_tf {
 #define ATA_STAT_ERR			(1 << 0)
 
 #define ATA_OP_IDENTIFY			0xec
+#define ATA_OP_FLUSH_CACHE		0xe7
 #define ATA_OP_DOWNLOAD_MICROCODE	0x92
 #define ATA_OP_STANDBY_IMMEDIATE	0xe0
 
@@ -473,8 +474,16 @@ fu_ata_device_activate (FuDevice *device, GError **error)
 	FuAtaDevice *self = FU_ATA_DEVICE (device);
 	struct ata_tf tf = { 0x0 };
 
-	/* flush caches and make sure drive is ready to activate */
+
+	/* flush cache and put drive in standby to prepare to activate */
 	tf.dev = ATA_USING_LBA;
+	tf.command = ATA_OP_FLUSH_CACHE;
+	if (!fu_ata_device_command (self, &tf, SG_DXFER_NONE,
+				    120 * 1000, /* a long time! */
+				    NULL, 0, error)) {
+		g_prefix_error (error, "failed to flush cache immediate: ");
+		return FALSE;
+	}
 	tf.command = ATA_OP_STANDBY_IMMEDIATE;
 	if (!fu_ata_device_command (self, &tf, SG_DXFER_NONE,
 				    120 * 1000, /* a long time! */


### PR DESCRIPTION
I had thought this should be implicit from standby immediate command
but it isn't.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
