### PR TITLE
Never use memcpy() in a possibly unsafe way

### DIFF
--- a/plugins/altos/fu-altos-device.c
+++ b/plugins/altos/fu-altos-device.c
@@ -371,7 +371,10 @@ fu_altos_device_write_firmware (FuDevice *device,
 			gsize chunk_len = 0x100;
 			if (i + 0x100 > data_len)
 				chunk_len = data_len - i;
-			memcpy (buf_tmp, data + i, chunk_len);
+			if (!fu_memcpy_safe (buf_tmp, sizeof(buf_tmp), 0,		/* dst */
+					     (const guint8 *) data, data_len, i,	/* src */
+					     chunk_len, error))
+				return FALSE;
 		}
 
 		/* verify data from device */

--- a/plugins/colorhug/fu-colorhug-device.c
+++ b/plugins/colorhug/fu-colorhug-device.c
@@ -78,8 +78,12 @@ fu_colorhug_device_msg (FuColorhugDevice *self, guint8 cmd,
 	}
 
 	/* optionally copy in data */
-	if (ibuf != NULL)
-		memcpy (buf + 1, ibuf, ibufsz);
+	if (ibuf != NULL) {
+		if (!fu_memcpy_safe (buf, sizeof(buf), 0x1,	/* dst */
+				     ibuf, ibufsz, 0x0,		/* src */
+				     ibufsz, error))
+			return FALSE;
+	}
 
 	/* request */
 	if (g_getenv ("FWUPD_COLORHUG_VERBOSE") != NULL)
@@ -151,9 +155,12 @@ fu_colorhug_device_msg (FuColorhugDevice *self, guint8 cmd,
 	}
 
 	/* copy back optional buf */
-	if (obuf != NULL)
-		memcpy (obuf, buf + 2, obufsz);
-
+	if (obuf != NULL) {
+		if (!fu_memcpy_safe (obuf, obufsz, 0x0,		/* dst */
+				     buf, sizeof(buf), 0x2,	/* src */
+				     obufsz, error))
+			return FALSE;
+	}
 	return TRUE;
 }
 
@@ -366,7 +373,10 @@ fu_colorhug_device_write_firmware (FuDevice *device,
 		fu_common_write_uint16 (buf + 0, chk->address, G_LITTLE_ENDIAN);
 		buf[2] = chk->data_sz;
 		buf[3] = ch_colorhug_device_calculate_checksum (chk->data, chk->data_sz);
-		memcpy (buf + 4, chk->data, chk->data_sz);
+		if (!fu_memcpy_safe (buf, sizeof(buf), 0x4,		/* dst */
+				     chk->data, chk->data_sz, 0x0,	/* src */
+				     chk->data_sz, error))
+			return FALSE;
 		if (!fu_colorhug_device_msg (self, CH_CMD_WRITE_FLASH,
 					     buf, sizeof(buf), /* in */
 					     NULL, 0, /* out */

--- a/plugins/csr/fu-csr-device.c
+++ b/plugins/csr/fu-csr-device.c
@@ -352,7 +352,10 @@ fu_csr_device_download_chunk (FuCsrDevice *self, guint16 idx, GBytes *chunk, GEr
 	buf[1] = FU_CSR_COMMAND_UPGRADE;
 	fu_common_write_uint16 (&buf[2], idx, G_LITTLE_ENDIAN);
 	fu_common_write_uint16 (&buf[4], chunk_sz, G_LITTLE_ENDIAN);
-	memcpy (buf + FU_CSR_COMMAND_HEADER_SIZE, chunk_data, chunk_sz);
+	if (!fu_memcpy_safe (buf, sizeof(buf), FU_CSR_COMMAND_HEADER_SIZE,	/* dst */
+			     chunk_data, chunk_sz, 0x0,				/* src */
+			     chunk_sz, error))
+		return FALSE;
 
 	/* hit hardware */
 	if (g_getenv ("FWUPD_CSR_VERBOSE") != NULL)

--- a/plugins/dell-dock/fu-dell-dock-status.c
+++ b/plugins/dell-dock/fu-dell-dock-status.c
@@ -78,8 +78,10 @@ fu_dell_dock_status_write (FuDevice *device,
 	if (fw == NULL)
 		return FALSE;
 	data = g_bytes_get_data (fw, &length);
-
-	memcpy (&status_version, data + self->blob_version_offset, sizeof (guint32));
+	if (!fu_memcpy_safe ((guint8 *) &status_version, sizeof(status_version), 0x0,	/* dst */
+			     data, length, self->blob_version_offset,		/* src */
+			     sizeof(status_version), error))
+		return FALSE;
 	dynamic_version = fu_dell_dock_status_ver_string (status_version);
 	g_debug ("writing status firmware version %s", dynamic_version);
 

--- a/plugins/dfu/dfu-cipher-xtea.c
+++ b/plugins/dfu/dfu-cipher-xtea.c
@@ -55,7 +55,10 @@ dfu_tool_parse_xtea_key (const gchar *key, guint32 *keys, GError **error)
 			guint64 tmp;
 
 			/* copy to 4-char buf (with NUL) */
-			memcpy (buf, key + i*8, 8);
+			if (!fu_memcpy_safe ((guint8 *) buf, sizeof(buf), 0x0,		/* dst */
+					     (const guint8 *) key, key_len, i * 8,	/* src */
+					     8, error))
+				return FALSE;
 			tmp = g_ascii_strtoull (buf, &endptr, 16);
 			if (endptr && endptr[0] != '\0') {
 				g_set_error (error,

--- a/plugins/dfu/dfu-format-metadata.c
+++ b/plugins/dfu/dfu-format-metadata.c
@@ -8,6 +8,8 @@
 
 #include <string.h>
 
+#include "fu-common.h"
+
 #include "dfu-element.h"
 #include "dfu-format-metadata.h"
 #include "dfu-image.h"
@@ -188,12 +190,18 @@ dfu_firmware_to_metadata (DfuFirmware *firmware, GError **error)
 
 		/* write the key */
 		mdbuf[idx++] = (guint8) key_len;
-		memcpy(mdbuf + idx, key, key_len);
+		if (!fu_memcpy_safe (mdbuf, sizeof(mdbuf), idx,			/* dst */
+				     (const guint8 *) key, key_len, 0x0,	/* src */
+				     key_len, error))
+			return NULL;
 		idx += key_len;
 
 		/* write the value */
 		mdbuf[idx++] = (guint8) value_len;
-		memcpy(mdbuf + idx, value, value_len);
+		if (!fu_memcpy_safe (mdbuf, sizeof(mdbuf), idx,			/* dst */
+				     (const guint8 *) value, value_len, 0x0,	/* src */
+				     value_len, error))
+			return NULL;
 		idx += value_len;
 	}
 	g_debug ("metadata table was %u/%" G_GSIZE_FORMAT " bytes",

--- a/plugins/ebitdo/fu-ebitdo-device.c
+++ b/plugins/ebitdo/fu-ebitdo-device.c
@@ -56,7 +56,10 @@ fu_ebitdo_device_send (FuEbitdoDevice *self,
 		hdr->cmd_len = GUINT16_TO_LE (in_len + 3);
 		hdr->cmd = cmd;
 		hdr->payload_len = GUINT16_TO_LE (in_len);
-		memcpy (packet + 0x08, in, in_len);
+		if (!fu_memcpy_safe (packet, sizeof(packet), 0x08,	/* dst */
+				     in, in_len, 0x0,			/* src */
+				     in_len, error))
+			return FALSE;
 		hdr->pkt_len = (guint8) (in_len + 7);
 	} else {
 		hdr->cmd_len = GUINT16_TO_LE (in_len + 1);
@@ -145,9 +148,10 @@ fu_ebitdo_device_receive (FuEbitdoDevice *self,
 					     hdr->payload_len);
 				return FALSE;
 			}
-			memcpy (out,
-				packet + sizeof(FuEbitdoPkt),
-				hdr->payload_len);
+			if (!fu_memcpy_safe (out, out_len, 0x0,					/* dst */
+					     packet, sizeof(packet), sizeof(FuEbitdoPkt),	/* src */
+					     hdr->payload_len, error))
+				return FALSE;
 		}
 		return TRUE;
 	}
@@ -163,7 +167,10 @@ fu_ebitdo_device_receive (FuEbitdoDevice *self,
 					     out_len);
 				return FALSE;
 			}
-			memcpy (out, packet + 1, 4);
+			if (!fu_memcpy_safe (out, out_len, 0x0,					/* dst */
+					     packet, sizeof(packet), 0x1,			/* src */
+					     4, error))
+				return FALSE;
 		}
 		return TRUE;
 	}
@@ -181,9 +188,10 @@ fu_ebitdo_device_receive (FuEbitdoDevice *self,
 					     hdr->cmd_len);
 				return FALSE;
 			}
-			memcpy (out,
-				packet + sizeof(FuEbitdoPkt) - 3,
-				hdr->cmd_len);
+			if (!fu_memcpy_safe (out, out_len, 0x0,					/* dst */
+					     packet, sizeof(packet), sizeof(FuEbitdoPkt) - 3,	/* src */
+					     hdr->cmd_len, error))
+				return FALSE;
 		}
 		return TRUE;
 	}

--- a/plugins/rts54hid/fu-rts54hid-device.c
+++ b/plugins/rts54hid/fu-rts54hid-device.c
@@ -149,7 +149,10 @@ fu_rts54hid_device_write_flash (FuRts54HidDevice *self,
 	g_return_val_if_fail (data_sz != 0, FALSE);
 
 	memcpy (buf, &cmd_buffer, sizeof(cmd_buffer));
-	memcpy (buf + FU_RTS54HID_CMD_BUFFER_OFFSET_DATA, data, data_sz);
+	if (!fu_memcpy_safe (buf, sizeof(buf), FU_RTS54HID_CMD_BUFFER_OFFSET_DATA,	/* dst */
+			     data, data_sz, 0x0,					/* src */
+			     data_sz, error))
+		return FALSE;
 	if (!fu_rts54hid_device_set_report (self, buf, sizeof(buf), error)) {
 		g_prefix_error (error, "failed to write flash @%08x: ", (guint) addr);
 		return FALSE;

--- a/plugins/synaptics-prometheus/fu-synaprom-config.c
+++ b/plugins/synaptics-prometheus/fu-synaprom-config.c
@@ -98,7 +98,10 @@ fu_synaprom_config_setup (FuDevice *device, GError **error)
 			     GUINT32_FROM_LE(hdr.itype));
 		return FALSE;
 	}
-	memcpy (&cfg, reply->data + sizeof(hdr), sizeof(cfg));
+	if (!fu_memcpy_safe ((guint8 *) &cfg, sizeof(cfg), 0x0,		/* dst */
+			     reply->data, reply->len, sizeof(hdr),	/* src */
+			     sizeof(cfg), error))
+		return FALSE;
 	self->configid1 = GUINT32_FROM_LE(cfg.config_id1);
 	self->configid2 = GUINT32_FROM_LE(cfg.config_id2);
 	g_debug ("id1=%u, id2=%u, ver=%u",

--- a/plugins/unifying/fu-unifying-bootloader.c
+++ b/plugins/unifying/fu-unifying-bootloader.c
@@ -296,7 +296,10 @@ fu_unifying_bootloader_request (FuUnifyingBootloader *self,
 	buf_request[0x01] = req->addr >> 8;
 	buf_request[0x02] = req->addr & 0xff;
 	buf_request[0x03] = req->len;
-	memcpy (buf_request + 0x04, req->data, 28);
+	if (!fu_memcpy_safe (buf_request, sizeof(buf_request), 0x04,	/* dst */
+			     req->data, sizeof(req->data), 0x0,		/* src */
+			     sizeof(req->data), error))
+		return FALSE;
 
 	/* send request */
 	if (g_getenv ("FWUPD_UNIFYING_VERBOSE") != NULL) {

--- a/plugins/unifying/fu-unifying-runtime.c
+++ b/plugins/unifying/fu-unifying-runtime.c
@@ -206,7 +206,10 @@ fu_unifying_runtime_setup_internal (FuDevice *device, GError **error)
 			g_prefix_error (error, "failed to read device config: ");
 			return FALSE;
 		}
-		memcpy (config + (i * 2), msg->data + 1, 2);
+		if (!fu_memcpy_safe (config, sizeof(config), i * 2,	/* dst */
+				     msg->data, sizeof(msg->data), 0x1,	/* src */
+				     2, error))
+			return FALSE;
 	}
 
 	/* get firmware version */

--- a/plugins/wacom-usb/fu-wac-device.c
+++ b/plugins/wacom-usb/fu-wac-device.c
@@ -381,8 +381,12 @@ fu_wac_device_write_block (FuWacDevice *self,
 	memset (buf, 0xff, bufsz);
 	buf[0] = FU_WAC_REPORT_ID_WRITE_BLOCK;
 	fu_common_write_uint32 (buf + 1, addr, G_LITTLE_ENDIAN);
-	if (sz > 0)
-		memcpy (buf + 5, tmp, sz);
+	if (sz > 0) {
+		if (!fu_memcpy_safe (buf, bufsz, 0x5,	/* dst */
+				     tmp, sz, 0x0,	/* src */
+				     sz, error))
+			return FALSE;
+	}
 
 	/* hit hardware */
 	return fu_wac_device_set_feature_report (self, buf, bufsz,

--- a/plugins/wacom-usb/fu-wac-module-bluetooth.c
+++ b/plugins/wacom-usb/fu-wac-module-bluetooth.c
@@ -72,7 +72,7 @@ fu_wac_module_bluetooth_calculate_crc (const guint8 *data, gsize sz)
 }
 
 static GPtrArray *
-fu_wac_module_bluetooth_parse_blocks (const guint8 *data, gsize sz, gboolean skip_user_data)
+fu_wac_module_bluetooth_parse_blocks (const guint8 *data, gsize sz, gboolean skip_user_data, GError **error)
 {
 	const guint8 preamble[] = {0x02, 0x00, 0x0f, 0x06, 0x01, 0x08, 0x01};
 	GPtrArray *blocks = g_ptr_array_new_with_free_func (g_free);
@@ -96,7 +96,10 @@ fu_wac_module_bluetooth_parse_blocks (const guint8 *data, gsize sz, gboolean ski
 		/* if file is not in multiples of payload size */
 		if (addr + FU_WAC_MODULE_BLUETOOTH_PAYLOAD_SZ >= sz)
 			cdata_sz = sz - addr;
-		memcpy (bd->cdata, data + addr, cdata_sz);
+		if (!fu_memcpy_safe (bd->cdata, sizeof(bd->cdata), 0x0,	/* dst */
+				     data, sz, addr,			/* src */
+				     cdata_sz, error))
+			return NULL;
 		bd->crc = fu_wac_module_bluetooth_calculate_crc (bd->cdata,
 								 FU_WAC_MODULE_BLUETOOTH_PAYLOAD_SZ);
 		g_ptr_array_add (blocks, bd);
@@ -126,7 +129,9 @@ fu_wac_module_bluetooth_write_firmware (FuDevice *device,
 
 	/* build each data packet */
 	data = g_bytes_get_data (fw, &len);
-	blocks = fu_wac_module_bluetooth_parse_blocks (data, len, TRUE);
+	blocks = fu_wac_module_bluetooth_parse_blocks (data, len, TRUE, error);
+	if (blocks == NULL)
+		return FALSE;
 	blocks_total = blocks->len + 2;
 
 	/* start, which will erase the module */

--- a/src/fu-common.c
+++ b/src/fu-common.c
@@ -1413,3 +1413,73 @@ fu_common_strnsplit (const gchar *str, gsize sz,
 	}
 	return g_strsplit (str, delimiter, max_tokens);
 }
+
+/**
+ * fu_memcpy_safe:
+ * @dst: destination buffer
+ * @dst_sz: maximum size of @dst, typically `sizeof(dst)`
+ * @dst_offset: offset in bytes into @dst to copy to
+ * @src: source buffer
+ * @src_sz: maximum size of @dst, typically `sizeof(src)`
+ * @src_offset: offset in bytes into @src to copy from
+ * @n: number of bytes to copy from @src+@offset from
+ * @error: A #GError or %NULL
+ *
+ * Copies some memory using memcpy in a safe way. Providing the buffer sizes
+ * of both the destination and the source allows us to check for buffer overflow.
+ *
+ * Providing the buffer offsets also allows us to check reading past the end of
+ * the source buffer. For this reason the caller should NEVER add an offset to
+ * @src or @dst.
+ *
+ * You don't need to use this function in "obviously correct" cases, nor should
+ * you use it when performance is a concern. Only us it when you're not sure if
+ * malicious data from a device or firmware could cause memory corruption.
+ *
+ * Return value: %TRUE if the bytes were copied, %FALSE otherwise
+ **/
+gboolean
+fu_memcpy_safe (guint8 *dst, gsize dst_sz, gsize dst_offset,
+		const guint8 *src, gsize src_sz, gsize src_offset,
+		gsize n, GError **error)
+{
+	if (n == 0)
+		return TRUE;
+
+	if (n > src_sz) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_READ,
+			     "attempted to read 0x%02x bytes from buffer of 0x%02x",
+			     (guint) n, (guint) src_sz);
+		return FALSE;
+	}
+	if (n + src_offset > src_sz) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_READ,
+			     "attempted to read 0x%02x bytes at offset 0x%02x from buffer of 0x%02x",
+			     (guint) n, (guint) src_offset, (guint) src_sz);
+		return FALSE;
+	}
+	if (n > dst_sz) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_WRITE,
+			     "attempted to write 0x%02x bytes to buffer of 0x%02x",
+			     (guint) n, (guint) dst_sz);
+		return FALSE;
+	}
+	if (n + dst_offset > dst_sz) {
+		g_set_error (error,
+			     FWUPD_ERROR,
+			     FWUPD_ERROR_WRITE,
+			     "attempted to write 0x%02x bytes at offset 0x%02x to buffer of 0x%02x",
+			     (guint) n, (guint) dst_offset, (guint) dst_sz);
+		return FALSE;
+	}
+
+	/* phew! */
+	memcpy (dst + dst_offset, src + src_offset, n);
+	return TRUE;
+}

--- a/src/fu-common.h
+++ b/src/fu-common.h
@@ -135,6 +135,14 @@ gboolean	 fu_common_bytes_compare	(GBytes		*bytes1,
 						 GError		**error);
 GBytes		*fu_common_bytes_pad		(GBytes		*bytes,
 						 gsize		 sz);
+gboolean	 fu_memcpy_safe			(guint8		*dst,
+						 gsize		 dst_sz,
+						 gsize		 dst_offset,
+						 const guint8	*src,
+						 gsize		 src_sz,
+						 gsize		 src_offset,
+						 gsize		 n,
+						 GError		**error);
 
 typedef guint FuEndianType;
 


### PR DESCRIPTION
There are several subtle bugs in various places in fwupd caused by not treating
user-provided offsets into buffers as unsafe. As fwupd runs as root we have to
assume that all user firmware is evil, and also that devices cannot be trusted.

Make a helper to put all the logic into one place and convert all users.
