### PR TITLE
ModemManager/qmi-pdc: activate config as part of the FW upgrade process

### DIFF
--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -15,8 +15,12 @@
 #include "fu-mm-utils.h"
 #include "fu-qmi-pdc-updater.h"
 
-/* amount of time for the modem to be re-probed and exposed in MM after being uninhibited */
-#define FU_MM_DEVICE_REMOVE_DELAY_REPROBE	45000	/* ms */
+/* Amount of time for the modem to be re-probed and exposed in MM after being
+ * uninhibited. The timeout is long enough to cover the worst case, where the
+ * modem boots without SIM card inserted (and therefore the initialization
+ * may be very slow) and also where carrier config switching is explicitly
+ * required (e.g. if switching from the default (DF) to generic (GC).*/
+#define FU_MM_DEVICE_REMOVE_DELAY_REPROBE	120000	/* ms */
 
 struct _FuMmDevice {
 	FuDevice			 parent_instance;

--- a/plugins/modem-manager/fu-qmi-pdc-updater.h
+++ b/plugins/modem-manager/fu-qmi-pdc-updater.h
@@ -15,13 +15,16 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE (FuQmiPdcUpdater, fu_qmi_pdc_updater, FU, QMI_PDC_UPDATER, GObject)
 
 FuQmiPdcUpdater	*fu_qmi_pdc_updater_new		(const gchar		*qmi_port);
-gboolean	fu_qmi_pdc_updater_open		(FuQmiPdcUpdater	*self,
+gboolean	 fu_qmi_pdc_updater_open	(FuQmiPdcUpdater	*self,
 						 GError			**error);
-gboolean	fu_qmi_pdc_updater_write	(FuQmiPdcUpdater	*self,
+GArray		*fu_qmi_pdc_updater_write	(FuQmiPdcUpdater	*self,
 						 const gchar		*filename,
 						 GBytes			*blob,
 						 GError			**error);
-gboolean	fu_qmi_pdc_updater_close	(FuQmiPdcUpdater	*self,
+gboolean	 fu_qmi_pdc_updater_activate	(FuQmiPdcUpdater	*self,
+						 GArray			*digest,
+						 GError			**error);
+gboolean	 fu_qmi_pdc_updater_close	(FuQmiPdcUpdater	*self,
 						 GError			**error);
 
 G_END_DECLS


### PR DESCRIPTION
Type of pull request:
- [x] Code fix
- [x] Feature

This MR avoids having the module be detected with any specific carrier config selected ("DF", default) after a firmware upgrade. As soon as the MCFG files have been downloaded to the device, we can right away select the one we want to use (based on the last firmware version reported, which includes the carrier config ID embedded).

This logic is needed to have the firmware update process working correctly when there is no SIM inserted, as the carrier selection automagic in ModemManager only works when there is a valid SIM inserted.
