### PR TITLE
Fix Fedora docker build missing directory: dist

### DIFF
--- a/contrib/ci/fedora.sh
+++ b/contrib/ci/fedora.sh
@@ -48,6 +48,7 @@ fi
 #install RPM packages
 dnf install -y $HOME/rpmbuild/RPMS/*/*.rpm
 
+mkdir -p dist
 cp $HOME/rpmbuild/RPMS/*/*.rpm dist
 
 if [ "$CI" = "true" ]; then


### PR DESCRIPTION
On Fedora 30 x86_64 I got:
```
docker run --privileged -t -v `pwd`:/build fwupd-fedora
...
Complete!
+ cp /root/rpmbuild/RPMS/noarch/fwupd-tests-1.2.10-0.1alpha.fc29.noarch.rpm /root/rpmbuild/RPMS/x86_64/fwupd-1.2.10-0.1alpha.fc29.x86_64.rpm /root/rpmbuild/RPMS/x86_64/fwupd-debuginfo-1.2.10-0.1alpha.fc29.x86_64.rpm /root/rpmbuild/RPMS/x86_64/fwupd-debugsource-1.2.10-0.1alpha.fc29.x86_64.rpm /root/rpmbuild/RPMS/x86_64/fwupd-devel-1.2.10-0.1alpha.fc29.x86_64.rpm dist
cp: target 'dist' is not a directory
```
Type of pull request:
- [ ] Code fix
