### PR TITLE
Don't upload reports when the user has configured their system in a b…

### DIFF
--- a/libfwupd/fwupd-error.c
+++ b/libfwupd/fwupd-error.c
@@ -63,6 +63,8 @@ fwupd_error_to_string (FwupdError error)
 		return FWUPD_DBUS_INTERFACE ".AcPowerRequired";
 	if (error == FWUPD_ERROR_PERMISSION_DENIED)
 		return FWUPD_DBUS_INTERFACE ".PermissionDenied";
+	if (error == FWUPD_ERROR_BROKEN_SYSTEM)
+		return FWUPD_DBUS_INTERFACE ".BrokenSystem";
 	return NULL;
 }
 
@@ -107,6 +109,8 @@ fwupd_error_from_string (const gchar *error)
 		return FWUPD_ERROR_AC_POWER_REQUIRED;
 	if (g_strcmp0 (error, FWUPD_DBUS_INTERFACE ".PermissionDenied") == 0)
 		return FWUPD_ERROR_PERMISSION_DENIED;
+	if (g_strcmp0 (error, FWUPD_DBUS_INTERFACE ".BrokenSystem") == 0)
+		return FWUPD_ERROR_BROKEN_SYSTEM;
 	return FWUPD_ERROR_LAST;
 }
 

--- a/libfwupd/fwupd-error.h
+++ b/libfwupd/fwupd-error.h
@@ -28,6 +28,7 @@ G_BEGIN_DECLS
  * @FWUPD_ERROR_SIGNATURE_INVALID:		Signature was invalid
  * @FWUPD_ERROR_AC_POWER_REQUIRED:		AC power was required
  * @FWUPD_ERROR_PERMISSION_DENIED:		Permission was denied
+ * @FWUPD_ERROR_BROKEN_SYSTEM:			User has configured their system in a broken way
  *
  * The error code.
  **/
@@ -46,6 +47,7 @@ typedef enum {
 	FWUPD_ERROR_SIGNATURE_INVALID,		/* Since: 0.1.2 */
 	FWUPD_ERROR_AC_POWER_REQUIRED,		/* Since: 0.8.0 */
 	FWUPD_ERROR_PERMISSION_DENIED,		/* Since: 0.9.8 */
+	FWUPD_ERROR_BROKEN_SYSTEM,		/* Since: 1.2.8 */
 	/*< private >*/
 	FWUPD_ERROR_LAST
 } FwupdError;

--- a/plugins/uefi/fu-uefi-bootmgr.c
+++ b/plugins/uefi/fu-uefi-bootmgr.c
@@ -11,6 +11,8 @@
 #include <gio/gio.h>
 #include <stdio.h>
 
+#include "fwupd-error.h"
+
 #include "fu-ucs2.h"
 #include "fu-uefi-bootmgr.h"
 #include "fu-uefi-common.h"
@@ -343,8 +345,8 @@ fu_uefi_bootmgr_bootnext (const gchar *esp_path,
 		if (fu_uefi_secure_boot_enabled () &&
 		    (flags & FU_UEFI_BOOTMGR_FLAG_USE_SHIM_FOR_SB) > 0) {
 			g_set_error_literal (error,
-					     G_IO_ERROR,
-					     G_IO_ERROR_FAILED,
+					     FWUPD_ERROR,
+					     FWUPD_ERROR_BROKEN_SYSTEM,
 					     "Secure boot is enabled, but shim isn't installed to the EFI system partition");
 			return FALSE;
 		}

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1635,7 +1635,10 @@ fu_engine_install (FuEngine *self,
 		fu_device_set_status (device, FWUPD_STATUS_IDLE);
 		if (g_error_matches (error_local,
 				     FWUPD_ERROR,
-				     FWUPD_ERROR_AC_POWER_REQUIRED)) {
+				     FWUPD_ERROR_AC_POWER_REQUIRED) ||
+		    g_error_matches (error_local,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_BROKEN_SYSTEM)) {
 			fu_device_set_update_state (device, FWUPD_UPDATE_STATE_FAILED_TRANSIENT);
 		} else {
 			fu_device_set_update_state (device, FWUPD_UPDATE_STATE_FAILED);


### PR DESCRIPTION
…roken way

I'm getting a bit fed up with failed reports from arch users where they just
have a broken system. I don't think it's useful to upload to the LVFS or notify
the vendor about failures like this.
