### PR TITLE
Add motd integration and automatic refresh systemd timer

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -32,6 +32,13 @@ if get_option('daemon')
   )
 endif
 
+if get_option('motd_integration')
+  if not get_option('systemd')
+    error('MOTD integration also needs systemd to work')
+  endif
+  subdir('motd')
+endif
+
 if get_option('systemd')
   con2 = configuration_data()
   con2.set('libexecdir', libexecdir)

--- a/data/motd/85-fwupd.motd.in
+++ b/data/motd/85-fwupd.motd.in
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ -f @motd_file@ ]; then
+        cat @motd_file@
+fi

--- a/data/motd/README.md
+++ b/data/motd/README.md
@@ -1,0 +1,17 @@
+# Message of the day integration
+
+Message on the day integration is used to display the availability of updates when connecting to a remote console.
+
+It has two elements:
+* Automatic firmware metadata refresh
+* Message of the day display
+
+## Automatic firmware metadata refresh
+This uses a systemd timer to run on a regular cadence.
+To enable this, run
+```
+# systemctl enable fwupd-refresh.timer
+```
+
+## Motd display
+Motd display is dependent upon the availability of the update-motd snippet consumption service such as pam_motd.

--- a/data/motd/fwupd-refresh.service.in
+++ b/data/motd/fwupd-refresh.service.in
@@ -1,0 +1,10 @@
+[Unit]
+Description=Refresh fwupd metadata
+Documentation=man:fwupdmgr(1)
+After=network.target network-online.target systemd-networkd.service NetworkManager.service connman.service
+
+[Service]
+Type=oneshot
+StandardOutput=file:@motd_file@
+ExecStart=@bindir@/fwupdmgr refresh
+ExecStart=@bindir@/fwupdmgr get-updates --no-metadata-check --no-unreported-check --quiet

--- a/data/motd/fwupd-refresh.timer
+++ b/data/motd/fwupd-refresh.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Refresh fwupd metadata regularly
+
+[Timer]
+OnCalendar=*-*-* 6,18:00
+RandomizedDelaySec=12h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/data/motd/meson.build
+++ b/data/motd/meson.build
@@ -1,0 +1,21 @@
+
+install_data(['fwupd-refresh.timer'],
+  install_dir: systemdunitdir)
+
+con2 = configuration_data()
+con2.set('bindir', bindir)
+con2.set('motd_file', join_paths(localstatedir, 'lib', 'fwupd', 'motd'))
+configure_file(
+  input : '85-fwupd.motd.in',
+  output : '85-fwupd',
+  configuration : con2,
+  install: true,
+  install_dir: join_paths(sysconfdir, 'update-motd.d')
+)
+
+configure_file(
+  input : 'fwupd-refresh.service.in',
+  output : 'fwupd-refresh.service',
+  configuration : con2,
+  install: true,
+  install_dir: systemdunitdir)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,6 +7,7 @@ option('gtkdoc', type : 'boolean', value : true, description : 'enable developer
 option('introspection', type : 'boolean', value : true, description : 'generate GObject Introspection data')
 option('lvfs', type : 'boolean', value : true, description : 'enable LVFS remotes')
 option('man', type : 'boolean', value : true, description : 'enable man pages')
+option('motd_integration', type: 'boolean', value : false, description : 'integrate into message of the day (motd)')
 option('pkcs7', type : 'boolean', value : true, description : 'enable the PKCS7 verification support')
 option('plugin_altos', type : 'boolean', value : true, description : 'enable altos support')
 option('plugin_amt', type : 'boolean', value : true, description : 'enable Intel AMT support')

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -55,6 +55,7 @@ struct FuUtilPrivate {
 	gboolean		 no_reboot_check;
 	gboolean		 no_unreported_check;
 	gboolean		 assume_yes;
+	gboolean		 quiet_mode;
 	gboolean		 sign;
 	gboolean		 show_all_devices;
 	/* only valid in update and downgrade */
@@ -1596,7 +1597,8 @@ fu_util_get_updates (FuUtilPrivate *priv, gchar **values, GError **error)
 						  fwupd_device_get_id (dev),
 						  NULL, &error_local);
 		if (rels == NULL) {
-			g_printerr ("%s\n", error_local->message);
+			if (!priv->quiet_mode)
+				g_printerr ("%s\n", error_local->message);
 			continue;
 		}
 
@@ -2313,6 +2315,9 @@ main (int argc, char *argv[])
 		{ "assume-yes", 'y', 0, G_OPTION_ARG_NONE, &priv->assume_yes,
 			/* TRANSLATORS: command line option */
 			_("Answer yes to all questions"), NULL },
+		{ "quiet", 'y', 0, G_OPTION_ARG_NONE, &priv->quiet_mode,
+			/* TRANSLATORS: command line option */
+			_("Only show important output (typically for scripting use)"), NULL },
 		{ "sign", '\0', 0, G_OPTION_ARG_NONE, &priv->sign,
 			/* TRANSLATORS: command line option */
 			_("Sign the uploaded data with the client certificate"), NULL },


### PR DESCRIPTION
Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation

I tested that this worked on Ubuntu 19.10, and at least according to the man page for pam_motd I think it should work elsewhere too.