### PR TITLE
Lite Mk II flag for use-shim-unique

### DIFF
--- a/plugins/uefi/uefi.quirk
+++ b/plugins/uefi/uefi.quirk
@@ -16,3 +16,7 @@ Name = Intel Management Engine
 # Star Labs LabTop (Mk III)
 [Guid=8265d473-a6c2-42b4-897b-bc220faa2d32]
 Flags = use-shim-unique
+
+# Star Labs Lite (Mk II)
+[Guid=797f8bae-0ea2-4c0f-8a30-7d10ccfacbc0]
+Flags = use-shim-unique


### PR DESCRIPTION
Added AMI fix for the "duplicate entry" issue to firmware version 1.0.4 - quirk is needed to install new version