### PR TITLE
fu-util-common: Support empty proxy strings (Fixes: #1199)

### DIFF
--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -570,7 +570,7 @@ fu_util_setup_networking (GError **error)
 		http_proxy = g_getenv ("http_proxy");
 	if (http_proxy == NULL)
 		http_proxy = g_getenv ("HTTP_PROXY");
-	if (http_proxy != NULL) {
+	if (http_proxy != NULL && strlen (http_proxy) > 0) {
 		g_autoptr(SoupURI) proxy_uri = soup_uri_new (http_proxy);
 		if (proxy_uri == NULL) {
 			g_set_error (error,


### PR DESCRIPTION
Arch apparently sets all proxies to zero length and this causes
problems for fwupd.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
