### PR TITLE
trivial: disable CentOS CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
   - OS=arch
   - OS=debian-i386
   - OS=ubuntu-x86_64
-  - OS=centos
   - OS=flatpak
 
 install:


### PR DESCRIPTION
It's currently failing with no changes caused by fwupd.

```
Step 10/16 : RUN pip3 install pillow pygobject
 ---> Running in 613ba74c32ce
Collecting pillow
  Downloading https://files.pythonhosted.org/packages/81/1a/6b2971adc1bca55b9a53ed1efa372acff7e8b9913982a396f3fa046efaf8/Pillow-6.0.0.tar.gz (29.5MB)
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/Pillow.egg-info
    writing dependency_links to pip-egg-info/Pillow.egg-info/dependency_links.txt
    writing top-level names to pip-egg-info/Pillow.egg-info/top_level.txt
    writing pip-egg-info/Pillow.egg-info/PKG-INFO
    writing manifest file 'pip-egg-info/Pillow.egg-info/SOURCES.txt'
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-6xakdwq1/pillow/setup.py", line 792, in <module>
        zip_safe=not (debug_build() or PLATFORM_MINGW), )
      File "/usr/lib/python3.4/site-packages/setuptools/__init__.py", line 129, in setup
        return distutils.core.setup(**attrs)
      File "/usr/lib64/python3.4/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/usr/lib64/python3.4/distutils/dist.py", line 955, in run_commands
        self.run_command(cmd)
      File "/usr/lib64/python3.4/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/usr/lib/python3.4/site-packages/setuptools/command/egg_info.py", line 278, in run
        self.find_sources()
      File "/usr/lib/python3.4/site-packages/setuptools/command/egg_info.py", line 293, in find_sources
        mm.run()
      File "/usr/lib/python3.4/site-packages/setuptools/command/egg_info.py", line 524, in run
        self.add_defaults()
      File "/usr/lib/python3.4/site-packages/setuptools/command/egg_info.py", line 560, in add_defaults
        sdist.add_defaults(self)
      File "/usr/lib/python3.4/site-packages/setuptools/command/py36compat.py", line 36, in add_defaults
        self._add_defaults_ext()
      File "/usr/lib/python3.4/site-packages/setuptools/command/py36compat.py", line 119, in _add_defaults_ext
        build_ext = self.get_finalized_command('build_ext')
      File "/usr/lib64/python3.4/distutils/cmd.py", line 299, in get_finalized_command
        cmd_obj.ensure_finalized()
      File "/usr/lib64/python3.4/distutils/cmd.py", line 107, in ensure_finalized
        self.finalize_options()
      File "/tmp/pip-build-6xakdwq1/pillow/setup.py", line 268, in finalize_options
        if sys.version_info.major >= 3 and not self.parallel:
      File "/usr/lib64/python3.4/distutils/cmd.py", line 103, in __getattr__
        raise AttributeError(attr)
    AttributeError: parallel

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-6xakdwq1/pillow/
You are using pip version 8.1.2, however version 19.0.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
The command '/bin/sh -c pip3 install pillow pygobject' returned a non-zero code: 1
```

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
