### PR TITLE
Wip/superm1/superio offline

### DIFF
--- a/plugins/superio/fu-superio-it89-device.c
+++ b/plugins/superio/fu-superio-it89-device.c
@@ -656,9 +656,8 @@ static void
 fu_superio_it89_device_init (FuSuperioIt89Device *self)
 {
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
-	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_ONLY_OFFLINE);
+	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_NEEDS_SHUTDOWN);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
-	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
 }
 
 static void

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -2438,8 +2438,15 @@ main (int argc, char *argv[])
 	}
 
 	/* set flags */
-	if (offline)
+	if (offline) {
+		const gchar *tmp = g_getenv ("SNAP");
+		if (tmp != NULL) {
+			/* TRANSLATORS: Type of package distibuted */
+			g_print ("%s\n", _("Offline unsupported with snap package"));
+			return EXIT_FAILURE;
+		}
 		priv->flags |= FWUPD_INSTALL_FLAG_OFFLINE;
+	}
 	if (allow_reinstall)
 		priv->flags |= FWUPD_INSTALL_FLAG_ALLOW_REINSTALL;
 	if (allow_older)


### PR DESCRIPTION
* Adjust superio to use shutdown
* Don't allow snap to use `--offline`

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
