### PR TITLE
trivial: circleci: try to fix automatic snap deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,14 @@ workflows:
           filters:
             branches:
               only: master
+  deploy:
+    jobs:
+      - build-snap:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/
       - publish-stable:
           requires:
             - build-snap
@@ -74,4 +82,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /^\d+\.\d+\.\d+$/
-


### PR DESCRIPTION
Split up the promotion step into a separate workflow with it's own
filters.

According to https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
every dependency needs its own tag filter, so hopefully this should
fix automatic deployment.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
