### PR TITLE
trivial: thunderbolt: catch failure setting up device

### DIFF
--- a/plugins/thunderbolt/fu-plugin-thunderbolt.c
+++ b/plugins/thunderbolt/fu-plugin-thunderbolt.c
@@ -255,6 +255,7 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 	g_autoptr(FuDevice) dev = NULL;
 	g_autoptr(GError) error_vid = NULL;
 	g_autoptr(GError) error_did = NULL;
+	g_autoptr(GError) error_setup = NULL;
 
 	uuid = g_udev_device_get_sysfs_attr (device, "unique_id");
 	if (uuid == NULL) {
@@ -377,7 +378,10 @@ fu_plugin_thunderbolt_add (FuPlugin *plugin, GUdevDevice *device)
 	fu_device_add_flag (dev, FWUPD_DEVICE_FLAG_REQUIRE_AC);
 
 	/* we never open the device, so convert the instance IDs */
-	fu_device_setup (dev, NULL);
+	if (!fu_device_setup (dev, &error_setup)) {
+		g_warning ("failed to setup: %s", error_setup->message);
+		return;
+	}
 	fu_plugin_cache_add (plugin, id, dev);
 	fu_plugin_device_add (plugin, dev);
 


### PR DESCRIPTION
Fixes: b3aa793539 ("thunderbolt: Convert the instance IDs as we never open the device")

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
