### PR TITLE
Fix a crash when stopping the fwupd service

### DIFF
--- a/plugins/dell/fu-plugin-dell.c
+++ b/plugins/dell/fu-plugin-dell.c
@@ -169,9 +169,9 @@ fu_dell_host_mst_supported (FuPlugin *plugin)
 static gboolean
 fu_dell_supported (FuPlugin *plugin)
 {
-	GBytes *de_table = NULL;
-	GBytes *da_table = NULL;
-	GBytes *enclosure = NULL;
+	g_autoptr(GBytes) de_table = NULL;
+	g_autoptr(GBytes) da_table = NULL;
+	g_autoptr(GBytes) enclosure = NULL;
 	const guint8 *value;
 	const struct da_structure *da_values;
 	gsize len;
@@ -482,7 +482,7 @@ fu_plugin_usb_device_added (FuPlugin *plugin,
 gboolean
 fu_plugin_get_results (FuPlugin *plugin, FuDevice *device, GError **error)
 {
-	GBytes *de_table = NULL;
+	g_autoptr(GBytes) de_table = NULL;
 	const gchar *tmp = NULL;
 	const guint16 *completion_code;
 	gsize len;

--- a/plugins/redfish/fu-plugin-redfish.c
+++ b/plugins/redfish/fu-plugin-redfish.c
@@ -48,9 +48,12 @@ gboolean
 fu_plugin_startup (FuPlugin *plugin, GError **error)
 {
 	FuPluginData *data = fu_plugin_get_data (plugin);
-	GBytes *smbios_data = fu_plugin_get_smbios_data (plugin, REDFISH_SMBIOS_TABLE_TYPE);
 	g_autofree gchar *redfish_uri = NULL;
 	g_autofree gchar *ca_check = NULL;
+	g_autoptr(GBytes) smbios_data = NULL;
+
+	/* optional */
+	smbios_data = fu_plugin_get_smbios_data (plugin, REDFISH_SMBIOS_TABLE_TYPE);
 
 	/* read the conf file */
 	redfish_uri = fu_plugin_get_config_value (plugin, "Uri");

--- a/src/fu-hwids.c
+++ b/src/fu-hwids.c
@@ -268,7 +268,7 @@ fu_hwids_convert_padded_integer_cb (FuSmbios *smbios,
 				    guint8 type, guint8 offset,
 				    GError **error)
 {
-	GBytes *data;
+	g_autoptr(GBytes) data = NULL;
 	const guint8 *data_raw;
 	gsize data_sz = 0;
 	data = fu_smbios_get_data (smbios, type, error);
@@ -290,7 +290,7 @@ fu_hwids_convert_integer_cb (FuSmbios *smbios,
 			     guint8 type, guint8 offset,
 			     GError **error)
 {
-	GBytes *data;
+	g_autoptr(GBytes) data = NULL;
 	const guint8 *data_raw;
 	gsize data_sz = 0;
 	data = fu_smbios_get_data (smbios, type, error);

--- a/src/fu-plugin.c
+++ b/src/fu-plugin.c
@@ -600,7 +600,7 @@ fu_plugin_get_smbios_string (FuPlugin *self, guint8 structure_type, guint8 offse
  *
  * Gets a hardware SMBIOS data.
  *
- * Returns: (transfer none): A #GBytes, or %NULL
+ * Returns: (transfer full): A #GBytes, or %NULL
  *
  * Since: 0.9.8
  **/

--- a/src/fu-smbios.c
+++ b/src/fu-smbios.c
@@ -370,7 +370,7 @@ fu_smbios_get_item_for_type (FuSmbios *self, guint8 type)
  *
  * Reads a SMBIOS data blob, which includes the SMBIOS section header.
  *
- * Returns: a #GBytes, or %NULL if invalid or not found
+ * Returns: (transfer full): a #GBytes, or %NULL if invalid or not found
  **/
 GBytes *
 fu_smbios_get_data (FuSmbios *self, guint8 type, GError **error)
@@ -385,7 +385,7 @@ fu_smbios_get_data (FuSmbios *self, guint8 type, GError **error)
 			     "no structure with type %02x", type);
 		return NULL;
 	}
-	return item->data;
+	return g_bytes_ref (item->data);
 }
 
 /**


### PR DESCRIPTION
This difficult to debug bug only showed up when the fwupd service was stopped,
which the user never noticed, but services like abrt were still keen to report.
The root issue was that the call to fu_plugin_get_smbios_data() in
fu-plugin-uefi.c:fu_plugin_startup() was freeing the returned const GBytes,
which rippled down all the way to a double-free deep in libxmlb.

It's somewhat unusual to have a const GBytes, so just change the plugin helper
to returned a ref'd copy, on the logic a potential 16 byte memory leak is better
than a double-free when the next plugin gets the logic the wrong way around.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1734746

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [ ] Feature
- [ ] Documentation
