### PR TITLE
Disable the flashrom plugin by default

### DIFF
--- a/contrib/ci/centos.sh
+++ b/contrib/ci/centos.sh
@@ -11,6 +11,7 @@ meson .. \
 	-Dplugin_dell=false \
 	-Dplugin_modem_manager=false \
 	-Dplugin_synaptics=true \
+	-Dplugin_flashrom=true \
 	-Dintrospection=true \
 	-Dgtkdoc=true \
 	-Dpkcs7=false \

--- a/contrib/ci/fedora.sh
+++ b/contrib/ci/fedora.sh
@@ -12,6 +12,7 @@ meson .. \
     -Dman=true \
     -Dtests=true \
     -Dplugin_dummy=true \
+    -Dplugin_flashrom=true \
     -Dplugin_modem_manager=false \
     -Dplugin_thunderbolt=true \
     -Dplugin_uefi=true \

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -18,7 +18,7 @@ option('plugin_redfish', type : 'boolean', value : true, description : 'enable R
 option('plugin_uefi', type : 'boolean', value : true, description : 'enable UEFI support')
 option('plugin_nvme', type : 'boolean', value : true, description : 'enable NVMe support')
 option('plugin_modem_manager', type : 'boolean', value : false, description : 'enable ModemManager support')
-option('plugin_flashrom', type : 'boolean', value : true, description : 'enable libflashrom support')
+option('plugin_flashrom', type : 'boolean', value : false, description : 'enable libflashrom support')
 option('systemd', type : 'boolean', value : true, description : 'enable systemd support')
 option('systemdunitdir', type: 'string', value: '', description: 'Directory for systemd units')
 option('elogind', type : 'boolean', value : false, description : 'enable elogind support')


### PR DESCRIPTION
When upstream libflashrom contains all the required API upstream we can build
this by default.
