### PR TITLE
fu-engine: Clear activation flag on old firmware not new (Fixes: #1130)

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -4144,6 +4144,7 @@ fu_engine_update_history_device (FuEngine *self, FuDevice *dev_history, GError *
 			const gchar *csum = g_ptr_array_index (checksums, i);
 			fu_device_add_checksum (dev_history, csum);
 		}
+		fu_device_set_version (dev_history, fu_device_get_version (dev));
 		fu_device_remove_flag (dev_history, FWUPD_DEVICE_FLAG_NEEDS_ACTIVATION);
 		fu_device_set_update_state (dev_history, FWUPD_UPDATE_STATE_SUCCESS);
 		return fu_history_modify_device (self->history, dev_history,


### PR DESCRIPTION
For me this seems to fix #1130 and match the right device.

Repro steps:
1. Clear pending.db
2. Start with ATA firmware X.
3. Flash ATA firmware Y.
4. Reboot machine (activate runs on shutdown)
5. Verify running on ATA firmware Y.
6. Verify that `fwupdmgr activate` return `No firmware to activate`.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
