### PR TITLE
Detect version number like RQR24.06_B0030 as 'plain'

### DIFF
--- a/src/fu-common-version.c
+++ b/src/fu-common-version.c
@@ -308,7 +308,7 @@ fu_common_version_guess_format (const gchar *version)
 	for (guint i = 0; split[i] != NULL; i++) {
 		/* check sections are plain numbers */
 		if (!_g_ascii_is_digits (split[i]))
-			return FU_VERSION_FORMAT_UNKNOWN;
+			return FU_VERSION_FORMAT_PLAIN;
 	}
 
 	/* the most common formats */

--- a/src/fu-self-test.c
+++ b/src/fu-self-test.c
@@ -163,7 +163,7 @@ fu_common_version_guess_format_func (void)
 	g_assert_cmpint (fu_common_version_guess_format ("1.2.3"), ==, FU_VERSION_FORMAT_TRIPLET);
 	g_assert_cmpint (fu_common_version_guess_format ("1.2.3.4"), ==, FU_VERSION_FORMAT_QUAD);
 	g_assert_cmpint (fu_common_version_guess_format ("1.2.3.4.5"), ==, FU_VERSION_FORMAT_UNKNOWN);
-	g_assert_cmpint (fu_common_version_guess_format ("1a.2b.3"), ==, FU_VERSION_FORMAT_UNKNOWN);
+	g_assert_cmpint (fu_common_version_guess_format ("1a.2b.3"), ==, FU_VERSION_FORMAT_PLAIN);
 	g_assert_cmpint (fu_common_version_guess_format ("1"), ==, FU_VERSION_FORMAT_PLAIN);
 }
 


### PR DESCRIPTION
Failing the semver checks we want to fall back to PLAIN, rather than UNKNOWN.
