### PR TITLE
Add support to integrate into the motd (Fixes: #1270)

### DIFF
--- a/contrib/debian/fwupd.install
+++ b/contrib/debian/fwupd.install
@@ -21,3 +21,4 @@ data/daemon.conf etc/fwupd
 debian/fwupd.pkla /var/lib/polkit-1/localauthority/10-vendor.d
 usr/lib/*/fwupd-plugins-*/*.so
 debian/lintian/fwupd usr/share/lintian/overrides
+obj*/data/motd/85-fwupd /etc/update-motd.d

--- a/contrib/fwupd.spec.in
+++ b/contrib/fwupd.spec.in
@@ -275,6 +275,8 @@ rm ${RPM_BUILD_ROOT}%{_sbindir}/flashrom
 %{_datadir}/fwupd/firmware-packager
 %{_unitdir}/fwupd-offline-update.service
 %{_unitdir}/fwupd.service
+%{_unitdir}/fwupd-refresh.service
+%{_unitdir}/fwupd-refresh.timer
 %{_unitdir}/system-update.target.wants/
 %dir %{_localstatedir}/lib/fwupd
 %dir %{_datadir}/fwupd/quirks.d

--- a/data/bash-completion/fwupdmgr.in
+++ b/data/bash-completion/fwupdmgr.in
@@ -42,6 +42,7 @@ _fwupdmgr_opts=(
 	'--show-all-devices'
 	'--sign'
 	'--filter'
+	'--log'
 )
 
 _show_filters()

--- a/data/meson.build
+++ b/data/meson.build
@@ -2,6 +2,7 @@ subdir('builder')
 subdir('pki')
 subdir('remotes.d')
 subdir('bash-completion')
+subdir('motd')
 
 if get_option('tests')
   subdir('tests')

--- a/data/motd/85-fwupd.motd.in
+++ b/data/motd/85-fwupd.motd.in
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+if [ -f @motd_fullpath@ ]; then
+        cat @motd_fullpath@
+fi

--- a/data/motd/README.md
+++ b/data/motd/README.md
@@ -1,0 +1,17 @@
+# Message of the day integration
+
+Message on the day integration is used to display the availability of updates when connecting to a remote console.
+
+It has two elements:
+* Automatic firmware metadata refresh
+* Message of the day display
+
+## Automatic firmware metadata refresh
+This uses a systemd timer to run on a regular cadence.
+To enable this, run
+```
+# systemctl enable fwupd-refresh.timer
+```
+
+## Motd display
+Motd display is dependent upon the availability of the update-motd snippet consumption service such as pam_motd.

--- a/data/motd/fwupd-refresh.service.in
+++ b/data/motd/fwupd-refresh.service.in
@@ -1,0 +1,19 @@
+[Unit]
+Description=Refresh fwupd metadata and update motd
+Documentation=man:fwupdmgr(1)
+After=network.target network-online.target systemd-networkd.service NetworkManager.service connman.service
+
+[Service]
+Type=oneshot
+RuntimeDirectory=@motd_dir@
+CacheDirectory=fwupd
+RuntimeDirectoryPreserve=yes
+StandardError=null
+ExecStart=@bindir@/fwupdmgr refresh
+ExecStart=@bindir@/fwupdmgr get-updates --log @motd_file@
+DynamicUser=yes
+RestrictAddressFamilies=AF_NETLINK AF_UNIX AF_INET AF_INET6
+SystemCallFilter=~@mount
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes

--- a/data/motd/fwupd-refresh.timer
+++ b/data/motd/fwupd-refresh.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Refresh fwupd metadata regularly
+
+[Timer]
+OnCalendar=*-*-* 6,18:00
+RandomizedDelaySec=12h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/data/motd/meson.build
+++ b/data/motd/meson.build
@@ -1,0 +1,30 @@
+motd_file = '85-fwupd'
+motd_dir = 'motd.d'
+motd_fullpath = join_paths ('/run', motd_dir, motd_file)
+con2 = configuration_data()
+con2.set('bindir', bindir)
+con2.set('motd_file', motd_file)
+con2.set('motd_dir', motd_dir)
+con2.set('motd_fullpath', motd_fullpath)
+
+# This file is only used in Ubuntu, which chooses to use update-motd instead
+# of sourcing /run/motd.d/*
+# See https://bugs.launchpad.net/ubuntu/+source/pam/+bug/399071
+configure_file(
+  input : '85-fwupd.motd.in',
+  output : motd_file,
+  configuration : con2,
+  install: false,
+)
+
+if get_option('systemd')
+  install_data(['fwupd-refresh.timer'],
+    install_dir: systemdunitdir)
+
+  configure_file(
+    input : 'fwupd-refresh.service.in',
+    output : 'fwupd-refresh.service',
+    configuration : con2,
+    install: true,
+    install_dir: systemdunitdir)
+endif

--- a/src/fu-util-common.c
+++ b/src/fu-util-common.c
@@ -187,16 +187,21 @@ fu_util_is_interesting_device (FwupdDevice *dev)
 gchar *
 fu_util_get_user_cache_path (const gchar *fn)
 {
+	const gchar *root = g_get_user_cache_dir ();
 	g_autofree gchar *basename = g_path_get_basename (fn);
 	g_autofree gchar *cachedir_legacy = NULL;
 
+	/* if run from a systemd unit, use the cache directory set there */
+	if (g_getenv ("CACHE_DIRECTORY") != NULL)
+		root = g_getenv ("CACHE_DIRECTORY");
+
 	/* return the legacy path if it exists rather than renaming it to
 	 * prevent problems when using old and new versions of fwupd */
-	cachedir_legacy = g_build_filename (g_get_user_cache_dir (), "fwupdmgr", NULL);
+	cachedir_legacy = g_build_filename (root, "fwupdmgr", NULL);
 	if (g_file_test (cachedir_legacy, G_FILE_TEST_IS_DIR))
 		return g_build_filename (cachedir_legacy, basename, NULL);
 
-	return g_build_filename (g_get_user_cache_dir (), "fwupd", basename, NULL);
+	return g_build_filename (root, "fwupd", basename, NULL);
 }
 
 gchar *


### PR DESCRIPTION
Second try on this.  Hopefully this is generic enough that it will work in all scenarios.  All an admin needs to do is run and it should work on most distros.

```
# systemctl enable fwupd-refresh.timer
```

Fixes Debian bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=921820

Introduce a new --log option to fwupdmgr that will log stdout to an argument.
If run under systemd, prefix that argument with $RUNTIME_DIRECTORY.

Add a new systemd unit and associated timer to regularly refresh metadata.
After the metadata refresh is complete, save the output to the motd location.

The timer and service are disabled by default and can be enabled by an admin.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [ ] Code fix
- [x] Feature
- [ ] Documentation
