### PR TITLE
modem-manager: add counterpart GUID for the DW5821e

### DIFF
--- a/plugins/modem-manager/meson.build
+++ b/plugins/modem-manager/meson.build
@@ -1,5 +1,9 @@
 cargs = ['-DG_LOG_DOMAIN="FuPluginMm"']
 
+install_data(['modem-manager.quirk'],
+  install_dir: join_paths(datadir, 'fwupd', 'quirks.d')
+)
+
 shared_module('fu_plugin_modem_manager',
   fu_hash,
   sources : [

--- a/plugins/modem-manager/modem-manager.quirk
+++ b/plugins/modem-manager/modem-manager.quirk
@@ -1,0 +1,11 @@
+
+# DW5821e
+[DeviceInstanceId=USB\VID_413C&PID_81D7]
+Summary = Dell DW5821e LTE modem
+CounterpartGuid = USB\VID_413C&PID_81D6
+
+# DW5821e in fastboot mode
+[DeviceInstanceId=USB\VID_413C&PID_81D6]
+Summary = Dell DW5821e LTE modem (fastboot)
+CounterpartGuid = USB\VID_413C&PID_81D7
+


### PR DESCRIPTION
The DW5821e in modem mode uses the 0x81D7 PID, but when it boots in
fastboot mode it uses the 0x81D6 PID. The upgrade procedure was able
to automatically match these two devices because they both shared the
very generic per-VID (0x413C) GUID, but this is no longer operational
since commit 8ef139faba, as the very generic GUIDs have been removed
for matching purposes.

So, define a quirk for the DW5821e, in order to add a counterpart
GUID to make device matching work properly again.

Fixes https://github.com/hughsie/fwupd/issues/1271

Type of pull request:
- [X ] Code fix
