### PR TITLE
Add meson target to fix translations

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -11,7 +11,7 @@ Update translations:
 ninja-build fwupd-pot
 tx push --source
 tx pull --all --force --minimum-perc=5
-../contrib/fix_translations.py ../po
+ninja-build fix-translations
 git add ../po/*.po
 
 2. Commit changes to git:

--- a/po/meson.build
+++ b/po/meson.build
@@ -8,3 +8,9 @@ i18n.gettext(meson.project_name(),
 if get_option('plugin_uefi')
 meson.add_install_script('make-images.sh', localedir, python3.path())
 endif
+
+run_target('fix-translations',
+	   command: [
+	     join_paths(meson.source_root(), 'contrib/fix_translations.py'),
+	     join_paths(meson.source_root(), 'po')
+	   ])


### PR DESCRIPTION
Target to run the contrib/fix_translation.py scripts with the correct path. Update the RELEASE documentation to use the new target instead of calling the script "manually".