### PR TITLE
Add support for --external-only and --internal-only flags

### DIFF
--- a/data/bash-completion/fwupdmgr
+++ b/data/bash-completion/fwupdmgr
@@ -43,6 +43,16 @@ _fwupdmgr_opts=(
 	'--sign'
 )
 
+_update_opts=(
+	'--internal-only'
+	'--external-only'
+)
+
+_show_update_modifiers()
+{
+	COMPREPLY+=( $(compgen -W '${_update_opts[@]}' -- "$cur") )
+}
+
 _show_modifiers()
 {
 	COMPREPLY+=( $(compgen -W '${_fwupdmgr_opts[@]}' -- "$cur") )
@@ -145,6 +155,15 @@ _fwupdmgr()
 		#find remote ID
 		elif [[ "$prev" = "${COMP_WORDS[3]}" ]]; then
 			_show_remotes
+		else
+			_show_modifiers
+		fi
+		;;
+	update)
+		#update modifiers
+		if [[ "$prev" = "$command" ]]; then
+			_show_update_modifiers
+		#generic modifiers
 		else
 			_show_modifiers
 		fi

--- a/data/bash-completion/fwupdtool.in
+++ b/data/bash-completion/fwupdtool.in
@@ -32,6 +32,16 @@ _fwupdtool_opts=(
 	'--cleanup'
 )
 
+_update_opts=(
+	'--internal-only'
+	'--external-only'
+)
+
+_show_update_modifiers()
+{
+	COMPREPLY+=( $(compgen -W '${_update_opts[@]}' -- "$cur") )
+}
+
 _show_plugins()
 {
 	local plugins
@@ -90,6 +100,15 @@ _fwupdtool()
 		#output
 		elif [[ "$prev" = "${COMP_WORDS[4]}" ]]; then
 			_filedir
+		else
+			_show_modifiers
+		fi
+		;;
+	update)
+		#update modifiers
+		if [[ "$prev" = "$command" ]]; then
+			_show_update_modifiers
+		#generic modifiers
 		else
 			_show_modifiers
 		fi


### PR DESCRIPTION
These are useful when scripting fwupdgmr to only install upgrades
to devices that will be fixed in the machine at safe times.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
