### PR TITLE
Allow specifying <firmware>GUID</firmware> to check any version exists

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -1096,7 +1096,8 @@ fu_engine_check_requirement_firmware (FuEngine *self, XbNode *req,
 
 		/* get the version of the other device */
 		version = fu_device_get_version (device2);
-		if (!fu_engine_require_vercmp (req, version, &error_local)) {
+		if (version != NULL &&
+		    !fu_engine_require_vercmp (req, version, &error_local)) {
 			if (g_strcmp0 (xb_node_get_attr (req, "compare"), "ge") == 0) {
 				g_set_error (error,
 					     FWUPD_ERROR,


### PR DESCRIPTION
If the version is not specified then treat it as just 'exists'.