### PR TITLE
contrib/debian/rules: allow for building subprojects from source

### DIFF
--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -11,7 +11,7 @@ ifeq "$(DEB_HOST_ARCH_BITS)" "32"
 endif
 
 ifneq ($(CI),)
-	export CI=--werror
+	export CI=--werror --wrap-mode=default
 endif
 
 SB_STYLE := debian


### PR DESCRIPTION
By default, "--wrap-mode=nodownload" switch is provided. It means that no
fallback subproject will be used (only packages from Debian archives will
be accepted). We need to build the flashrom from source, hence modification
of this switch is needed.

Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [*] Code fix
- [ ] Feature
- [ ] Documentation
