### PR TITLE
Allow handling FORCE for devices that subclass FuDevice

### DIFF
--- a/plugins/altos/fu-altos-device.c
+++ b/plugins/altos/fu-altos-device.c
@@ -269,7 +269,10 @@ fu_altos_device_write_page (FuAltosDevice *self,
 }
 
 static gboolean
-fu_altos_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
+fu_altos_device_write_firmware (FuDevice *device,
+				GBytes *fw,
+				FwupdInstallFlags flags,
+				GError **error)
 {
 	FuAltosDevice *self = FU_ALTOS_DEVICE (device);
 	GBytes *fw_blob;

--- a/plugins/altos/fu-plugin-altos.c
+++ b/plugins/altos/fu-plugin-altos.c
@@ -91,5 +91,5 @@ fu_plugin_update (FuPlugin *plugin,
 		  GError **error)
 {
 	fu_device_set_status (dev, FWUPD_STATUS_DEVICE_WRITE);
-	return fu_device_write_firmware (dev, blob_fw, error);
+	return fu_device_write_firmware (dev, blob_fw, flags, error);
 }

--- a/plugins/ata/fu-ata-device.c
+++ b/plugins/ata/fu-ata-device.c
@@ -574,7 +574,10 @@ fu_ata_device_fw_download (FuAtaDevice *self,
 }
 
 static gboolean
-fu_ata_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
+fu_ata_device_write_firmware (FuDevice *device,
+			      GBytes *fw,
+			      FwupdInstallFlags flags,
+			      GError **error)
 {
 	FuAtaDevice *self = FU_ATA_DEVICE (device);
 	guint32 chunksz = (guint32) self->transfer_blocks * FU_ATA_BLOCK_SIZE;

--- a/plugins/ata/fu-plugin-ata.c
+++ b/plugins/ata/fu-plugin-ata.c
@@ -56,7 +56,7 @@ fu_plugin_update (FuPlugin *plugin,
 	locker = fu_device_locker_new (device, error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_write_firmware (device, blob_fw, error);
+	return fu_device_write_firmware (device, blob_fw, flags, error);
 }
 
 gboolean

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -327,7 +327,10 @@ ch_colorhug_device_calculate_checksum (const guint8 *data, guint32 len)
 }
 
 static gboolean
-fu_colorhug_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
+fu_colorhug_device_write_firmware (FuDevice *device,
+				   GBytes *fw,
+				   FwupdInstallFlags flags,
+				   GError **error)
 {
 	FuColorhugDevice *self = FU_COLORHUG_DEVICE (device);
 	g_autoptr(GPtrArray) chunks = NULL;

--- a/plugins/colorhug/fu-plugin-colorhug.c
+++ b/plugins/colorhug/fu-plugin-colorhug.c
@@ -96,7 +96,7 @@ fu_plugin_update (FuPlugin *plugin,
 	locker = fu_device_locker_new (device, error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_write_firmware (device, blob_fw, error);
+	return fu_device_write_firmware (device, blob_fw, flags, error);
 }
 
 gboolean

--- a/plugins/csr/fu-csr-device.c
+++ b/plugins/csr/fu-csr-device.c
@@ -431,7 +431,10 @@ _dfu_firmware_get_default_element_data (DfuFirmware *firmware)
 }
 
 static GBytes *
-fu_csr_device_prepare_firmware (FuDevice *device, GBytes *fw, GError **error)
+fu_csr_device_prepare_firmware (FuDevice *device,
+				GBytes *fw,
+				FwupdInstallFlags flags,
+				GError **error)
 {
 	GBytes *blob_noftr;
 	g_autoptr(DfuFirmware) dfu_firmware = dfu_firmware_new ();
@@ -468,7 +471,10 @@ fu_csr_device_prepare_firmware (FuDevice *device, GBytes *fw, GError **error)
 }
 
 static gboolean
-fu_csr_device_download (FuDevice *device, GBytes *blob, GError **error)
+fu_csr_device_download (FuDevice *device,
+			GBytes *blob,
+			FwupdInstallFlags flags,
+			GError **error)
 {
 	FuCsrDevice *self = FU_CSR_DEVICE (device);
 	guint16 idx;

--- a/plugins/csr/fu-plugin-csr.c
+++ b/plugins/csr/fu-plugin-csr.c
@@ -65,7 +65,7 @@ fu_plugin_update (FuPlugin *plugin, FuDevice *device, GBytes *blob_fw,
 	locker = fu_device_locker_new (device, error);
 	if (locker == NULL)
 		return FALSE;
-	if (!fu_device_write_firmware (device, blob_fw, error))
+	if (!fu_device_write_firmware (device, blob_fw, flags, error))
 		return FALSE;
 	return fu_device_attach (device, error);
 }

--- a/plugins/dell-dock/fu-dell-dock-hub.c
+++ b/plugins/dell-dock/fu-dell-dock-hub.c
@@ -47,6 +47,7 @@ fu_dell_dock_hub_probe (FuDevice *device, GError **error)
 static gboolean
 fu_dell_dock_hub_write_fw (FuDevice *device,
 			   GBytes *blob_fw,
+			   FwupdInstallFlags flags,
 			   GError **error)
 {
 	FuDellDockHub *self = FU_DELL_DOCK_HUB (device);

--- a/plugins/dell-dock/fu-dell-dock-i2c-ec.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-ec.c
@@ -744,7 +744,9 @@ fu_dell_dock_ec_commit_package (FuDevice *device, GBytes *blob_fw,
 }
 
 static gboolean
-fu_dell_dock_ec_write_fw (FuDevice *device, GBytes *blob_fw,
+fu_dell_dock_ec_write_fw (FuDevice *device,
+			  GBytes *blob_fw,
+			  FwupdInstallFlags flags,
 			  GError **error)
 {
 	FuDellDockEc *self = FU_DELL_DOCK_EC (device);

--- a/plugins/dell-dock/fu-dell-dock-i2c-mst.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-mst.c
@@ -736,6 +736,7 @@ fu_dell_dock_mst_invalidate_bank (FuDevice *symbiote, MSTBank bank_in_use,
 static gboolean
 fu_dell_dock_mst_write_fw (FuDevice *device,
 			   GBytes *blob_fw,
+			   FwupdInstallFlags flags,
 			   GError **error)
 {
 	FuDellDockMst *self = FU_DELL_DOCK_MST (device);

--- a/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
+++ b/plugins/dell-dock/fu-dell-dock-i2c-tbt.c
@@ -54,6 +54,7 @@ G_DEFINE_TYPE (FuDellDockTbt, fu_dell_dock_tbt, FU_TYPE_DEVICE)
 static gboolean
 fu_dell_dock_tbt_write_fw (FuDevice *device,
 			   GBytes *blob_fw,
+			   FwupdInstallFlags flags,
 			   GError **error)
 {
 	FuDellDockTbt *self = FU_DELL_DOCK_TBT (device);

--- a/plugins/dell-dock/fu-dell-dock-status.c
+++ b/plugins/dell-dock/fu-dell-dock-status.c
@@ -59,6 +59,7 @@ fu_dell_dock_status_setup (FuDevice *device, GError **error)
 static gboolean
 fu_dell_dock_status_write (FuDevice *device,
 			   GBytes *blob_fw,
+			   FwupdInstallFlags flags,
 			   GError **error)
 {
 	FuDellDockStatus *self = FU_DELL_DOCK_STATUS (device);

--- a/plugins/dell-dock/fu-plugin-dell-dock.c
+++ b/plugins/dell-dock/fu-plugin-dell-dock.c
@@ -162,7 +162,7 @@ fu_plugin_update (FuPlugin *plugin,
 		return FALSE;
 
 	fu_device_set_status (dev, FWUPD_STATUS_DEVICE_WRITE);
-	if (!fu_device_write_firmware (dev, blob_fw, error)) {
+	if (!fu_device_write_firmware (dev, blob_fw, flags, error)) {
 		g_prefix_error (error,
 				"failed to update %s: ",
 				fu_device_get_name (dev));

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -347,7 +347,10 @@ fu_ebitdo_device_get_serial (FuEbitdoDevice *self)
 }
 
 static gboolean
-fu_ebitdo_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
+fu_ebitdo_device_write_firmware (FuDevice *device,
+				 GBytes *fw,
+				 FwupdInstallFlags flags,
+				 GError **error)
 {
 	FuEbitdoDevice *self = FU_EBITDO_DEVICE (device);
 	FuEbitdoFirmwareHeader *hdr;

--- a/plugins/ebitdo/fu-plugin-ebitdo.c
+++ b/plugins/ebitdo/fu-plugin-ebitdo.c
@@ -59,7 +59,7 @@ fu_plugin_update (FuPlugin *plugin,
 	locker = fu_device_locker_new (ebitdo_dev, error);
 	if (locker == NULL)
 		return FALSE;
-	if (!fu_device_write_firmware (FU_DEVICE (ebitdo_dev), blob_fw, error))
+	if (!fu_device_write_firmware (FU_DEVICE (ebitdo_dev), blob_fw, flags, error))
 		return FALSE;
 
 	/* when doing a soft-reboot the device does not re-enumerate properly

--- a/plugins/fastboot/fu-fastboot-device.c
+++ b/plugins/fastboot/fu-fastboot-device.c
@@ -594,7 +594,10 @@ fu_fastboot_device_write_qfil (FuDevice *device, FuArchive* archive, GError **er
 }
 
 static gboolean
-fu_fastboot_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
+fu_fastboot_device_write_firmware (FuDevice *device,
+				   GBytes *fw,
+				   FwupdInstallFlags flags,
+				   GError **error)
 {
 	g_autoptr(FuArchive) archive = NULL;
 

--- a/plugins/fastboot/fu-plugin-fastboot.c
+++ b/plugins/fastboot/fu-plugin-fastboot.c
@@ -28,7 +28,7 @@ fu_plugin_update (FuPlugin *plugin,
 	g_autoptr(FuDeviceLocker) locker = fu_device_locker_new (device, error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_write_firmware (device, blob_fw, error);
+	return fu_device_write_firmware (device, blob_fw, flags, error);
 }
 
 gboolean

--- a/plugins/modem-manager/fu-mm-device.c
+++ b/plugins/modem-manager/fu-mm-device.c
@@ -597,7 +597,10 @@ fu_mm_device_write_firmware_qmi_pdc (FuDevice *device, GBytes *fw, GArray **acti
 }
 
 static gboolean
-fu_mm_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
+fu_mm_device_write_firmware (FuDevice *device,
+			     GBytes *fw,
+			     FwupdInstallFlags flags,
+			     GError **error)
 {
 	FuMmDevice *self = FU_MM_DEVICE (device);
 	g_autoptr(FuDeviceLocker) locker = NULL;

--- a/plugins/modem-manager/fu-plugin-modem-manager.c
+++ b/plugins/modem-manager/fu-plugin-modem-manager.c
@@ -393,7 +393,7 @@ fu_plugin_update (FuPlugin *plugin,
 	g_autoptr(FuDeviceLocker) locker = fu_device_locker_new (device, error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_write_firmware (device, blob_fw, error);
+	return fu_device_write_firmware (device, blob_fw, flags, error);
 }
 
 static void

--- a/plugins/nvme/fu-nvme-device.c
+++ b/plugins/nvme/fu-nvme-device.c
@@ -394,7 +394,10 @@ fu_nvme_device_close (FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_nvme_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
+fu_nvme_device_write_firmware (FuDevice *device,
+			       GBytes *fw,
+			       FwupdInstallFlags flags,
+			       GError **error)
 {
 	FuNvmeDevice *self = FU_NVME_DEVICE (device);
 	g_autoptr(GBytes) fw2 = NULL;

--- a/plugins/nvme/fu-plugin-nvme.c
+++ b/plugins/nvme/fu-plugin-nvme.c
@@ -47,5 +47,5 @@ fu_plugin_update (FuPlugin *plugin,
 	locker = fu_device_locker_new (device, error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_write_firmware (device, blob_fw, error);
+	return fu_device_write_firmware (device, blob_fw, flags, error);
 }

--- a/plugins/rts54hid/fu-plugin-rts54hid.c
+++ b/plugins/rts54hid/fu-plugin-rts54hid.c
@@ -32,7 +32,7 @@ fu_plugin_update (FuPlugin *plugin,
 	g_autoptr(FuDeviceLocker) locker = fu_device_locker_new (device, error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_write_firmware (device, blob_fw, error);
+	return fu_device_write_firmware (device, blob_fw, flags, error);
 }
 
 gboolean

--- a/plugins/rts54hid/fu-rts54hid-device.c
+++ b/plugins/rts54hid/fu-rts54hid-device.c
@@ -314,7 +314,10 @@ fu_rts54hid_device_close (FuUsbDevice *device, GError **error)
 }
 
 static gboolean
-fu_rts54hid_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
+fu_rts54hid_device_write_firmware (FuDevice *device,
+				   GBytes *fw,
+				   FwupdInstallFlags flags,
+				   GError **error)
 {
 	FuRts54HidDevice *self = FU_RTS54HID_DEVICE (device);
 	g_autoptr(GPtrArray) chunks = NULL;

--- a/plugins/rts54hid/fu-rts54hid-module.c
+++ b/plugins/rts54hid/fu-rts54hid-module.c
@@ -211,7 +211,10 @@ fu_rts54hid_module_close (FuDevice *device, GError **error)
 }
 
 static gboolean
-fu_rts54hid_module_write_firmware (FuDevice *module, GBytes *fw, GError **error)
+fu_rts54hid_module_write_firmware (FuDevice *module,
+				   GBytes *fw,
+				   FwupdInstallFlags flags,
+				   GError **error)
 {
 	FuRts54HidModule *self = FU_RTS54HID_MODULE (module);
 	g_autoptr(GPtrArray) chunks = NULL;

--- a/plugins/rts54hub/fu-plugin-rts54hub.c
+++ b/plugins/rts54hub/fu-plugin-rts54hub.c
@@ -28,7 +28,7 @@ fu_plugin_update (FuPlugin *plugin,
 	g_autoptr(FuDeviceLocker) locker = fu_device_locker_new (device, error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_write_firmware (device, blob_fw, error);
+	return fu_device_write_firmware (device, blob_fw, flags, error);
 }
 
 gboolean

--- a/plugins/rts54hub/fu-rts54hub-device.c
+++ b/plugins/rts54hub/fu-rts54hub-device.c
@@ -308,7 +308,10 @@ fu_rts54hub_device_close (FuUsbDevice *device, GError **error)
 }
 
 static gboolean
-fu_rts54hub_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
+fu_rts54hub_device_write_firmware (FuDevice *device,
+				   GBytes *fw,
+				   FwupdInstallFlags flags,
+				   GError **error)
 {
 	FuRts54HubDevice *self = FU_RTS54HUB_DEVICE (device);
 	g_autoptr(GPtrArray) chunks = NULL;
@@ -381,7 +384,10 @@ fu_rts54hub_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
 }
 
 static GBytes *
-fu_rts54hub_device_prepare_firmware (FuDevice *device, GBytes *fw, GError **error)
+fu_rts54hub_device_prepare_firmware (FuDevice *device,
+				     GBytes *fw,
+				     FwupdInstallFlags flags,
+				     GError **error)
 {
 	gsize sz = 0;
 	const guint8 *data = g_bytes_get_data (fw, &sz);

--- a/plugins/superio/fu-plugin-superio.c
+++ b/plugins/superio/fu-plugin-superio.c
@@ -187,5 +187,5 @@ fu_plugin_update (FuPlugin *plugin,
 	locker = fu_device_locker_new (device, error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_write_firmware (device, blob_fw, error);
+	return fu_device_write_firmware (device, blob_fw, flags, error);
 }

--- a/plugins/superio/fu-superio-device.c
+++ b/plugins/superio/fu-superio-device.c
@@ -363,7 +363,10 @@ fu_superio_device_setup (FuDevice *device, GError **error)
 }
 
 static GBytes *
-fu_superio_device_prepare_firmware (FuDevice *device, GBytes *fw, GError **error)
+fu_superio_device_prepare_firmware (FuDevice *device,
+				    GBytes *fw,
+				    FwupdInstallFlags flags,
+				    GError **error)
 {
 	gsize sz = 0;
 	const guint8 *buf = g_bytes_get_data (fw, &sz);

--- a/plugins/superio/fu-superio-it89-device.c
+++ b/plugins/superio/fu-superio-it89-device.c
@@ -590,7 +590,10 @@ fu_superio_it89_device_get_jedec_id (FuSuperioDevice *self, guint8 *id, GError *
 }
 
 static gboolean
-fu_superio_it89_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
+fu_superio_it89_device_write_firmware (FuDevice *device,
+				       GBytes *fw,
+				       FwupdInstallFlags flags,
+				       GError **error)
 {
 	FuSuperioDevice *self = FU_SUPERIO_DEVICE (device);
 	guint8 id[4] = { 0x0 };

--- a/plugins/uefi/fu-plugin-uefi.c
+++ b/plugins/uefi/fu-plugin-uefi.c
@@ -408,7 +408,7 @@ fu_plugin_update (FuPlugin *plugin,
 		g_debug ("failed to upload UEFI UX capsule text: %s",
 			 error_splash->message);
 	}
-	if (!fu_device_write_firmware (device, blob_fw, error))
+	if (!fu_device_write_firmware (device, blob_fw, flags, error))
 		return FALSE;
 
 	/* record if we had an invalid header during update */

--- a/plugins/uefi/fu-uefi-device.c
+++ b/plugins/uefi/fu-uefi-device.c
@@ -400,7 +400,10 @@ fu_uefi_device_write_update_info (FuUefiDevice *self,
 }
 
 static gboolean
-fu_uefi_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
+fu_uefi_device_write_firmware (FuDevice *device,
+			       GBytes *fw,
+			       FwupdInstallFlags install_flags,
+			       GError **error)
 {
 	FuUefiDevice *self = FU_UEFI_DEVICE (device);
 	FuUefiBootmgrFlags flags = FU_UEFI_BOOTMGR_FLAG_NONE;

--- a/plugins/uefi/fu-uefi-tool.c
+++ b/plugins/uefi/fu-uefi-tool.c
@@ -324,7 +324,9 @@ main (int argc, char *argv[])
 			return EXIT_FAILURE;
 		}
 		fu_device_set_metadata (FU_DEVICE (dev), "EspPath", esp_path);
-		if (!fu_device_write_firmware (FU_DEVICE (dev), fw, &error_local)) {
+		if (!fu_device_write_firmware (FU_DEVICE (dev), fw,
+					       FWUPD_INSTALL_FLAG_NONE,
+					       &error_local)) {
 			g_printerr ("failed: %s\n", error_local->message);
 			return EXIT_FAILURE;
 		}

--- a/plugins/unifying/fu-plugin-unifying.c
+++ b/plugins/unifying/fu-plugin-unifying.c
@@ -57,7 +57,7 @@ fu_plugin_update (FuPlugin *plugin,
 	g_autoptr(FuDeviceLocker) locker = fu_device_locker_new (device, error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_write_firmware (device, blob_fw, error);
+	return fu_device_write_firmware (device, blob_fw, flags, error);
 }
 
 static gboolean

--- a/plugins/unifying/fu-unifying-bootloader-nordic.c
+++ b/plugins/unifying/fu-unifying-bootloader-nordic.c
@@ -195,7 +195,10 @@ fu_unifying_bootloader_nordic_erase (FuUnifyingBootloader *self, guint16 addr, G
 }
 
 static gboolean
-fu_unifying_bootloader_nordic_write_firmware (FuDevice *device, GBytes *fw, GError **error)
+fu_unifying_bootloader_nordic_write_firmware (FuDevice *device,
+					      GBytes *fw,
+					      FwupdInstallFlags flags,
+					      GError **error)
 {
 	FuUnifyingBootloader *self = FU_UNIFYING_BOOTLOADER (device);
 	const FuUnifyingBootloaderRequest *payload;

--- a/plugins/unifying/fu-unifying-bootloader-texas.c
+++ b/plugins/unifying/fu-unifying-bootloader-texas.c
@@ -108,7 +108,10 @@ fu_unifying_bootloader_texas_clear_ram_buffer (FuUnifyingBootloader *self, GErro
 }
 
 static gboolean
-fu_unifying_bootloader_texas_write_firmware (FuDevice *device, GBytes *fw, GError **error)
+fu_unifying_bootloader_texas_write_firmware (FuDevice *device,
+					     GBytes *fw,
+					     FwupdInstallFlags flags,
+					     GError **error)
 {
 	FuUnifyingBootloader *self = FU_UNIFYING_BOOTLOADER (device);
 	const FuUnifyingBootloaderRequest *payload;

--- a/plugins/unifying/fu-unifying-peripheral.c
+++ b/plugins/unifying/fu-unifying-peripheral.c
@@ -881,7 +881,10 @@ fu_unifying_peripheral_write_firmware_pkt (FuUnifyingPeripheral *self,
 }
 
 static gboolean
-fu_unifying_peripheral_write_firmware (FuDevice *device, GBytes *fw, GError **error)
+fu_unifying_peripheral_write_firmware (FuDevice *device,
+				       GBytes *fw,
+				       FwupdInstallFlags flags,
+				       GError **error)
 {
 	FuUnifyingPeripheral *self = FU_UNIFYING_PERIPHERAL (device);
 	gsize sz = 0;

--- a/plugins/wacom-raw/fu-plugin-wacom-raw.c
+++ b/plugins/wacom-raw/fu-plugin-wacom-raw.c
@@ -92,5 +92,5 @@ fu_plugin_update (FuPlugin *plugin,
 	locker = fu_device_locker_new (device, error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_write_firmware (device, blob_fw, error);
+	return fu_device_write_firmware (device, blob_fw, flags, error);
 }

--- a/plugins/wacom-raw/fu-wacom-device.c
+++ b/plugins/wacom-raw/fu-wacom-device.c
@@ -217,7 +217,10 @@ fu_wacom_device_set_version_bootloader (FuWacomDevice *self, GError **error)
 }
 
 static gboolean
-fu_wacom_device_write_firmware (FuDevice *device, GBytes *fw, GError **error)
+fu_wacom_device_write_firmware (FuDevice *device,
+				GBytes *fw,
+				FwupdInstallFlags flags,
+				GError **error)
 {
 	FuWacomDevice *self = FU_WACOM_DEVICE (device);
 	FuWacomDevicePrivate *priv = GET_PRIVATE (self);

--- a/plugins/wacom-usb/fu-plugin-wacom-usb.c
+++ b/plugins/wacom-usb/fu-plugin-wacom-usb.c
@@ -40,7 +40,7 @@ fu_plugin_update (FuPlugin *plugin, FuDevice *device, GBytes *blob_fw,
 	locker = fu_device_locker_new (parent != NULL ? parent : device, error);
 	if (locker == NULL)
 		return FALSE;
-	return fu_device_write_firmware (device, blob_fw, error);
+	return fu_device_write_firmware (device, blob_fw, flags, error);
 }
 
 static FuDevice *

--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -482,7 +482,10 @@ fu_wac_device_switch_to_flash_loader (FuWacDevice *self, GError **error)
 }
 
 static gboolean
-fu_wac_device_write_firmware (FuDevice *device, GBytes *blob, GError **error)
+fu_wac_device_write_firmware (FuDevice *device,
+			      GBytes *blob,
+			      FwupdInstallFlags flags,
+			      GError **error)
 {
 	DfuElement *element;
 	DfuImage *image;

--- a/plugins/wacom-usb/fu-wac-module-bluetooth.c
+++ b/plugins/wacom-usb/fu-wac-module-bluetooth.c
@@ -105,7 +105,10 @@ fu_wac_module_bluetooth_parse_blocks (const guint8 *data, gsize sz, gboolean ski
 }
 
 static gboolean
-fu_wac_module_bluetooth_write_firmware (FuDevice *device, GBytes *blob, GError **error)
+fu_wac_module_bluetooth_write_firmware (FuDevice *device,
+					GBytes *blob,
+					FwupdInstallFlags flags,
+					GError **error)
 {
 	FuWacModule *self = FU_WAC_MODULE (device);
 	const guint8 *data;

--- a/plugins/wacom-usb/fu-wac-module-touch.c
+++ b/plugins/wacom-usb/fu-wac-module-touch.c
@@ -22,7 +22,10 @@ struct _FuWacModuleTouch
 G_DEFINE_TYPE (FuWacModuleTouch, fu_wac_module_touch, FU_TYPE_WAC_MODULE)
 
 static gboolean
-fu_wac_module_touch_write_firmware (FuDevice *device, GBytes *blob, GError **error)
+fu_wac_module_touch_write_firmware (FuDevice *device,
+				    GBytes *blob,
+				    FwupdInstallFlags flags,
+				    GError **error)
 {
 	DfuElement *element;
 	DfuImage *image;

--- a/src/fu-device.c
+++ b/src/fu-device.c
@@ -1683,6 +1683,7 @@ fu_device_get_release_default (FuDevice *self)
  * fu_device_write_firmware:
  * @self: A #FuDevice
  * @fw: A #GBytes
+ * @flags: #FwupdInstallFlags, e.g. %FWUPD_INSTALL_FLAG_FORCE
  * @error: A #GError
  *
  * Writes firmware to the device by calling a plugin-specific vfunc.
@@ -1692,7 +1693,10 @@ fu_device_get_release_default (FuDevice *self)
  * Since: 1.0.8
  **/
 gboolean
-fu_device_write_firmware (FuDevice *self, GBytes *fw, GError **error)
+fu_device_write_firmware (FuDevice *self,
+			  GBytes *fw,
+			  FwupdInstallFlags flags,
+			  GError **error)
 {
 	FuDeviceClass *klass = FU_DEVICE_GET_CLASS (self);
 	g_autoptr(GBytes) fw_new = NULL;
@@ -1710,18 +1714,19 @@ fu_device_write_firmware (FuDevice *self, GBytes *fw, GError **error)
 	}
 
 	/* prepare (e.g. decompress) firmware */
-	fw_new = fu_device_prepare_firmware (self, fw, error);
+	fw_new = fu_device_prepare_firmware (self, fw, flags, error);
 	if (fw_new == NULL)
 		return FALSE;
 
 	/* call vfunc */
-	return klass->write_firmware (self, fw_new, error);
+	return klass->write_firmware (self, fw_new, flags, error);
 }
 
 /**
  * fu_device_prepare_firmware:
  * @self: A #FuDevice
  * @fw: A #GBytes
+ * @flags: #FwupdInstallFlags, e.g. %FWUPD_INSTALL_FLAG_FORCE
  * @error: A #GError
  *
  * Prepares the firmware by calling an optional device-specific vfunc for the
@@ -1737,7 +1742,10 @@ fu_device_write_firmware (FuDevice *self, GBytes *fw, GError **error)
  * Since: 1.1.2
  **/
 GBytes *
-fu_device_prepare_firmware (FuDevice *self, GBytes *fw, GError **error)
+fu_device_prepare_firmware (FuDevice *self,
+			    GBytes *fw,
+			    FwupdInstallFlags flags,
+			    GError **error)
 {
 	FuDeviceClass *klass = FU_DEVICE_GET_CLASS (self);
 	FuDevicePrivate *priv = GET_PRIVATE (self);
@@ -1750,7 +1758,7 @@ fu_device_prepare_firmware (FuDevice *self, GBytes *fw, GError **error)
 
 	/* optionally subclassed */
 	if (klass->prepare_firmware != NULL) {
-		fw_new = klass->prepare_firmware (self, fw, error);
+		fw_new = klass->prepare_firmware (self, fw, flags, error);
 		if (fw_new == NULL)
 			return NULL;
 	} else {

--- a/src/fu-device.h
+++ b/src/fu-device.h
@@ -24,6 +24,7 @@ struct _FuDeviceClass
 							 GString	*str);
 	gboolean		 (*write_firmware)	(FuDevice	*self,
 							 GBytes		*fw,
+							 FwupdInstallFlags flags,
 							 GError		**error);
 	GBytes			*(*read_firmware)	(FuDevice	*self,
 							 GError		**error);
@@ -39,6 +40,7 @@ struct _FuDeviceClass
 							 GError		**error);
 	GBytes			*(*prepare_firmware)	(FuDevice	*self,
 							 GBytes		*fw,
+							 FwupdInstallFlags flags,
 							 GError		**error);
 	gboolean		 (*set_quirk_kv)	(FuDevice	*self,
 							 const gchar	*key,
@@ -206,9 +208,11 @@ FuQuirks	*fu_device_get_quirks			(FuDevice	*self);
 FwupdRelease	*fu_device_get_release_default		(FuDevice	*self);
 gboolean	 fu_device_write_firmware		(FuDevice	*self,
 							 GBytes		*fw,
+							 FwupdInstallFlags flags,
 							 GError		**error);
 GBytes		*fu_device_prepare_firmware		(FuDevice	*self,
 							 GBytes		*fw,
+							 FwupdInstallFlags flags,
 							 GError		**error);
 GBytes		*fu_device_read_firmware		(FuDevice	*self,
 							 GError		**error);


### PR DESCRIPTION
Pass FwupdInstallFlags down to the vfunc to allow us to check the flags when
parsing the firmware and updating the device.
