### PR TITLE
trivial: If no devices support updates, show messaging (Closes: #1295)

### DIFF
--- a/src/fu-engine.c
+++ b/src/fu-engine.c
@@ -2362,6 +2362,16 @@ fu_engine_load_metadata_store (FuEngine *self, FuEngineLoadFlags flags, GError *
 	return TRUE;
 }
 
+static void
+fu_engine_config_changed_cb (FuConfig *config, FuEngine *self)
+{
+	g_autoptr(GError) error_local = NULL;
+	if (!fu_engine_load_metadata_store (self, FU_ENGINE_LOAD_FLAG_NONE,
+					    &error_local))
+		g_warning ("Failed to reload metadata store: %s",
+			   error_local->message);
+}
+
 static FuKeyringResult *
 fu_engine_get_existing_keyring_result (FuEngine *self,
 				       FuKeyring *kr,
@@ -4669,6 +4679,10 @@ fu_engine_init (FuEngine *self)
 	self->runtime_versions = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
 	self->compile_versions = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
 	self->approved_firmware = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
+
+	g_signal_connect (self->config, "changed",
+			  G_CALLBACK (fu_engine_config_changed_cb),
+			  self);
 
 	g_signal_connect (self->idle, "notify::status",
 			  G_CALLBACK (fu_engine_idle_status_notify_cb), self);

--- a/src/fu-util.c
+++ b/src/fu-util.c
@@ -1569,6 +1569,7 @@ static gboolean
 fu_util_get_updates (FuUtilPrivate *priv, gchar **values, GError **error)
 {
 	g_autoptr(GPtrArray) devices = NULL;
+	gboolean supported = FALSE;
 
 	/* are the remotes very old */
 	if (!fu_util_perhaps_refresh_remotes (priv, error))
@@ -1590,6 +1591,7 @@ fu_util_get_updates (FuUtilPrivate *priv, gchar **values, GError **error)
 			continue;
 		if (!fu_util_filter_device (priv, dev))
 			continue;
+		supported = TRUE;
 
 		/* get the releases for this device and filter for validity */
 		rels = fwupd_client_get_upgrades (priv->client,
@@ -1674,6 +1676,15 @@ fu_util_get_updates (FuUtilPrivate *priv, gchar **values, GError **error)
 	/* nag? */
 	if (!fu_util_perhaps_show_unreported (priv, error))
 		return FALSE;
+
+	/* no devices supported by LVFS or all are filtered */
+	if (!supported) {
+		g_set_error_literal (error,
+				     FWUPD_ERROR,
+				     FWUPD_ERROR_NOTHING_TO_DO,
+				     "No updatable devices");
+		return FALSE;
+	}
 
 	/* success */
 	return TRUE;


### PR DESCRIPTION
Normally the flag 'supported' is used to indicate that devices can
update from a remote such as LVFS.

Running `#fwupdmgr get-updates` in this situation will show a message
for each device that is already up to date as well as messages for
devices that have updates available.

If no devices contain the supported flag, `# fwupdmgr get-updates`
will show no output, which is confusing to some people.

Show "No updatable devices" instead for those situations.

Type of pull request:
- [ ] New plugin (Please include [new plugin checklist](https://github.com/hughsie/fwupd/wiki/New-plugin-checklist))
- [x] Code fix
- [ ] Feature
- [ ] Documentation
