### PR TITLE
fu-install-task: Convert the GUID from xml to lower-case

### DIFF
--- a/src/fu-install-task.c
+++ b/src/fu-install-task.c
@@ -136,7 +136,9 @@ fu_install_task_check_requirements (FuInstallTask *self,
 	}
 	for (guint i = 0; i < provides->len; i++) {
 		XbNode *provide = g_ptr_array_index (provides, i);
-		if (fu_device_has_guid (self->device, xb_node_get_text (provide))) {
+		g_autofree gchar *guid_str = NULL;
+		guid_str = g_ascii_strdown (xb_node_get_text (provide), -1);
+		if (fu_device_has_guid (self->device, guid_str)) {
 			matches_guid = TRUE;
 			break;
 		}


### PR DESCRIPTION
The capsules generated by the latest Minnowboard build scripts use
upper-case in GUIDs, and fwupd failed to recognize the corresponding
device. Since GUID is case-insensitive, we can just convert the GUIDs
from xml to lower-case so that the hash of the device won't be affected.

Signed-off-by: Gary Lin <glin@suse.com>

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [X] Code fix
- [ ] Feature
- [ ] Documentation
