### PR TITLE
synapticsmst: fix GUID generation (Closes: #1207)

### DIFF
--- a/plugins/synapticsmst/fu-plugin-synapticsmst.c
+++ b/plugins/synapticsmst/fu-plugin-synapticsmst.c
@@ -196,7 +196,8 @@ fu_plugin_synaptics_add_device (FuPlugin *plugin,
 	/* create GUIDs and name */
 	if (!fu_plugin_synapticsmst_lookup_device (plugin, dev, device, error))
 		return FALSE;
-
+	if (!fu_device_setup (dev, error))
+		return FALSE;
 	fu_plugin_device_add (plugin, dev);
 	fu_plugin_cache_add (plugin, dev_id_str, dev);
 


### PR DESCRIPTION
When converting to instances we forgot to add the GUIDs to the device
as well.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
