### PR TITLE
Allow SuperIO updates to be done live

### DIFF
--- a/plugins/superio/fu-superio-it89-device.c
+++ b/plugins/superio/fu-superio-it89-device.c
@@ -659,7 +659,6 @@ static void
 fu_superio_it89_device_init (FuSuperioIt89Device *self)
 {
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_UPDATABLE);
-	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_ONLY_OFFLINE);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_REQUIRE_AC);
 	fu_device_add_flag (FU_DEVICE (self), FWUPD_DEVICE_FLAG_NEEDS_REBOOT);
 }


### PR DESCRIPTION
Apparently Star Labs have been using this for some time. It's still important
to reboot after the update has been performed.
