### PR TITLE
fu-usb-device: Don't create GUIDs for class/subclass (Fixes: #1162)

### DIFF
--- a/src/fu-usb-device.c
+++ b/src/fu-usb-device.c
@@ -228,7 +228,6 @@ fu_usb_device_probe (FuDevice *device, GError **error)
 	g_autofree gchar *devid1 = NULL;
 	g_autofree gchar *devid2 = NULL;
 	g_autofree gchar *vendor_id = NULL;
-	g_autoptr(GPtrArray) intfs = NULL;
 
 	/* set vendor ID */
 	vendor_id = g_strdup_printf ("USB:0x%04X", g_usb_device_get_vid (priv->usb_device));
@@ -255,29 +254,6 @@ fu_usb_device_probe (FuDevice *device, GError **error)
 	devid0 = g_strdup_printf ("USB\\VID_%04X",
 				  g_usb_device_get_vid (priv->usb_device));
 	fu_device_add_instance_id (device, devid0);
-
-	/* add the interface GUIDs */
-	intfs = g_usb_device_get_interfaces (priv->usb_device, error);
-	if (intfs == NULL)
-		return FALSE;
-	for (guint i = 0; i < intfs->len; i++) {
-		GUsbInterface *intf = g_ptr_array_index (intfs, i);
-		g_autofree gchar *intid1 = NULL;
-		g_autofree gchar *intid2 = NULL;
-		g_autofree gchar *intid3 = NULL;
-		intid1 = g_strdup_printf ("USB\\CLASS_%02X&SUBCLASS_%02X&PROT_%02X",
-					  g_usb_interface_get_class (intf),
-					  g_usb_interface_get_subclass (intf),
-					  g_usb_interface_get_protocol (intf));
-		fu_device_add_instance_id (device, intid1);
-		intid2 = g_strdup_printf ("USB\\CLASS_%02X&SUBCLASS_%02X",
-					  g_usb_interface_get_class (intf),
-					  g_usb_interface_get_subclass (intf));
-		fu_device_add_instance_id (device, intid2);
-		intid3 = g_strdup_printf ("USB\\CLASS_%02X",
-					  g_usb_interface_get_class (intf));
-		fu_device_add_instance_id (device, intid3);
-	}
 
 	/* subclassed */
 	if (klass->probe != NULL) {


### PR DESCRIPTION
These are dangerous GUIDs that shouldn't be used by any device
for distribution of firmware updates.  They'll potentially apply to
devices outside of the vendor they were created for.

Additionally if two USB devices with common interface classes are
on the system, they may lead to one device not being populated by
fwupd.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
