### PR TITLE
Display the remote warning on the console in an easy-to-read way

### DIFF
--- a/src/fu-util-common.h
+++ b/src/fu-util-common.h
@@ -38,6 +38,8 @@ SoupSession	*fu_util_setup_networking	(GError		**error);
 
 gchar		*fu_util_get_versions		(void);
 
+void		 fu_util_warning_box		(const gchar	*str,
+						 guint		 width);
 gboolean	fu_util_prompt_complete		(FwupdDeviceFlags flags,
 						 gboolean prompt,
 						 GError **error);

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -351,7 +351,7 @@ fu_util_modify_remote_warning (FuUtilPrivate *priv, FwupdRemote *remote, GError 
 		return FALSE;
 
 	/* show and ask user to confirm */
-	g_print ("%s", warning_plain);
+	fu_util_warning_box (warning_plain, 80);
 	if (!priv->assume_yes) {
 		/* ask for permission */
 		g_print ("\n%s [Y|n]: ",


### PR DESCRIPTION
The lines are almost impossible to read as they are not wrapped and not
delimited from the normal script output. Add a box around to make them stand out:

    ╔══════════════════════════════════════════════════════════════════════════════╗
    ║ The LVFS is a free service that operates as an independent legal entity and  ║
    ║ has no connection with Fedora. Your distributor may not have verified any    ║
    ║ of the firmware updates for compatibility with your system or connected      ║
    ║ devices. All firmware is provided only by the original equipment             ║
    ║ manufacturer.                                                                ║
    ║                                                                              ║
    ║ Enabling this functionality is done at your own risk, which means you have   ║
    ║ to contact your original equipment manufacturer regarding any problems       ║
    ║ caused by these updates. Only problems with the update process itself        ║
    ║ should be filed at https://bugzilla.redhat.com/.                             ║
    ║                                                                              ║
    ╚══════════════════════════════════════════════════════════════════════════════╝

    Agree and enable the remote? [Y|n]:
