### PR TITLE
snap: Add a custom systemd unit to call activation on shutdown (Fixes…

### DIFF
--- a/contrib/snap/activate-shutdown/Makefile
+++ b/contrib/snap/activate-shutdown/Makefile
@@ -1,0 +1,9 @@
+build:
+	true
+install:
+	install -d ${DESTDIR}/etc/systemd/system/
+	install -m0644 fwupd-activate.service ${DESTDIR}/etc/systemd/system
+	# fixes up shutdown activation script for classic snap
+	sed -i "s,/libexec/fwupd/,/snap/bin/fwupd.,"                                    \
+		${SNAPCRAFT_STAGE}/lib/systemd/system-shutdown/fwupd.shutdown
+

--- a/contrib/snap/activate-shutdown/fwupd-activate.service
+++ b/contrib/snap/activate-shutdown/fwupd-activate.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Activate fwupd updates
+RequiresMountsFor=/snap/fwupd/current
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStop=/snap/bin/fwupd.fwupdtool activate
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/snap/snapcraft-master.yaml
+++ b/contrib/snap/snapcraft-master.yaml
@@ -313,6 +313,10 @@ parts:
     plugin: make
     source: contrib/snap/fix-bash-completion
     after: [fwupd]
+  activate-shutdown:
+    plugin: make
+    source: contrib/snap/activate-shutdown
+    after: [fwupd]
   update-mime:
     plugin: make
     source: contrib/snap/update-mime

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -12,4 +12,6 @@ install_if_missing share/dbus-1/system-services/org.freedesktop.fwupd.service /u
 install_if_missing share/dbus-1/interfaces/org.freedesktop.fwupd.xml /usr
 install_if_missing etc/dbus-1/system.d/org.freedesktop.fwupd.conf /
 #activation via systemd
-install_if_missing lib/systemd/system-shutdown/fwupd.shutdown /
+install_if_missing etc/systemd/system/fwupd-activate.service /
+systemctl daemon-reload
+systemctl enable fwupd-activate

--- a/snap/hooks/remove
+++ b/snap/hooks/remove
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+#activation via systemd
+systemctl disable fwupd-activate
+rm /etc/systemd/system/fwupd-activate.service -f
+systemctl daemon-reload

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -327,6 +327,10 @@ parts:
     plugin: make
     source: contrib/snap/fix-bash-completion
     after: [fwupd]
+  activate-shutdown:
+    plugin: make
+    source: contrib/snap/activate-shutdown
+    after: [fwupd]
   update-mime:
     plugin: make
     source: contrib/snap/update-mime


### PR DESCRIPTION
…: #1125)

The systemd shutdown script gets called after /snap/fwupd/* gets
unmounted meaning it can't be used to do the activation.

Explicitly check that the symlink for /snap/fwupd/current is mounted
when calling the script.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
