### PR TITLE
UEFI Fixes

### DIFF
--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -763,8 +763,11 @@ fu_plugin_coldplug (FuPlugin *plugin, GError **error)
 
 	/* if secure boot is enabled ensure we have a signed fwupd.efi */
 	bootloader = fu_uefi_get_built_app_path (&error_bootloader);
-	if (bootloader == NULL)
+	if (bootloader == NULL) {
+		if (fu_uefi_secure_boot_enabled ())
+			g_prefix_error (&error_bootloader, "missing signed bootloader for secure boot: ");
 		g_warning ("%s", error_bootloader->message);
+	}
 
 	/* ensure the ESP is detected */
 	if (!fu_plugin_uefi_ensure_esp_path (plugin, &error_esp))

--- a/plugins/uefi/fu-uefi-common.c
+++ b/plugins/uefi/fu-uefi-common.c
@@ -88,8 +88,6 @@ fu_uefi_get_built_app_path (GError **error)
 	g_autofree gchar *prefix = NULL;
 	if (fu_uefi_secure_boot_enabled ())
 		extension = ".signed";
-	if (g_file_test (EFI_APP_LOCATION_BUILD, G_FILE_TEST_EXISTS))
-		return g_strdup_printf ("%s%s", EFI_APP_LOCATION_BUILD, extension);
 	suffix = fu_uefi_bootmgr_get_suffix (error);
 	if (suffix == NULL)
 		return NULL;

--- a/plugins/uefi/meson.build
+++ b/plugins/uefi/meson.build
@@ -1,7 +1,6 @@
 subdir('efi')
 
 cargs = ['-DG_LOG_DOMAIN="FuPluginUefi"']
-cargs += '-DEFI_APP_LOCATION_BUILD="' + app.full_path() + '"'
 
 efi_os_dir = get_option('efi_os_dir')
 if efi_os_dir != ''


### PR DESCRIPTION
When booted with secure boot and a hand install I noticed that I wasn't getting an error related to a missing secure boot binary, which was completely unexpected to me.

It's because the build path was leaked into the binary and was not really being checked.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
