### PR TITLE
Verify we don't break the ABI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,17 @@
 version: 2
 jobs:
+  check-abi:
+    machine:
+      image: circleci/classic:latest
+    steps:
+      - checkout
+      - run:
+          name: "Build container"
+          command: OS=debian-x86_64 ./contrib/ci/generate_docker.py
+      - run:
+          name: "Run build script"
+          command: docker run -t -v `pwd`:/build fwupd-debian-x86_64 ./contrib/ci/check-abi $(git describe --abbrev=0 --tags) $(git rev-parse HEAD)
+
   build-s390x:
     machine:
       image: circleci/classic:latest
@@ -60,6 +72,7 @@ workflows:
     jobs:
       - build-s390x
       - build-snap
+      - check-abi
       - publish-edge:
           requires:
             - build-snap

--- a/contrib/ci/abidiff.suppr
+++ b/contrib/ci/abidiff.suppr
@@ -1,0 +1,3 @@
+[suppress_type]
+  type_kind = enum
+  changed_enumerators = FWUPD_STATUS_LAST

--- a/contrib/ci/check-abi
+++ b/contrib/ci/check-abi
@@ -1,0 +1,114 @@
+#!/usr/bin/python3
+
+
+import argparse
+import contextlib
+import os
+import shutil
+import subprocess
+import sys
+
+
+def format_title(title):
+    box = {
+        'tl': '╔', 'tr': '╗', 'bl': '╚', 'br': '╝', 'h': '═', 'v': '║',
+    }
+    hline = box['h'] * (len(title) + 2)
+
+    return '\n'.join([
+        f"{box['tl']}{hline}{box['tr']}",
+        f"{box['v']} {title} {box['v']}",
+        f"{box['bl']}{hline}{box['br']}",
+    ])
+
+
+def rm_rf(path):
+    try:
+        shutil.rmtree(path)
+    except FileNotFoundError:
+        pass
+
+
+def sanitize_path(name):
+    return name.replace('/', '-')
+
+
+def get_current_revision():
+    revision = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
+                                       encoding='utf-8').strip()
+
+    if revision == 'HEAD':
+        # This is a detached HEAD, get the commit hash
+        revision = subprocess.check_output(['git', 'rev-parse', 'HEAD']).strip().decode('utf-8')
+
+    return revision
+
+
+@contextlib.contextmanager
+def checkout_git_revision(revision):
+    current_revision = get_current_revision()
+    subprocess.check_call(['git', 'checkout', '-q', revision])
+
+    try:
+        yield
+    finally:
+        subprocess.check_call(['git', 'checkout', '-q', current_revision])
+
+
+def build_install(revision):
+    build_dir = '_build'
+    dest_dir = os.path.abspath(sanitize_path(revision))
+    print(format_title(f'# Building and installing {revision} in {dest_dir}'),
+          end='\n\n', flush=True)
+
+    with checkout_git_revision(revision):
+        rm_rf(build_dir)
+        rm_rf(revision)
+
+        subprocess.check_call(['meson', build_dir,
+                               '--prefix=/usr', '--libdir=lib',
+                               '-Db_coverage=false', '-Dgtkdoc=false', '-Dtests=false'])
+        subprocess.check_call(['ninja', '-v', '-C', build_dir])
+        subprocess.check_call(['ninja', '-v', '-C', build_dir, 'install'],
+                              env={'DESTDIR': dest_dir})
+
+    return dest_dir
+
+
+def compare(old_tree, new_tree):
+    print(format_title(f'# Comparing the two ABIs'), end='\n\n', flush=True)
+
+    old_headers = os.path.join(old_tree, 'usr', 'include')
+    old_lib = os.path.join(old_tree, 'usr', 'lib', 'libfwupd.so')
+
+    new_headers = os.path.join(new_tree, 'usr', 'include')
+    new_lib = os.path.join(new_tree, 'usr', 'lib', 'libfwupd.so')
+
+    subprocess.check_call([
+        'abidiff', '--headers-dir1', old_headers, '--headers-dir2', new_headers,
+        '--drop-private-types', '--suppressions', 'contrib/ci/abidiff.suppr',
+        '--fail-no-debug-info', '--no-added-syms', old_lib, new_lib])
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('old', help='the previous revision, considered the reference')
+    parser.add_argument('new', help='the new revision, to compare to the reference')
+
+    args = parser.parse_args()
+
+    if args.old == args.new:
+        print("Let's not waste time comparing something to itself")
+        sys.exit(0)
+
+    old_tree = build_install(args.old)
+    new_tree = build_install(args.new)
+
+    try:
+        compare(old_tree, new_tree)
+
+    except subprocess.CalledProcessError:
+        sys.exit(1)
+
+    print(f'Hurray! {args.old} and {args.new} are ABI-compatible!')

--- a/contrib/ci/dependencies.xml
+++ b/contrib/ci/dependencies.xml
@@ -10,6 +10,11 @@
       <package />
     </distro>
   </dependency>
+  <dependency type="build" id="abigail-tools">
+    <distro id="debian">
+      <package variant="x86_64" />
+    </distro>
+  </dependency>
   <dependency type="build" id="bash-completion">
     <distro id="debian">
       <control />


### PR DESCRIPTION
This adds a script which can check for ABI breaks between two Git
revisions:

    $ ./contrib/ci/check-abi.sh

The CI is set up to run it automatically between the tip of the branch
being tested and the last release tag.

Based on the work by Mathieu Bridon <bochecha@daitauha.fr>, many thanks.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
