### PR TITLE
fu-usb-device: Refresh version format when re-reading it (Fixes: #1173)

### DIFF
--- a/src/fu-usb-device.c
+++ b/src/fu-usb-device.c
@@ -170,6 +170,7 @@ fu_usb_device_open (FuDevice *device, GError **error)
 	if (idx != 0x00) {
 		g_autofree gchar *tmp = NULL;
 		tmp = g_usb_device_get_string_descriptor (priv->usb_device, idx, NULL);
+		fu_device_set_version_format (device, fu_common_version_guess_format (tmp));
 		fu_device_set_version (device, tmp);
 	}
 


### PR DESCRIPTION
When the format is read from a custom descriptor the format may no
longer be a BCD pair.

Correct this by re-reading the firmware.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
