### PR TITLE
Add a specific error code for the low battery case

### DIFF
--- a/libfwupd/fwupd-error.c
+++ b/libfwupd/fwupd-error.c
@@ -65,6 +65,8 @@ fwupd_error_to_string (FwupdError error)
 		return FWUPD_DBUS_INTERFACE ".PermissionDenied";
 	if (error == FWUPD_ERROR_BROKEN_SYSTEM)
 		return FWUPD_DBUS_INTERFACE ".BrokenSystem";
+	if (error == FWUPD_ERROR_BATTERY_LEVEL_TOO_LOW)
+		return FWUPD_DBUS_INTERFACE ".BatteryLevelTooLow";
 	return NULL;
 }
 
@@ -111,6 +113,8 @@ fwupd_error_from_string (const gchar *error)
 		return FWUPD_ERROR_PERMISSION_DENIED;
 	if (g_strcmp0 (error, FWUPD_DBUS_INTERFACE ".BrokenSystem") == 0)
 		return FWUPD_ERROR_BROKEN_SYSTEM;
+	if (g_strcmp0 (error, FWUPD_DBUS_INTERFACE ".BatteryLevelTooLow") == 0)
+		return FWUPD_ERROR_BATTERY_LEVEL_TOO_LOW;
 	return FWUPD_ERROR_LAST;
 }
 

--- a/libfwupd/fwupd-error.h
+++ b/libfwupd/fwupd-error.h
@@ -29,6 +29,7 @@ G_BEGIN_DECLS
  * @FWUPD_ERROR_AC_POWER_REQUIRED:		AC power was required
  * @FWUPD_ERROR_PERMISSION_DENIED:		Permission was denied
  * @FWUPD_ERROR_BROKEN_SYSTEM:			User has configured their system in a broken way
+ * @FWUPD_ERROR_BATTERY_LEVEL_TOO_LOW:		The system battery level is too low
  *
  * The error code.
  **/
@@ -48,6 +49,7 @@ typedef enum {
 	FWUPD_ERROR_AC_POWER_REQUIRED,		/* Since: 0.8.0 */
 	FWUPD_ERROR_PERMISSION_DENIED,		/* Since: 0.9.8 */
 	FWUPD_ERROR_BROKEN_SYSTEM,		/* Since: 1.2.8 */
+	FWUPD_ERROR_BATTERY_LEVEL_TOO_LOW,	/* Since: 1.2.10 */
 	/*< private >*/
 	FWUPD_ERROR_LAST
 } FwupdError;

--- a/plugins/upower/fu-plugin-upower.c
+++ b/plugins/upower/fu-plugin-upower.c
@@ -139,7 +139,7 @@ fu_plugin_update_prepare (FuPlugin *plugin,
 	   (flags & FWUPD_INSTALL_FLAG_FORCE) == 0) {
 		g_set_error (error,
 			     FWUPD_ERROR,
-			     FWUPD_ERROR_AC_POWER_REQUIRED,
+			     FWUPD_ERROR_BATTERY_LEVEL_TOO_LOW,
 			     "Cannot install update when battery "
 			     "is not at least %d%% unless forced",
 			      MINIMUM_BATTERY_PERCENTAGE);

--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1660,6 +1660,9 @@ fu_engine_install (FuEngine *self,
 				     FWUPD_ERROR_AC_POWER_REQUIRED) ||
 		    g_error_matches (error_local,
 				     FWUPD_ERROR,
+				     FWUPD_ERROR_BATTERY_LEVEL_TOO_LOW) ||
+		    g_error_matches (error_local,
+				     FWUPD_ERROR,
 				     FWUPD_ERROR_BROKEN_SYSTEM)) {
 			fu_device_set_update_state (device, FWUPD_UPDATE_STATE_FAILED_TRANSIENT);
 		} else {


### PR DESCRIPTION
Users are getting confused when they're being told that AC power is required
when they are already on AC power... but the battery is too low to perform the
update.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
